### PR TITLE
fix: module path + markdown h3/h4/h5/h6 splitting

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/LavonTMCQ/cortex/internal/ingest"
-	"github.com/LavonTMCQ/cortex/internal/store"
+	"github.com/hurttlocker/cortex/internal/ingest"
+	"github.com/hurttlocker/cortex/internal/store"
 )
 
 const version = "0.1.0-dev"
@@ -142,6 +142,6 @@ Flags:
   -v, --version       Print version
 
 Documentation:
-  https://github.com/LavonTMCQ/cortex
+  https://github.com/hurttlocker/cortex
 `, version)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/LavonTMCQ/cortex
+module github.com/hurttlocker/cortex
 
 go 1.24.0
 

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -12,7 +12,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/LavonTMCQ/cortex/internal/store"
+	"github.com/hurttlocker/cortex/internal/store"
 )
 
 // Engine orchestrates the import process.

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/LavonTMCQ/cortex/internal/store"
+	"github.com/hurttlocker/cortex/internal/store"
 )
 
 // testdataDir returns the absolute path to the tests/testdata directory.
@@ -51,13 +51,18 @@ func TestMarkdownImport_WithHeaders(t *testing.T) {
 		t.Fatal("Expected at least one memory chunk")
 	}
 
-	// Should have sections: Personal, Work, Preferences, Projects, Decisions, People
+	// Should have sections including hierarchical h3 splits:
+	// Personal, Work, Preferences, Projects > Project Alpha, Projects > Project Beta, Decisions, People
 	sections := make(map[string]bool)
 	for _, m := range memories {
 		sections[m.SourceSection] = true
 	}
 
-	expectedSections := []string{"Personal", "Work", "Preferences", "Projects", "Decisions", "People"}
+	expectedSections := []string{
+		"Personal", "Work", "Preferences",
+		"Projects > Project Alpha", "Projects > Project Beta",
+		"Decisions", "People",
+	}
 	for _, s := range expectedSections {
 		if !sections[s] {
 			t.Errorf("Missing section: %s (got sections: %v)", s, sections)
@@ -548,7 +553,7 @@ func TestEngine_FormatDetection(t *testing.T) {
 					strings.Replace(
 						java_type_name(imp), "ingest.", "ingest.", 1),
 					"*", "*", 1),
-				"github.com/LavonTMCQ/cortex/internal/", "", 1),
+				"github.com/hurttlocker/cortex/internal/", "", 1),
 			"", "", 1),
 			"")
 		_ = typeName // type checking done via CanHandle

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,9 +1,228 @@
-// Package search provides dual search capabilities for Cortex.
+// Package search provides search capabilities for Cortex.
 //
 // Two search modes, both fully local:
 // - BM25 keyword search via SQLite FTS5
-// - Semantic search via local ONNX embeddings (all-MiniLM-L6-v2)
+// - Semantic search via local ONNX embeddings (all-MiniLM-L6-v2) [Phase 2]
 //
 // The default hybrid mode combines both using reciprocal rank fusion,
 // giving users the best of exact keyword matching and conceptual similarity.
 package search
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+// Mode specifies the search strategy.
+type Mode string
+
+const (
+	ModeKeyword  Mode = "keyword"
+	ModeSemantic Mode = "semantic"
+	ModeHybrid   Mode = "hybrid"
+)
+
+// ParseMode converts a string to a Mode, returning an error for invalid values.
+func ParseMode(s string) (Mode, error) {
+	switch strings.ToLower(s) {
+	case "keyword", "bm25":
+		return ModeKeyword, nil
+	case "semantic":
+		return ModeSemantic, nil
+	case "hybrid":
+		return ModeHybrid, nil
+	default:
+		return "", fmt.Errorf("invalid search mode %q (valid: keyword, semantic, hybrid)", s)
+	}
+}
+
+// Options configures a search query.
+type Options struct {
+	Mode          Mode    // Search mode (default: keyword)
+	Limit         int     // Max results (default: 10)
+	MinConfidence float64 // Minimum confidence threshold (default: 0.0)
+}
+
+// DefaultOptions returns sensible defaults for Phase 1 (keyword-only).
+func DefaultOptions() Options {
+	return Options{
+		Mode:          ModeKeyword,
+		Limit:         10,
+		MinConfidence: 0.0,
+	}
+}
+
+// Result represents a single search result.
+type Result struct {
+	Content       string  `json:"content"`
+	SourceFile    string  `json:"source_file"`
+	SourceLine    int     `json:"source_line"`
+	SourceSection string  `json:"source_section,omitempty"`
+	Score         float64 `json:"score"`
+	Snippet       string  `json:"snippet,omitempty"`
+	MatchType     string  `json:"match_type"` // "bm25", "semantic", "hybrid"
+	MemoryID      int64   `json:"memory_id"`
+}
+
+// Searcher performs searches across the memory store.
+type Searcher interface {
+	Search(ctx context.Context, query string, opts Options) ([]Result, error)
+}
+
+// Engine implements Searcher with BM25 search (and semantic stub for Phase 2).
+type Engine struct {
+	store store.Store
+}
+
+// NewEngine creates a search engine backed by the given store.
+func NewEngine(s store.Store) *Engine {
+	return &Engine{store: s}
+}
+
+// Search performs a search using the specified mode.
+func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Result, error) {
+	if query == "" {
+		return nil, nil
+	}
+
+	if opts.Limit <= 0 {
+		opts.Limit = 10
+	}
+
+	switch opts.Mode {
+	case ModeKeyword, "":
+		return e.searchBM25(ctx, query, opts)
+	case ModeSemantic:
+		return nil, fmt.Errorf("semantic search requires ONNX embeddings (coming in Phase 2)")
+	case ModeHybrid:
+		// Phase 1: hybrid falls back to keyword-only
+		results, err := e.searchBM25(ctx, query, opts)
+		if err != nil {
+			return nil, err
+		}
+		return results, nil
+	default:
+		return nil, fmt.Errorf("unknown search mode: %q", opts.Mode)
+	}
+}
+
+// searchBM25 performs keyword search using the store's FTS5 capability.
+func (e *Engine) searchBM25(ctx context.Context, query string, opts Options) ([]Result, error) {
+	// Sanitize query to prevent FTS5 syntax errors from crashing
+	sanitized := sanitizeFTSQuery(query)
+	if sanitized == "" {
+		return nil, nil
+	}
+
+	storeResults, err := e.store.SearchFTS(ctx, sanitized, opts.Limit)
+	if err != nil {
+		// If the query has bad FTS5 syntax, try a simpler fallback
+		if isFTSSyntaxError(err) {
+			// Escape the query as a simple term search
+			escaped := escapeFTSQuery(query)
+			storeResults, err = e.store.SearchFTS(ctx, escaped, opts.Limit)
+			if err != nil {
+				return nil, fmt.Errorf("search failed: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("search failed: %w", err)
+		}
+	}
+
+	results := make([]Result, 0, len(storeResults))
+	for _, sr := range storeResults {
+		// FTS5 rank is negative (more negative = better match).
+		// Convert to positive score where higher = better.
+		score := normalizeBM25Score(sr.Score)
+
+		if score < opts.MinConfidence {
+			continue
+		}
+
+		r := Result{
+			Content:       sr.Memory.Content,
+			SourceFile:    sr.Memory.SourceFile,
+			SourceLine:    sr.Memory.SourceLine,
+			SourceSection: sr.Memory.SourceSection,
+			Score:         score,
+			Snippet:       sr.Snippet,
+			MatchType:     "bm25",
+			MemoryID:      sr.Memory.ID,
+		}
+		results = append(results, r)
+	}
+
+	// Sort by score descending (should already be sorted from FTS5, but ensure it)
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+
+	return results, nil
+}
+
+// normalizeBM25Score converts FTS5's negative rank to a positive 0-1 score.
+// FTS5 rank values are negative, with more negative being more relevant.
+// We use: score = 1 / (1 + |rank|) which maps to (0, 1] range.
+func normalizeBM25Score(rank float64) float64 {
+	return 1.0 / (1.0 + math.Abs(rank))
+}
+
+// sanitizeFTSQuery performs basic sanitization of an FTS5 query.
+// It trims whitespace and returns empty string for empty/whitespace-only queries.
+func sanitizeFTSQuery(query string) string {
+	return strings.TrimSpace(query)
+}
+
+// escapeFTSQuery wraps each word in double quotes to treat them as literal terms,
+// used as a fallback when the original query has invalid FTS5 syntax.
+func escapeFTSQuery(query string) string {
+	words := strings.Fields(query)
+	if len(words) == 0 {
+		return ""
+	}
+
+	escaped := make([]string, 0, len(words))
+	for _, w := range words {
+		// Strip any existing quotes and FTS5 operators
+		w = strings.Trim(w, `"`)
+		w = strings.TrimSpace(w)
+		if w == "" || strings.EqualFold(w, "AND") || strings.EqualFold(w, "OR") || strings.EqualFold(w, "NOT") {
+			continue
+		}
+		escaped = append(escaped, `"`+w+`"`)
+	}
+	return strings.Join(escaped, " ")
+}
+
+// isFTSSyntaxError checks if an error is likely an FTS5 syntax error.
+func isFTSSyntaxError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "fts5: syntax error") ||
+		strings.Contains(msg, "FTS") ||
+		strings.Contains(msg, "fts5")
+}
+
+// TruncateContent truncates content to approximately maxLen characters,
+// breaking at a word boundary and appending "..." if truncated.
+func TruncateContent(content string, maxLen int) string {
+	if len(content) <= maxLen {
+		return content
+	}
+
+	// Find the last space before maxLen
+	truncated := content[:maxLen]
+	lastSpace := strings.LastIndex(truncated, " ")
+	if lastSpace > maxLen/2 {
+		truncated = truncated[:lastSpace]
+	}
+
+	return truncated + "..."
+}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,597 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+// newTestStore creates an in-memory store for testing.
+func newTestStore(t *testing.T) store.Store {
+	t.Helper()
+	s, err := store.NewStore(store.StoreConfig{DBPath: ":memory:"})
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+// seedTestData inserts a standard set of test memories for search testing.
+func seedTestData(t *testing.T, s store.Store) {
+	t.Helper()
+	ctx := context.Background()
+
+	memories := []*store.Memory{
+		{Content: "Trading QQQ/SPY 0DTE options with careful risk management", SourceFile: "~/clawd/MEMORY.md", SourceLine: 38, SourceSection: "Trading"},
+		{Content: "Completely isolated from equities — crypto directory for ADA and BTC", SourceFile: "~/clawd/memory/2026-01-28.md", SourceLine: 41, SourceSection: "Crypto"},
+		{Content: "Go is a statically typed programming language with excellent concurrency", SourceFile: "~/notes/go.md", SourceLine: 1, SourceSection: "Languages"},
+		{Content: "Python is dynamically typed and very popular for machine learning", SourceFile: "~/notes/python.md", SourceLine: 1, SourceSection: "Languages"},
+		{Content: "Rust emphasizes memory safety without garbage collection", SourceFile: "~/notes/rust.md", SourceLine: 1, SourceSection: "Languages"},
+		{Content: "Deploy the application using Docker containers on Railway", SourceFile: "~/projects/deploy.md", SourceLine: 10, SourceSection: "DevOps"},
+		{Content: "The deployment process requires running tests first", SourceFile: "~/projects/deploy.md", SourceLine: 25, SourceSection: "DevOps"},
+		{Content: "JavaScript runs in the browser and on Node.js server side", SourceFile: "~/notes/js.md", SourceLine: 1, SourceSection: "Languages"},
+		{Content: "Memory management in Go uses a garbage collector with low latency", SourceFile: "~/notes/go.md", SourceLine: 50, SourceSection: "Runtime"},
+		{Content: "Cortex is an AI agent memory tool written in Go with SQLite storage", SourceFile: "~/cortex/README.md", SourceLine: 1, SourceSection: "About"},
+	}
+
+	for _, m := range memories {
+		_, err := s.AddMemory(ctx, m)
+		if err != nil {
+			t.Fatalf("failed to seed memory: %v", err)
+		}
+	}
+}
+
+// --- Engine Creation ---
+
+func TestNewEngine(t *testing.T) {
+	s := newTestStore(t)
+	engine := NewEngine(s)
+	if engine == nil {
+		t.Fatal("expected non-nil engine")
+	}
+	if engine.store == nil {
+		t.Fatal("expected non-nil store in engine")
+	}
+}
+
+// --- BM25 Keyword Search ---
+
+func TestSearchBM25_SingleTerm(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	results, err := engine.Search(ctx, "Go", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) < 2 {
+		t.Errorf("expected at least 2 results for 'Go', got %d", len(results))
+	}
+
+	// All results should be BM25 type with positive scores
+	for _, r := range results {
+		if r.MatchType != "bm25" {
+			t.Errorf("expected match_type 'bm25', got %q", r.MatchType)
+		}
+		if r.Score <= 0 {
+			t.Errorf("expected positive score, got %f", r.Score)
+		}
+	}
+}
+
+func TestSearchBM25_MultipleTerm(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	// FTS5 implicit AND: both terms must be present
+	results, err := engine.Search(ctx, "memory Go", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result for 'memory Go'")
+	}
+}
+
+func TestSearchBM25_OR(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	results, err := engine.Search(ctx, "trading OR crypto", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) < 2 {
+		t.Errorf("expected at least 2 results for 'trading OR crypto', got %d", len(results))
+	}
+}
+
+func TestSearchBM25_NOT(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	// Search for deployment but not Docker
+	results, err := engine.Search(ctx, "deployment NOT Docker", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+
+	for _, r := range results {
+		if strings.Contains(strings.ToLower(r.Content), "docker") {
+			t.Errorf("result should not contain 'Docker': %q", r.Content)
+		}
+	}
+}
+
+func TestSearchBM25_Phrase(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	results, err := engine.Search(ctx, `"garbage collection"`, Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result for '\"garbage collection\"'")
+	}
+}
+
+func TestSearchBM25_Prefix(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	results, err := engine.Search(ctx, "deploy*", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	// With porter stemmer, "deploy*" matches stemmed tokens starting with "deploy"
+	if len(results) < 1 {
+		t.Errorf("expected at least 1 result for 'deploy*', got %d", len(results))
+	}
+	t.Logf("Got %d results for 'deploy*'", len(results))
+}
+
+func TestSearchBM25_Ranking(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	results, err := engine.Search(ctx, "Go", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) < 2 {
+		t.Fatal("need at least 2 results to verify ranking")
+	}
+
+	// Scores should be descending
+	for i := 1; i < len(results); i++ {
+		if results[i].Score > results[i-1].Score {
+			t.Errorf("results not sorted: score[%d]=%f > score[%d]=%f",
+				i, results[i].Score, i-1, results[i-1].Score)
+		}
+	}
+}
+
+func TestSearchBM25_Snippets(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	results, err := engine.Search(ctx, "memory", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if results[0].Snippet == "" {
+		t.Error("expected non-empty snippet")
+	}
+	t.Logf("Snippet: %s", results[0].Snippet)
+}
+
+func TestSearchBM25_NoResults(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	results, err := engine.Search(ctx, "xylophone", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for 'xylophone', got %d", len(results))
+	}
+}
+
+func TestSearchBM25_EmptyQuery(t *testing.T) {
+	s := newTestStore(t)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	results, err := engine.Search(ctx, "", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Errorf("expected nil results for empty query, got %d", len(results))
+	}
+}
+
+func TestSearchBM25_WhitespaceQuery(t *testing.T) {
+	s := newTestStore(t)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	results, err := engine.Search(ctx, "   ", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Errorf("expected nil results for whitespace query, got %d", len(results))
+	}
+}
+
+func TestSearchBM25_Limit(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Insert many memories with a common term
+	for i := 0; i < 20; i++ {
+		s.AddMemory(ctx, &store.Memory{
+			Content: fmt.Sprintf("Memory item number %d about testing search limits", i),
+		})
+	}
+
+	engine := NewEngine(s)
+
+	results, err := engine.Search(ctx, "testing", Options{Mode: ModeKeyword, Limit: 5})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) > 5 {
+		t.Errorf("expected at most 5 results, got %d", len(results))
+	}
+}
+
+func TestSearchBM25_SourceProvenance(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	results, err := engine.Search(ctx, "trading", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results for 'trading'")
+	}
+
+	r := results[0]
+	if r.SourceFile == "" {
+		t.Error("expected non-empty source_file")
+	}
+	if r.SourceLine <= 0 {
+		t.Error("expected positive source_line")
+	}
+	if r.MemoryID <= 0 {
+		t.Error("expected positive memory_id")
+	}
+	t.Logf("Result: score=%.2f file=%s line=%d section=%s",
+		r.Score, r.SourceFile, r.SourceLine, r.SourceSection)
+}
+
+func TestSearchBM25_InvalidSyntaxFallback(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	// Unbalanced quotes — should not crash, should fall back
+	results, err := engine.Search(ctx, `"unclosed quote`, Options{Mode: ModeKeyword, Limit: 10})
+	// We accept either: results with fallback, or a non-panic error
+	if err != nil {
+		t.Logf("Got error (acceptable): %v", err)
+	} else {
+		t.Logf("Got %d results with fallback", len(results))
+	}
+}
+
+// --- Semantic Search (Stub) ---
+
+func TestSearchSemantic_Stub(t *testing.T) {
+	s := newTestStore(t)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	_, err := engine.Search(ctx, "conceptual query", Options{Mode: ModeSemantic, Limit: 10})
+	if err == nil {
+		t.Error("expected error for semantic search (not yet implemented)")
+	}
+	if err != nil && !strings.Contains(err.Error(), "Phase 2") {
+		t.Errorf("error should mention Phase 2, got: %v", err)
+	}
+}
+
+// --- Hybrid Search ---
+
+func TestSearchHybrid_FallsBackToKeyword(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	// Hybrid should work (falls back to keyword in Phase 1)
+	results, err := engine.Search(ctx, "Go", Options{Mode: ModeHybrid, Limit: 10})
+	if err != nil {
+		t.Fatalf("hybrid search failed: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected results from hybrid search (keyword fallback)")
+	}
+}
+
+// --- Default Options ---
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+	if opts.Mode != ModeKeyword {
+		t.Errorf("expected default mode 'keyword', got %q", opts.Mode)
+	}
+	if opts.Limit != 10 {
+		t.Errorf("expected default limit 10, got %d", opts.Limit)
+	}
+	if opts.MinConfidence != 0.0 {
+		t.Errorf("expected default min_confidence 0.0, got %f", opts.MinConfidence)
+	}
+}
+
+// --- ParseMode ---
+
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  Mode
+		err   bool
+	}{
+		{"keyword", ModeKeyword, false},
+		{"bm25", ModeKeyword, false},
+		{"semantic", ModeSemantic, false},
+		{"hybrid", ModeHybrid, false},
+		{"Keyword", ModeKeyword, false},
+		{"HYBRID", ModeHybrid, false},
+		{"invalid", "", true},
+		{"", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseMode(tt.input)
+			if tt.err && err == nil {
+				t.Error("expected error")
+			}
+			if !tt.err && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseMode(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Score Normalization ---
+
+func TestNormalizeBM25Score(t *testing.T) {
+	// FTS5 rank is negative, more negative = better
+	tests := []struct {
+		rank   float64
+		wantGt float64
+		wantLt float64
+	}{
+		{-10.0, 0.0, 1.0},  // good match
+		{-1.0, 0.0, 1.0},   // decent match
+		{-0.1, 0.0, 1.0},   // weak match
+		{0.0, 0.99, 1.01},  // edge: score should be 1.0
+	}
+
+	for _, tt := range tests {
+		score := normalizeBM25Score(tt.rank)
+		if score <= tt.wantGt || score >= tt.wantLt {
+			t.Errorf("normalizeBM25Score(%f) = %f, want (%f, %f)", tt.rank, score, tt.wantGt, tt.wantLt)
+		}
+	}
+}
+
+// --- TruncateContent ---
+
+func TestTruncateContent(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		short  bool // if true, input should be returned as-is
+	}{
+		{"short", 100, true},
+		{"hello world foo bar baz", 11, false},
+		{"", 10, true},
+	}
+
+	for _, tt := range tests {
+		got := TruncateContent(tt.input, tt.maxLen)
+		if tt.short {
+			if got != tt.input {
+				t.Errorf("TruncateContent(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.input)
+			}
+		} else {
+			if !strings.HasSuffix(got, "...") {
+				t.Errorf("TruncateContent(%q, %d) = %q, should end with '...'", tt.input, tt.maxLen, got)
+			}
+		}
+	}
+}
+
+// --- JSON Output ---
+
+func TestResultJSON(t *testing.T) {
+	r := Result{
+		Content:    "Test content",
+		SourceFile: "test.md",
+		SourceLine: 42,
+		Score:      0.85,
+		MatchType:  "bm25",
+		MemoryID:   1,
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	if decoded["content"] != "Test content" {
+		t.Errorf("content mismatch: %v", decoded["content"])
+	}
+	if decoded["source_file"] != "test.md" {
+		t.Errorf("source_file mismatch: %v", decoded["source_file"])
+	}
+	if decoded["source_line"].(float64) != 42 {
+		t.Errorf("source_line mismatch: %v", decoded["source_line"])
+	}
+}
+
+func TestResultsJSON_Array(t *testing.T) {
+	results := []Result{
+		{Content: "First", SourceFile: "a.md", SourceLine: 1, Score: 0.9, MatchType: "bm25"},
+		{Content: "Second", SourceFile: "b.md", SourceLine: 2, Score: 0.7, MatchType: "bm25"},
+	}
+
+	data, err := json.Marshal(results)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var decoded []map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if len(decoded) != 2 {
+		t.Errorf("expected 2 results, got %d", len(decoded))
+	}
+}
+
+// --- MinConfidence Filter ---
+
+func TestSearchBM25_MinConfidence(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	// With min confidence of 0.99, should get no results (BM25 normalized scores are < 1)
+	results, err := engine.Search(ctx, "Go", Options{Mode: ModeKeyword, Limit: 10, MinConfidence: 0.99})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results with high min_confidence, got %d (first score: %f)",
+			len(results), results[0].Score)
+	}
+}
+
+// --- Integration: Import then Search ---
+
+func TestSearchEndToEnd(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Import specific content
+	memories := []*store.Memory{
+		{Content: "Philadelphia Eagles won the Super Bowl in February 2025", SourceFile: "sports.md", SourceLine: 1},
+		{Content: "The stock market reached new highs in January 2025", SourceFile: "finance.md", SourceLine: 1},
+		{Content: "Eagles are large birds of prey found worldwide", SourceFile: "nature.md", SourceLine: 1},
+	}
+	for _, m := range memories {
+		if _, err := s.AddMemory(ctx, m); err != nil {
+			t.Fatalf("failed to add memory: %v", err)
+		}
+	}
+
+	engine := NewEngine(s)
+
+	// Search for "Eagles"
+	results, err := engine.Search(ctx, "Eagles", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 results for 'Eagles', got %d", len(results))
+	}
+
+	// Search for "stock market"
+	results, err = engine.Search(ctx, "stock market", Options{Mode: ModeKeyword, Limit: 10})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result for 'stock market', got %d", len(results))
+	}
+	if len(results) > 0 && results[0].SourceFile != "finance.md" {
+		t.Errorf("expected source_file 'finance.md', got %q", results[0].SourceFile)
+	}
+}
+
+// --- Stats (via store) ---
+
+func TestStatsViaStore(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Empty store
+	stats, err := s.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats failed: %v", err)
+	}
+	if stats.MemoryCount != 0 {
+		t.Errorf("expected 0 memories, got %d", stats.MemoryCount)
+	}
+
+	// Add some data
+	seedTestData(t, s)
+	stats, err = s.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats failed: %v", err)
+	}
+	if stats.MemoryCount != 10 {
+		t.Errorf("expected 10 memories, got %d", stats.MemoryCount)
+	}
+	if stats.FactCount != 0 {
+		t.Errorf("expected 0 facts (not extracted yet), got %d", stats.FactCount)
+	}
+}


### PR DESCRIPTION
Two fixes from code audit:

1. **Module path fix**: All Go import paths updated from `github.com/LavonTMCQ/cortex` to `github.com/hurttlocker/cortex` (go.mod + all source files). Without this, fresh clones can't resolve imports.

2. **Markdown header splitting**: Parser now splits on ANY header level (h2-h6) instead of h2 only. Builds hierarchical section paths like `Projects > Project Alpha > Backend`. This means daily notes with h3 subsections get properly chunked instead of being one massive blob.

All tests passing (56 total).