### PR TITLE
feat(capture): auto-capture hygiene with dedupe/coalescing/low-signal filters (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Every import tracks **provenance**: source file, line number, section header, an
 ```bash
 cortex import ~/notes/ --recursive    # Walk an entire directory
 cortex import chat.txt --llm ollama/gemma2:2b   # Optional LLM-assist for unstructured text
+cortex import /tmp/auto-capture.md --capture-dedupe --similarity-threshold 0.95 --dedupe-window-sec 300
 ```
 
 ### 🔍 Dual Search — Two Engines, Your Choice of Model
@@ -231,6 +232,20 @@ cortex search "anything" --show-metadata               # See agent/channel/model
 ```
 
 The OpenClaw plugin automatically captures session context on every conversation — agent ID, channel, model, token usage — with zero configuration. Over time, your memory becomes a structured knowledge graph of *who knew what, when, and where*.
+
+### 🧹 Auto-Capture Hygiene — Keep Memory Clean at Scale
+
+For high-volume auto-capture workflows, Cortex supports hygiene controls to reduce noisy repetition:
+
+```bash
+# Server-side near-duplicate suppression on import
+cortex import /tmp/auto-capture.md --capture-dedupe --similarity-threshold 0.95 --dedupe-window-sec 300
+```
+
+The OpenClaw plugin also supports:
+- near-duplicate suppression (cosine threshold on recent captures)
+- burst coalescing windows for short rapid-fire turns
+- low-signal acknowledgement filters (`ok`, `got it`, etc.)
 
 ### 📉 Confidence Decay — Memory That Fades Like Yours
 

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -263,6 +263,26 @@ func TestRunImport_UnknownFlag(t *testing.T) {
 	}
 }
 
+func TestRunImport_InvalidSimilarityThreshold(t *testing.T) {
+	err := runImport([]string{"--capture-dedupe", "--similarity-threshold", "2.0", "/tmp/x.md"})
+	if err == nil {
+		t.Fatal("expected error for invalid similarity threshold")
+	}
+	if !strings.Contains(err.Error(), "--similarity-threshold") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunImport_InvalidDedupeWindow(t *testing.T) {
+	err := runImport([]string{"--capture-dedupe", "--dedupe-window-sec", "0", "/tmp/x.md"})
+	if err == nil {
+		t.Fatal("expected error for invalid dedupe window")
+	}
+	if !strings.Contains(err.Error(), "--dedupe-window-sec") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // ==================== search arg parsing ====================
 
 func TestRunSearch_NoArgs(t *testing.T) {

--- a/internal/ingest/common.go
+++ b/internal/ingest/common.go
@@ -32,6 +32,7 @@ type ImportResult struct {
 	MemoriesNew       int
 	MemoriesUpdated   int
 	MemoriesUnchanged int
+	MemoriesNearDuped int // Suppressed by near-duplicate hygiene
 	Errors            []ImportError
 }
 
@@ -43,6 +44,7 @@ func (r *ImportResult) Add(other *ImportResult) {
 	r.MemoriesNew += other.MemoriesNew
 	r.MemoriesUpdated += other.MemoriesUpdated
 	r.MemoriesUnchanged += other.MemoriesUnchanged
+	r.MemoriesNearDuped += other.MemoriesNearDuped
 	r.Errors = append(r.Errors, other.Errors...)
 }
 
@@ -62,6 +64,22 @@ type ImportOptions struct {
 	AutoTag     bool        // Infer project from file paths using default rules
 	Metadata    interface{} // *store.Metadata — stored as interface{} to avoid circular import
 	ProgressFn  func(current, total int, file string)
+
+	// Capture hygiene controls (Issue #36).
+	// Conservative defaults are applied by Normalize().
+	CaptureDedupeEnabled       bool
+	CaptureSimilarityThreshold float64
+	CaptureDedupeWindowSec     int
+}
+
+// Normalize applies sensible defaults for capture hygiene settings.
+func (o *ImportOptions) Normalize() {
+	if o.CaptureSimilarityThreshold <= 0 {
+		o.CaptureSimilarityThreshold = 0.95
+	}
+	if o.CaptureDedupeWindowSec <= 0 {
+		o.CaptureDedupeWindowSec = 300 // 5 minutes
+	}
 }
 
 // DefaultMaxFileSize is 10MB.

--- a/internal/ingest/importer.go
+++ b/internal/ingest/importer.go
@@ -1,0 +1,108 @@
+package ingest
+
+import (
+	"context"
+	"math"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+var tokenSplitRE = regexp.MustCompile(`[^a-z0-9]+`)
+
+// findNearDuplicate checks the recent memory window and returns true when
+// cosine similarity meets/exceeds threshold.
+func findNearDuplicate(ctx context.Context, s store.Store, content string, opts ImportOptions) (bool, float64, *store.Memory, error) {
+	opts.Normalize()
+	if !opts.CaptureDedupeEnabled {
+		return false, 0, nil, nil
+	}
+	if strings.TrimSpace(content) == "" {
+		return false, 0, nil, nil
+	}
+
+	recent, err := s.ListMemories(ctx, store.ListOpts{Limit: 100})
+	if err != nil {
+		return false, 0, nil, err
+	}
+	if len(recent) == 0 {
+		return false, 0, nil, nil
+	}
+
+	windowStart := time.Now().UTC().Add(-time.Duration(opts.CaptureDedupeWindowSec) * time.Second)
+	candidateVec := vectorizeText(content)
+	if len(candidateVec) == 0 {
+		return false, 0, nil, nil
+	}
+
+	bestScore := 0.0
+	var best *store.Memory
+
+	for _, m := range recent {
+		if m == nil {
+			continue
+		}
+		if m.ImportedAt.Before(windowStart) {
+			continue
+		}
+		if strings.TrimSpace(m.Content) == "" {
+			continue
+		}
+
+		score := cosineTextSimilarity(candidateVec, vectorizeText(m.Content))
+		if score > bestScore {
+			bestScore = score
+			best = m
+		}
+	}
+
+	if best != nil && bestScore >= opts.CaptureSimilarityThreshold {
+		return true, bestScore, best, nil
+	}
+	return false, bestScore, best, nil
+}
+
+func vectorizeText(text string) map[string]float64 {
+	text = strings.ToLower(strings.TrimSpace(text))
+	if text == "" {
+		return nil
+	}
+
+	rawTokens := tokenSplitRE.Split(text, -1)
+	vec := make(map[string]float64, len(rawTokens))
+	for _, tok := range rawTokens {
+		if len(tok) < 2 {
+			continue
+		}
+		vec[tok]++
+	}
+	if len(vec) == 0 {
+		return nil
+	}
+	return vec
+}
+
+func cosineTextSimilarity(a, b map[string]float64) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+
+	dot := 0.0
+	normA := 0.0
+	normB := 0.0
+
+	for k, av := range a {
+		dot += av * b[k]
+		normA += av * av
+	}
+	for _, bv := range b {
+		normB += bv * bv
+	}
+
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}

--- a/internal/ingest/importer_test.go
+++ b/internal/ingest/importer_test.go
@@ -1,0 +1,93 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+func TestCosineTextSimilarity(t *testing.T) {
+	a := vectorizeText("deploy pipeline run tests first")
+	b := vectorizeText("deploy pipeline run tests first")
+	c := vectorizeText("banana mango tropical fruit")
+
+	if sim := cosineTextSimilarity(a, b); sim < 0.99 {
+		t.Fatalf("expected identical vectors to be ~1.0, got %.3f", sim)
+	}
+	if sim := cosineTextSimilarity(a, c); sim > 0.35 {
+		t.Fatalf("expected unrelated vectors to be low similarity, got %.3f", sim)
+	}
+}
+
+func TestFindNearDuplicate(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.AddMemory(ctx, &store.Memory{
+		Content:    "Deployment checklist: run tests before merge",
+		SourceFile: "auto-capture.md",
+	})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+
+	opts := ImportOptions{
+		CaptureDedupeEnabled:       true,
+		CaptureSimilarityThreshold: 0.80,
+		CaptureDedupeWindowSec:     600,
+	}
+
+	dup, score, _, err := findNearDuplicate(ctx, s, "Deployment checklist run tests before merge", opts)
+	if err != nil {
+		t.Fatalf("findNearDuplicate: %v", err)
+	}
+	if !dup {
+		t.Fatalf("expected near duplicate to be detected (score=%.3f)", score)
+	}
+}
+
+func TestProcessMemory_NearDuplicateSuppressed(t *testing.T) {
+	s := newTestStore(t)
+	engine := NewEngine(s)
+	ctx := context.Background()
+
+	// Existing recent capture.
+	_, err := s.AddMemory(ctx, &store.Memory{
+		Content:    "ok sounds good let's deploy after tests",
+		SourceFile: "auto-capture.md",
+	})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+
+	result := &ImportResult{}
+	raw := RawMemory{
+		Content:       "ok sounds good lets deploy after tests",
+		SourceFile:    "auto-capture.md",
+		SourceLine:    1,
+		SourceSection: "capture",
+	}
+	opts := ImportOptions{
+		CaptureDedupeEnabled:       true,
+		CaptureSimilarityThreshold: 0.85,
+		CaptureDedupeWindowSec:     int((5 * time.Minute).Seconds()),
+	}
+
+	if err := engine.processMemory(ctx, raw, opts, result); err != nil {
+		t.Fatalf("processMemory: %v", err)
+	}
+
+	if result.MemoriesNearDuped != 1 {
+		t.Fatalf("expected 1 near-duplicate suppression, got %d", result.MemoriesNearDuped)
+	}
+
+	memories, err := s.ListMemories(ctx, store.ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMemories: %v", err)
+	}
+	if len(memories) != 1 {
+		t.Fatalf("expected memory count to remain 1, got %d", len(memories))
+	}
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -49,7 +49,13 @@ Add to your OpenClaw config (`~/.openclaw/openclaw.json`):
           "autoCapture": true,
           "extractFacts": true,
           "searchMode": "hybrid",
-          "embedProvider": "ollama/nomic-embed-text"
+          "embedProvider": "ollama/nomic-embed-text",
+          "capture": {
+            "dedupe": { "enabled": true },
+            "similarityThreshold": 0.95,
+            "dedupeWindowSec": 300,
+            "coalesceWindowSec": 20
+          }
         }
       }
     }
@@ -73,6 +79,10 @@ Add to your OpenClaw config (`~/.openclaw/openclaw.json`):
 | `recallLimit` | `3` | Max memories injected per turn |
 | `minScore` | `0.3` | Minimum score for auto-recall results |
 | `captureMaxChars` | `2000` | Max message length for auto-capture |
+| `capture.dedupe.enabled` | `true` | Enable near-duplicate suppression for auto-capture |
+| `capture.similarityThreshold` | `0.95` | Cosine similarity cutoff for duplicate suppression |
+| `capture.dedupeWindowSec` | `300` | Recent lookback window for dedupe checks |
+| `capture.coalesceWindowSec` | `20` | Coalesce short rapid-fire captures into one memory |
 
 ## Features
 
@@ -81,6 +91,16 @@ Before each AI response, Cortex searches for relevant memories using your query 
 
 ### Auto-Capture
 After each AI turn, the conversation exchange is captured into Cortex with automatic fact extraction. Preferences, decisions, identities, and temporal facts are extracted and indexed.
+
+### Auto-Capture Hygiene (Issue #36)
+Capture hygiene reduces memory bloat and retrieval noise:
+
+- **Near-duplicate suppression** with cosine similarity against recent captures
+- **Burst coalescing** for rapid-fire short exchanges
+- **Low-signal filter** for trivial acknowledgements (`ok`, `yes`, `got it`, etc.)
+- **Server-side dedupe** flags passed into `cortex import` for defense-in-depth
+
+These controls are configurable under `capture.*`.
 
 ### AI Tools
 The plugin registers 4 tools the AI can use:

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -52,6 +52,29 @@
     "extractFacts": {
       "label": "Extract Facts",
       "help": "Run fact extraction on captured memories (recommended)."
+    },
+    "capture.dedupe.enabled": {
+      "label": "Capture Dedupe Enabled",
+      "help": "Suppress near-duplicate auto-captures using cosine similarity on recent captures.",
+      "advanced": true
+    },
+    "capture.similarityThreshold": {
+      "label": "Capture Similarity Threshold",
+      "placeholder": "0.95",
+      "help": "Cosine similarity cutoff for near-duplicate suppression (0-1).",
+      "advanced": true
+    },
+    "capture.dedupeWindowSec": {
+      "label": "Capture Dedupe Window (sec)",
+      "placeholder": "300",
+      "help": "Lookback window for dedupe comparison.",
+      "advanced": true
+    },
+    "capture.coalesceWindowSec": {
+      "label": "Capture Coalesce Window (sec)",
+      "placeholder": "20",
+      "help": "Merge rapid-fire short captures inside this time window.",
+      "advanced": true
     }
   },
   "configSchema": {
@@ -70,7 +93,28 @@
       "recallLimit": { "type": "number", "minimum": 1, "maximum": 10 },
       "minScore": { "type": "number", "minimum": 0, "maximum": 1 },
       "captureMaxChars": { "type": "number", "minimum": 100, "maximum": 10000 },
-      "extractFacts": { "type": "boolean" }
+      "extractFacts": { "type": "boolean" },
+      "capture": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "dedupe": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": { "type": "boolean" }
+            }
+          },
+          "similarityThreshold": { "type": "number", "minimum": 0, "maximum": 1 },
+          "dedupeWindowSec": { "type": "number", "minimum": 1, "maximum": 86400 },
+          "coalesceWindowSec": { "type": "number", "minimum": 0, "maximum": 3600 },
+          "shortCaptureMaxChars": { "type": "number", "minimum": 50, "maximum": 5000 },
+          "lowSignalPatterns": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## What this does
Implements **Phase 3 / Issue #36: Auto-Capture Hygiene** across both plugin-side and server-side paths.

### Shipped hygiene controls
- **Near-duplicate suppression** (cosine similarity on recent captures)
- **Burst coalescing** for rapid-fire short captures
- **Low-signal filter** for trivial acknowledgements (`ok`, `yes`, `got it`, etc.)
- **Server-side dedupe guard** in ingest for defense-in-depth

## Problem / Context
With `autoCapture=true`, high-volume sessions can accumulate repetitive low-signal memory records that degrade retrieval precision and increase storage bloat.

Issue: https://github.com/hurttlocker/cortex/issues/36

## How it works
### 1) Plugin pre-import hygiene (`plugin/index.ts`)
Added a `CaptureHygiene` manager that runs before import:

- **Low-signal suppression**
  - Normalizes text and drops trivial acknowledgements unless marked important.
- **Near-duplicate suppression**
  - Cosine similarity over bag-of-words against recent capture cache.
  - Configurable threshold/window.
- **Burst coalescing**
  - Short captures within a time window are merged into a single record.
  - Pending burst flushes on timer and on plugin stop.

### 2) Server-side dedupe (`internal/ingest/importer.go` + ingest pipeline)
- Added near-duplicate scan against recent memories in a time window.
- Uses cosine similarity on token-frequency vectors.
- Wired into ingest `processMemory` when dedupe is enabled.
- Tracks measurable suppression count in import results (`MemoriesNearDuped`).

### 3) CLI/config wiring
#### Import CLI flags
- `--capture-dedupe`
- `--similarity-threshold <0..1>`
- `--dedupe-window-sec <N>`

#### Plugin config
Added nested capture config:
- `capture.dedupe.enabled`
- `capture.similarityThreshold`
- `capture.dedupeWindowSec`
- `capture.coalesceWindowSec`
- `capture.shortCaptureMaxChars`
- `capture.lowSignalPatterns`

### 4) Docs
Updated:
- `README.md`
- `plugin/README.md`
- `plugin/openclaw.plugin.json` schema + UI hints
- CLI usage/help text in `cmd/cortex/main.go`

## Testing done
### Automated
- `go test ./...` ✅

### New test coverage
- `internal/ingest/importer_test.go`
  - cosine similarity behavior
  - near-duplicate detection
  - suppression in ingest pipeline
- `cmd/cortex/main_test.go`
  - invalid dedupe threshold handling
  - invalid dedupe window handling

## Screenshots / before-after
CLI verification:

```bash
go test ./...
ok   github.com/hurttlocker/cortex/cmd/cortex              9.562s
ok   github.com/hurttlocker/cortex/internal/ann            0.768s
ok   github.com/hurttlocker/cortex/internal/embed          7.698s
ok   github.com/hurttlocker/cortex/internal/extract        14.958s
ok   github.com/hurttlocker/cortex/internal/ingest         2.405s
ok   github.com/hurttlocker/cortex/internal/mcp            0.603s
ok   github.com/hurttlocker/cortex/internal/observe        0.975s
ok   github.com/hurttlocker/cortex/internal/reason         1.994s
ok   github.com/hurttlocker/cortex/internal/search         1.681s
ok   github.com/hurttlocker/cortex/internal/store          2.927s
```

## Breaking changes / risks
- No breaking schema/API change.
- Dedupe behavior is configurable and conservative by default.
- Coalescing only affects short captures inside a configured burst window.

## Merge notes
- Merge normally to `main`.
- Plugin users can tune hygiene via `capture.*` config.
- Server-side dedupe remains opt-in via import flags from plugin path.