### PR TITLE
feat(facts): superseded tombstone model + include-superseded queries (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,22 @@ cortex search "anything" --show-metadata               # See agent/channel/model
 
 The OpenClaw plugin automatically captures session context on every conversation — agent ID, channel, model, token usage — with zero configuration. Over time, your memory becomes a structured knowledge graph of *who knew what, when, and where*.
 
+### 🪦 Superseded/Tombstone Facts — Keep History, Hide Stale Truth
+
+When a fact is replaced, you can mark the old fact as superseded without deleting it:
+
+```bash
+cortex supersede 12345 --by 12399 --reason "policy updated"
+```
+
+By default, superseded facts are excluded from active listings/conflict scans and from search results tied only to superseded facts. Use `--include-superseded` for historical/debug views:
+
+```bash
+cortex list --facts --include-superseded
+cortex conflicts --include-superseded
+cortex search "old policy" --include-superseded
+```
+
 ### 📉 Confidence Decay — Memory That Fades Like Yours
 
 Inspired by [Ebbinghaus's forgetting curve](https://en.wikipedia.org/wiki/Forgetting_curve) from cognitive science. Facts decay over time unless reinforced — just like human memory.
@@ -405,10 +421,12 @@ Generates a markdown report with timing, token usage, cost estimates, and output
 ```bash
 cortex stats        # Overview: counts, freshness, storage, top facts
 cortex stale        # What's fading — reinforce, delete, or skip
-cortex conflicts    # Contradictions — merge, keep both, or delete one
+cortex conflicts    # Contradictions among active facts
 cortex conflicts --resolve highest-confidence  # Auto-resolve by confidence
 cortex conflicts --resolve newest --dry-run    # Preview before applying
 cortex conflicts --keep 12345 --drop 12346     # Surgical manual resolution
+cortex supersede 12345 --by 12399 --reason "policy updated"
+cortex search "deployment policy" --include-superseded
 ```
 
 No more black-box memory. No more hoping the agent remembers correctly.

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -98,6 +98,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
+	case "supersede":
+		if err := runSupersede(args[1:]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 	case "reimport":
 		if err := runReimport(args[1:]); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -389,6 +394,7 @@ func runSearch(args []string) error {
 	afterFlag := ""
 	beforeFlag := ""
 	showMetadata := false
+	includeSuperseded := false
 
 	for i := 0; i < len(args); i++ {
 		switch {
@@ -426,6 +432,8 @@ func runSearch(args []string) error {
 			beforeFlag = strings.TrimPrefix(args[i], "--before=")
 		case args[i] == "--show-metadata":
 			showMetadata = true
+		case args[i] == "--include-superseded":
+			includeSuperseded = true
 		case args[i] == "--mode" && i+1 < len(args):
 			i++
 			mode = args[i]
@@ -479,7 +487,7 @@ func runSearch(args []string) error {
 
 	query := strings.Join(queryParts, " ")
 	if query == "" {
-		return fmt.Errorf("usage: cortex search <query> [--mode keyword|semantic|hybrid] [--limit N] [--embed <provider/model>] [--class rule,decision] [--no-class-boost] [--json] [--agent <id>] [--channel <name>] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--show-metadata]")
+		return fmt.Errorf("usage: cortex search <query> [--mode keyword|semantic|hybrid] [--limit N] [--embed <provider/model>] [--class rule,decision] [--no-class-boost] [--include-superseded] [--json] [--agent <id>] [--channel <name>] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--show-metadata]")
 	}
 
 	searchMode, err := search.ParseMode(mode)
@@ -545,6 +553,7 @@ func runSearch(args []string) error {
 		Channel:           channelFlag,
 		After:             afterFlag,
 		Before:            beforeFlag,
+		IncludeSuperseded: includeSuperseded,
 	}
 
 	results, err := engine.Search(ctx, query, opts)
@@ -642,6 +651,8 @@ func runStale(args []string) error {
 			opts.MaxConfidence = conf
 		case args[i] == "--json":
 			jsonOutput = true
+		case args[i] == "--include-superseded":
+			opts.IncludeSuperseded = true
 		case strings.HasPrefix(args[i], "-"):
 			return fmt.Errorf("unknown flag: %s", args[i])
 		default:
@@ -695,6 +706,7 @@ func runConflicts(args []string) error {
 	limitFlag := 100
 	keepFlag := int64(0)
 	dropFlag := int64(0)
+	includeSuperseded := false
 
 	// Parse flags
 	for i := 0; i < len(args); i++ {
@@ -735,6 +747,8 @@ func runConflicts(args []string) error {
 				return fmt.Errorf("invalid --drop: %s", args[i])
 			}
 			dropFlag = n
+		case args[i] == "--include-superseded":
+			includeSuperseded = true
 		default:
 			if strings.HasPrefix(args[i], "-") {
 				return fmt.Errorf("unknown flag: %s", args[i])
@@ -770,7 +784,7 @@ func runConflicts(args []string) error {
 			enc.SetIndent("", "  ")
 			return enc.Encode(res)
 		}
-		fmt.Printf("✅ Resolved: kept fact %d, suppressed fact %d\n", res.WinnerID, res.LoserID)
+		fmt.Printf("✅ Resolved: kept fact %d, superseded fact %d\n", res.WinnerID, res.LoserID)
 		fmt.Printf("   %s\n", res.Reason)
 		return nil
 	}
@@ -782,9 +796,21 @@ func runConflicts(args []string) error {
 			return err
 		}
 
-		batch, err := resolver.DetectAndResolve(ctx, strategy, dryRun)
-		if err != nil {
-			return fmt.Errorf("resolving conflicts: %w", err)
+		var batch *observe.ResolveBatch
+		if includeSuperseded {
+			conflicts, err := engine.GetConflictsLimitWithSuperseded(ctx, limitFlag, true)
+			if err != nil {
+				return fmt.Errorf("resolving conflicts: %w", err)
+			}
+			batch, err = resolver.ResolveConflicts(ctx, conflicts, strategy, dryRun)
+			if err != nil {
+				return fmt.Errorf("resolving conflicts: %w", err)
+			}
+		} else {
+			batch, err = resolver.DetectAndResolve(ctx, strategy, dryRun)
+			if err != nil {
+				return fmt.Errorf("resolving conflicts: %w", err)
+			}
 		}
 
 		if jsonOutput || !isTTY() {
@@ -817,7 +843,7 @@ func runConflicts(args []string) error {
 	}
 
 	// Detection only (default)
-	conflicts, err := engine.GetConflictsLimit(ctx, limitFlag)
+	conflicts, err := engine.GetConflictsLimitWithSuperseded(ctx, limitFlag, includeSuperseded)
 	if err != nil {
 		return fmt.Errorf("getting conflicts: %w", err)
 	}
@@ -912,7 +938,7 @@ func runList(args []string) error {
 	// Parse flags
 	var limit int = 20
 	var sourceFile, factType, classFlag string
-	var listFacts, jsonOutput bool
+	var listFacts, jsonOutput, includeSuperseded bool
 
 	for i := 0; i < len(args); i++ {
 		switch {
@@ -946,6 +972,8 @@ func runList(args []string) error {
 			factType = strings.TrimPrefix(args[i], "--type=")
 		case args[i] == "--json":
 			jsonOutput = true
+		case args[i] == "--include-superseded":
+			includeSuperseded = true
 		case strings.HasPrefix(args[i], "-"):
 			return fmt.Errorf("unknown flag: %s", args[i])
 		default:
@@ -970,11 +998,12 @@ func runList(args []string) error {
 	}
 
 	opts := store.ListOpts{
-		Limit:         limit,
-		Offset:        0,
-		SourceFile:    sourceFile,
-		FactType:      factType,
-		MemoryClasses: classes,
+		Limit:             limit,
+		Offset:            0,
+		SourceFile:        sourceFile,
+		FactType:          factType,
+		MemoryClasses:     classes,
+		IncludeSuperseded: includeSuperseded,
 	}
 
 	if listFacts {
@@ -1229,6 +1258,66 @@ func runReinforce(args []string) error {
 	}
 
 	fmt.Printf("Reinforced %d fact(s)\n", reinforced)
+	return nil
+}
+
+func runSupersede(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: cortex supersede <old_fact_id> --by <new_fact_id> [--reason <text>]")
+	}
+
+	oldFactID, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid old fact id %q", args[0])
+	}
+
+	newFactID := int64(0)
+	reason := ""
+	for i := 1; i < len(args); i++ {
+		switch {
+		case args[i] == "--by" && i+1 < len(args):
+			i++
+			v, err := strconv.ParseInt(args[i], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid --by value %q", args[i])
+			}
+			newFactID = v
+		case strings.HasPrefix(args[i], "--by="):
+			v, err := strconv.ParseInt(strings.TrimPrefix(args[i], "--by="), 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid --by value %q", args[i])
+			}
+			newFactID = v
+		case args[i] == "--reason" && i+1 < len(args):
+			i++
+			reason = args[i]
+		case strings.HasPrefix(args[i], "--reason="):
+			reason = strings.TrimPrefix(args[i], "--reason=")
+		default:
+			return fmt.Errorf("unknown argument: %s", args[i])
+		}
+	}
+
+	if newFactID <= 0 {
+		return fmt.Errorf("--by <new_fact_id> is required")
+	}
+
+	s, err := store.NewStore(getStoreConfig())
+	if err != nil {
+		return fmt.Errorf("opening store: %w", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	if err := s.SupersedeFact(ctx, oldFactID, newFactID, reason); err != nil {
+		return err
+	}
+
+	fmt.Printf("Fact %d superseded by fact %d", oldFactID, newFactID)
+	if reason != "" {
+		fmt.Printf(" (%s)", reason)
+	}
+	fmt.Println()
 	return nil
 }
 
@@ -2173,6 +2262,9 @@ func outputListFactsTTY(facts []*store.Fact, opts store.ListOpts) error {
 		fmt.Printf("  %d. [%s] %s\n", i+1, fact.FactType, factContent)
 		fmt.Printf("     Confidence: %.2f · Decay: %.3f/day\n",
 			fact.Confidence, fact.DecayRate)
+		if fact.SupersededBy != nil {
+			fmt.Printf("     Superseded by fact: %d\n", *fact.SupersededBy)
+		}
 
 		// Add source quote if available and verbose
 		if globalVerbose && fact.SourceQuote != "" {
@@ -3271,6 +3363,7 @@ Commands:
   embed [provider/model] Generate embeddings for missing memories (or run daemon with --watch)
   search <query>      Search memory (keyword, semantic, or hybrid)
   reinforce <id>      Reinforce a fact (reset its decay timer)
+  supersede <id>      Mark a fact as superseded by a newer fact
   stats               Show memory statistics and health
   list                List memories or facts from the store
   export              Export the full memory store in different formats
@@ -3298,6 +3391,7 @@ Search Flags:
   --project <name>    Scope search to a specific project (e.g., --project trading)
   --class <list>      Filter by memory class (e.g., --class rule,decision)
   --no-class-boost    Disable class-aware ranking boosts
+  --include-superseded Include memories tied only to superseded facts
   --json              Force JSON output even in TTY
 
 Import Flags:
@@ -3326,6 +3420,7 @@ List Flags:
   --source <file>     Filter by source file
   --class <list>      Filter memories by class (e.g., --class rule,decision)
   --type <fact_type>  Filter facts by type (kv, temporal, identity, etc.)
+  --include-superseded Include superseded facts in --facts output
   --json              Force JSON output even in TTY
 
 Export Flags:
@@ -3335,6 +3430,9 @@ Export Flags:
 
 Stats Flags:
   --json              Force JSON output even in TTY
+
+Stale/Conflict Flags:
+  --include-superseded Include superseded facts in stale/conflict views
 
 Reimport Flags:
   -r, --recursive     Recursively import from directories
@@ -3352,6 +3450,9 @@ Embed Flags:
 Reinforce:
   cortex reinforce <fact_id> [fact_id...]   Reset decay timer for specified facts
 
+Supersede:
+  cortex supersede <old_fact_id> --by <new_fact_id> [--reason <text>]
+
 MCP Flags:
   --port <N>          Start HTTP+SSE transport on port (default: stdio)
   --embed <provider/model> Enable semantic/hybrid search via embeddings
@@ -3363,6 +3464,8 @@ Examples:
   cortex --db ~/my-cortex.db list --source ~/notes.md
   cortex embed ollama/nomic-embed-text --batch-size 10
   cortex embed ollama/nomic-embed-text --watch --interval 30m --batch-size 10
+  cortex supersede 101 --by 204 --reason "policy updated"
+  cortex search "deployment rule" --include-superseded
   cortex mcp                          # Start MCP server (stdio, for Claude Desktop/Cursor)
   cortex mcp --port 8080              # Start MCP server (HTTP+SSE)
 

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -275,6 +275,26 @@ func TestRunSearch_NoArgs(t *testing.T) {
 	}
 }
 
+func TestRunSupersede_MissingBy(t *testing.T) {
+	err := runSupersede([]string{"1"})
+	if err == nil {
+		t.Fatal("expected --by required error")
+	}
+	if !strings.Contains(err.Error(), "--by") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunSupersede_InvalidOldID(t *testing.T) {
+	err := runSupersede([]string{"abc", "--by", "2"})
+	if err == nil {
+		t.Fatal("expected invalid old id error")
+	}
+	if !strings.Contains(err.Error(), "invalid old fact id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // ==================== conflicts arg parsing ====================
 
 func TestRunConflicts_UnknownFlag(t *testing.T) {

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -106,6 +106,14 @@ Reset decay timer on a fact you just used — keeps it fresh:
 cortex reinforce <fact_id>
 ```
 
+### Supersede (Tombstone)
+Mark an outdated fact as superseded by a newer one (keeps audit history, hides stale truth by default):
+
+```bash
+cortex supersede <old_fact_id> --by <new_fact_id> --reason "policy updated"
+cortex list --facts --include-superseded
+```
+
 ### Cleanup
 Purge garbage/duplicate memories:
 


### PR DESCRIPTION
## What this does
Implements **Phase 4 / Issue #35: Superseded (tombstone) model for facts**.

Key outcomes:
- Adds `superseded_by` field on facts (nullable FK to `facts.id`)
- Old contradictory facts are **marked superseded, not deleted**
- Superseded facts are excluded by default in active retrieval paths
- Historical visibility restored with `--include-superseded`
- Integrates with existing conflict resolution flow (#14)

## Problem / Context
Contradictions and evolving preferences/rules create stale truth over time. The previous conflict flow relied on confidence suppression only, which preserved rows but lacked explicit supersession semantics and clean historical query controls.

Issue: https://github.com/hurttlocker/cortex/issues/35

## How it works
### Schema + migration
- `facts.superseded_by INTEGER REFERENCES facts(id)`
- New migration for existing DBs + index (`idx_facts_superseded_by`)

### Store/API behavior
- New method: `SupersedeFact(ctx, oldFactID, newFactID, reason)`
  - Marks loser as superseded by winner
  - Keeps row for audit history
  - Sets loser confidence to `0.0` to reduce ranking leakage when historical views are enabled
- `ListFacts` excludes superseded by default; includes with `ListOpts.IncludeSuperseded`
- Added `GetFactsByMemoryIDsIncludingSuperseded` for historical-aware search flows

### Conflict resolution integration (#14)
- Resolver now uses tombstone semantics (`SupersedeFact`) instead of only confidence suppression
- Manual and auto conflict resolution both mark losing facts as superseded
- Conflict detection now defaults to active (non-superseded) facts
- Historical conflicts available through include-superseded path

### Retrieval behavior
- Search option: `--include-superseded`
- Default search excludes memories whose linked facts are all superseded
- `--include-superseded` restores historical visibility

### CLI additions
- New command:
  - `cortex supersede <old_fact_id> --by <new_fact_id> [--reason <text>]`
- Added `--include-superseded` support for:
  - `cortex search`
  - `cortex list --facts`
  - `cortex stale`
  - `cortex conflicts`

## Testing done
- `go test ./...` ✅

Added/updated tests for:
- `superseded_by` migration column presence
- supersede lifecycle behavior (active default vs include-superseded historical view)
- search default exclusion + explicit include-superseded behavior
- CLI arg validation for `supersede` and dedupe parsing regressions

## Screenshots / before-after
CLI test run:

```bash
go test ./...
ok   github.com/hurttlocker/cortex/cmd/cortex              0.330s
ok   github.com/hurttlocker/cortex/internal/ann            2.043s
ok   github.com/hurttlocker/cortex/internal/embed          7.831s
ok   github.com/hurttlocker/cortex/internal/extract        14.133s
ok   github.com/hurttlocker/cortex/internal/ingest         1.005s
ok   github.com/hurttlocker/cortex/internal/mcp            2.458s
ok   github.com/hurttlocker/cortex/internal/observe        3.160s
ok   github.com/hurttlocker/cortex/internal/reason         0.599s
ok   github.com/hurttlocker/cortex/internal/search         2.996s
ok   github.com/hurttlocker/cortex/internal/store          1.591s
```

## Breaking changes / risks
- No breaking schema change for users (migration is additive and backward-compatible).
- Default active fact counts/search views now exclude superseded facts by design.
- Historical visibility remains available via `--include-superseded`.

## Merge notes
- Merge normally to `main`.
- No manual migration action required; startup migration handles schema update.
- Recommended operator workflow:
  - resolve conflicts normally (now tombstones old facts)
  - use `--include-superseded` for audits/debug history
