### PR TITLE
feat(bench): comprehensive overhaul with recursive + A/B compare (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,11 +443,17 @@ cortex bench --models "google/gemini-2.5-flash,deepseek/deepseek-chat" \
   --embed ollama/nomic-embed-text \
   --output benchmark-report.md
 
+# Quick A/B (diff-style compare section in report)
+cortex bench --compare "google/gemini-2.5-flash,deepseek/deepseek-v3.2" --output ab-report.md
+
+# Benchmark recursive reasoning mode
+cortex bench --recursive --max-iterations 8 --max-depth 1 --output recursive-bench.md
+
 # Include local models
 cortex bench --local --embed ollama/nomic-embed-text
 ```
 
-Generates a markdown report with timing, token usage, cost estimates, and output quality for each model × preset combination. Run it whenever a new model drops.
+Generates a publication-ready markdown report with summary table, per-preset breakdown, winners by category, cost analysis, and (when using `--compare`) an A/B diff section. Default runs cover all 5 presets: `daily-digest`, `fact-audit`, `conflict-check`, `weekly-dive`, and `agent-review`.
 
 ### 👁️ Observability — Finally See What Your Agent Knows
 

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -305,6 +305,42 @@ func TestRunSearch_ExplainFlagAccepted(t *testing.T) {
 	}
 }
 
+func TestParseBenchArgs_Compare(t *testing.T) {
+	opts, err := parseBenchArgs([]string{"--compare", "google/gemini-2.5-flash,deepseek/deepseek-v3.2", "--recursive"})
+	if err != nil {
+		t.Fatalf("parseBenchArgs failed: %v", err)
+	}
+	if !opts.compareMode {
+		t.Fatal("expected compareMode=true")
+	}
+	if len(opts.customModels) != 2 {
+		t.Fatalf("expected 2 compare models, got %d", len(opts.customModels))
+	}
+	if !opts.recursive {
+		t.Fatal("expected recursive=true")
+	}
+}
+
+func TestParseBenchArgs_CompareAndModelsConflict(t *testing.T) {
+	_, err := parseBenchArgs([]string{"--compare", "a,b", "--models", "c,d"})
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "cannot be used") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseBenchArgs_InvalidCompareCount(t *testing.T) {
+	_, err := parseBenchArgs([]string{"--compare", "onlyone"})
+	if err == nil {
+		t.Fatal("expected compare arity error")
+	}
+	if !strings.Contains(err.Error(), "exactly two") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunSupersede_MissingBy(t *testing.T) {
 	err := runSupersede([]string{"1"})
 	if err == nil {

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -212,6 +212,12 @@ When a new model drops, test it on your own memory:
 ```bash
 cortex bench --models "google/gemini-2.5-flash,deepseek/deepseek-chat" \
   --embed ollama/nomic-embed-text --output report.md
+
+# Quick A/B compare
+cortex bench --compare "google/gemini-2.5-flash,deepseek/deepseek-v3.2" --output ab.md
+
+# Recursive benchmark (deep mode)
+cortex bench --recursive --max-iterations 8 --max-depth 1 --output recursive.md
 ```
 
 ## 7. Ongoing Habits

--- a/internal/reason/bench.go
+++ b/internal/reason/bench.go
@@ -3,6 +3,7 @@ package reason
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ var DefaultBenchPresets = []BenchPreset{
 	{Name: "daily-digest", Query: "recent development activity and decisions"},
 	{Name: "fact-audit", Query: "data quality issues in extracted facts"},
 	{Name: "conflict-check", Query: "contradictory or inconsistent information"},
+	{Name: "weekly-dive", Query: "key patterns, risks, and recommendations from the last week"},
+	{Name: "agent-review", Query: "agent performance, coordination gaps, and improvement opportunities"},
 }
 
 // Pricing per million tokens (input, output) — updated Feb 2026.
@@ -63,55 +66,88 @@ var ModelPricing = map[string][2]float64{
 	"openai/gpt-oss-safeguard-20b":  {0, 0}, // Preview/free
 }
 
+// BenchQualitySignals are lightweight quality markers for output comparison.
+type BenchQualitySignals struct {
+	HasHeaders         bool `json:"has_headers"`
+	HasActionableItems bool `json:"has_actionable_items"`
+	WordCount          int  `json:"word_count"`
+	UniqueMemoryRefs   int  `json:"unique_memory_refs"`
+}
+
 // BenchResult holds one model × preset test result.
 type BenchResult struct {
-	Model       string        `json:"model"`
-	Label       string        `json:"label"`
-	Provider    string        `json:"provider"`
-	Preset      string        `json:"preset"`
-	Query       string        `json:"query"`
-	WallTime    time.Duration `json:"wall_time"`
-	SearchTime  time.Duration `json:"search_time"`
-	LLMTime     time.Duration `json:"llm_time"`
-	TokensIn    int           `json:"tokens_in"`
-	TokensOut   int           `json:"tokens_out"`
-	CostUSD     float64       `json:"cost_usd"`
-	Content     string        `json:"content"`
-	ContentLen  int           `json:"content_len"`
-	Error       string        `json:"error,omitempty"`
-	MemoryCount int           `json:"memories_used"`
+	Model           string              `json:"model"`
+	Label           string              `json:"label"`
+	Provider        string              `json:"provider"`
+	Preset          string              `json:"preset"`
+	Query           string              `json:"query"`
+	WallTime        time.Duration       `json:"wall_time"`
+	SearchTime      time.Duration       `json:"search_time"`
+	LLMTime         time.Duration       `json:"llm_time"`
+	TokensIn        int                 `json:"tokens_in"`
+	TokensOut       int                 `json:"tokens_out"`
+	CostUSD         float64             `json:"cost_usd"`
+	CostKnown       bool                `json:"cost_known"`
+	CostPer1KTokens float64             `json:"cost_per_1k_tokens"`
+	Content         string              `json:"content"`
+	ContentLen      int                 `json:"content_len"`
+	Error           string              `json:"error,omitempty"`
+	MemoryCount     int                 `json:"memories_used"`
+	FactsUsed       int                 `json:"facts_used"`
+	Iterations      int                 `json:"iterations"`
+	Recursive       bool                `json:"recursive"`
+	RecursiveDepth  int                 `json:"recursive_depth"`
+	QualitySignals  BenchQualitySignals `json:"quality_signals"`
 }
 
 // BenchReport is the full benchmark output.
 type BenchReport struct {
-	Timestamp string         `json:"timestamp"`
-	Models    int            `json:"models_tested"`
-	Presets   int            `json:"presets_tested"`
-	Results   []BenchResult  `json:"results"`
-	Summary   []BenchSummary `json:"summary"`
+	Timestamp      string         `json:"timestamp"`
+	Models         int            `json:"models_tested"`
+	Presets        int            `json:"presets_tested"`
+	Recursive      bool           `json:"recursive"`
+	CompareMode    bool           `json:"compare_mode"`
+	ComparedModels []string       `json:"compared_models,omitempty"`
+	Results        []BenchResult  `json:"results"`
+	Summary        []BenchSummary `json:"summary"`
 }
 
 // BenchSummary aggregates a model's performance across all presets.
 type BenchSummary struct {
-	Label     string  `json:"label"`
-	Model     string  `json:"model"`
-	Provider  string  `json:"provider"`
-	AvgTime   float64 `json:"avg_time_sec"`
-	AvgTokens int     `json:"avg_tokens_out"`
-	TotalCost float64 `json:"total_cost_usd"`
-	AvgCost   float64 `json:"avg_cost_usd"`
-	Errors    int     `json:"errors"`
-	Verdict   string  `json:"verdict"`
+	Label              string  `json:"label"`
+	Model              string  `json:"model"`
+	Provider           string  `json:"provider"`
+	AvgTime            float64 `json:"avg_time_sec"`
+	AvgTokens          int     `json:"avg_tokens_out"`
+	AvgIterations      float64 `json:"avg_iterations"`
+	AvgFactsUsed       float64 `json:"avg_facts_used"`
+	TotalCost          float64 `json:"total_cost_usd"`
+	AvgCost            float64 `json:"avg_cost_usd"`
+	AvgCostPer1KTokens float64 `json:"avg_cost_per_1k_tokens"`
+	KnownCostRuns      int     `json:"known_cost_runs"`
+	CostUnknownRuns    int     `json:"cost_unknown_runs"`
+	Errors             int     `json:"errors"`
+	Verdict            string  `json:"verdict"`
 }
 
 // BenchOptions configures a benchmark run.
 type BenchOptions struct {
-	Models       []BenchModel                             // Models to test (nil = DefaultBenchModels)
-	Presets      []BenchPreset                            // Presets to test (nil = DefaultBenchPresets)
-	IncludeLocal bool                                     // Include local ollama models
-	MaxContext   int                                      // Max context chars (default: 8000)
-	Verbose      bool                                     // Print progress
-	ProgressFn   func(model, preset string, i, total int) // Progress callback
+	Models         []BenchModel                             // Models to test (nil = DefaultBenchModels)
+	Presets        []BenchPreset                            // Presets to test (nil = DefaultBenchPresets)
+	IncludeLocal   bool                                     // Include local ollama models
+	MaxContext     int                                      // Max context chars (default: 8000)
+	Recursive      bool                                     // Use recursive reasoning mode
+	MaxIterations  int                                      // Recursive mode only (default: 8)
+	MaxDepth       int                                      // Recursive mode only (default: 1)
+	CompareMode    bool                                     // Output compare-oriented report sections
+	ComparedModels []string                                 // Models from --compare (for report metadata)
+	Verbose        bool                                     // Print progress
+	ProgressFn     func(model, preset string, i, total int) // Progress callback
+
+	// Test hooks
+	llmFactory  func(model BenchModel) (*LLM, error)
+	reasonFn    func(ctx context.Context, opts ReasonOptions) (*ReasonResult, error)
+	recursiveFn func(ctx context.Context, opts RecursiveOptions) (*RecursiveResult, error)
 }
 
 // RunBenchmark executes the full benchmark suite.
@@ -129,16 +165,46 @@ func (e *Engine) RunBenchmark(ctx context.Context, opts BenchOptions) (*BenchRep
 		presets = DefaultBenchPresets
 	}
 
+	maxCtx := opts.MaxContext
+	if maxCtx <= 0 {
+		maxCtx = 8000
+	}
+	maxIter := opts.MaxIterations
+	if maxIter <= 0 {
+		maxIter = 8
+	}
+	maxDepth := opts.MaxDepth
+	if maxDepth <= 0 {
+		maxDepth = 1
+	}
+
+	llmFactory := opts.llmFactory
+	if llmFactory == nil {
+		llmFactory = func(model BenchModel) (*LLM, error) {
+			return NewLLM(LLMConfig{Provider: model.Provider, Model: model.Model})
+		}
+	}
+
+	reasonRunner := opts.reasonFn
+	if reasonRunner == nil {
+		reasonRunner = func(ctx context.Context, ropts ReasonOptions) (*ReasonResult, error) {
+			return e.Reason(ctx, ropts)
+		}
+	}
+
+	recursiveRunner := opts.recursiveFn
+	if recursiveRunner == nil {
+		recursiveRunner = func(ctx context.Context, ropts RecursiveOptions) (*RecursiveResult, error) {
+			return e.ReasonRecursive(ctx, ropts)
+		}
+	}
+
 	total := len(models) * len(presets)
-	var results []BenchResult
+	results := make([]BenchResult, 0, total)
 	i := 0
 
 	for _, model := range models {
-		// Create LLM client for this model
-		llm, err := NewLLM(LLMConfig{
-			Provider: model.Provider,
-			Model:    model.Model,
-		})
+		llm, llmErr := llmFactory(model)
 
 		for _, bp := range presets {
 			i++
@@ -146,82 +212,190 @@ func (e *Engine) RunBenchmark(ctx context.Context, opts BenchOptions) (*BenchRep
 				opts.ProgressFn(model.Label, bp.Name, i, total)
 			}
 
-			if err != nil {
-				results = append(results, BenchResult{
-					Model:    model.Model,
-					Label:    model.Label,
-					Provider: model.Provider,
-					Preset:   bp.Name,
-					Query:    bp.Query,
-					Error:    fmt.Sprintf("LLM init: %v", err),
-				})
+			br := BenchResult{
+				Model:     model.Model,
+				Label:     model.Label,
+				Provider:  model.Provider,
+				Preset:    bp.Name,
+				Query:     bp.Query,
+				Recursive: opts.Recursive,
+			}
+
+			if llmErr != nil {
+				br.Error = fmt.Sprintf("LLM init: %v", llmErr)
+				results = append(results, br)
 				continue
 			}
 
-			// Swap the LLM for this model
 			origLLM := e.llm
 			e.llm = llm
 
-			maxCtx := opts.MaxContext
-			if maxCtx <= 0 {
-				maxCtx = 8000
-			}
-
 			start := time.Now()
-			result, reasonErr := e.Reason(ctx, ReasonOptions{
-				Query:      bp.Query,
-				Preset:     bp.Name,
-				MaxContext: maxCtx,
-			})
-			wallTime := time.Since(start)
+			if opts.Recursive {
+				rResult, err := recursiveRunner(ctx, RecursiveOptions{
+					Query:         bp.Query,
+					Preset:        bp.Name,
+					MaxContext:    maxCtx,
+					MaxIterations: maxIter,
+					MaxDepth:      maxDepth,
+				})
+				br.WallTime = time.Since(start)
+
+				if err != nil {
+					br.Error = err.Error()
+				} else {
+					br.SearchTime = rResult.SearchTime
+					br.LLMTime = rResult.LLMTime
+					br.TokensIn = rResult.TokensIn
+					br.TokensOut = rResult.TokensOut
+					br.Content = rResult.Content
+					br.ContentLen = len(rResult.Content)
+					br.MemoryCount = rResult.MemoriesUsed
+					br.FactsUsed = rResult.FactsUsed
+					br.Iterations = maxInt(1, rResult.Iterations)
+					br.RecursiveDepth = maxSubQueryDepth(rResult)
+					br.QualitySignals = extractQualitySignals(rResult.Content)
+					br.CostUSD, br.CostKnown = estimateCost(model.Model, rResult.TokensIn, rResult.TokensOut)
+					br.CostPer1KTokens = estimateCostPer1K(br.CostUSD, rResult.TokensIn, rResult.TokensOut, br.CostKnown)
+				}
+			} else {
+				rResult, err := reasonRunner(ctx, ReasonOptions{
+					Query:      bp.Query,
+					Preset:     bp.Name,
+					MaxContext: maxCtx,
+				})
+				br.WallTime = time.Since(start)
+
+				if err != nil {
+					br.Error = err.Error()
+				} else {
+					br.SearchTime = rResult.SearchTime
+					br.LLMTime = rResult.LLMTime
+					br.TokensIn = rResult.TokensIn
+					br.TokensOut = rResult.TokensOut
+					br.Content = rResult.Content
+					br.ContentLen = len(rResult.Content)
+					br.MemoryCount = rResult.MemoriesUsed
+					br.FactsUsed = rResult.FactsUsed
+					br.Iterations = 1
+					br.RecursiveDepth = 0
+					br.QualitySignals = extractQualitySignals(rResult.Content)
+					br.CostUSD, br.CostKnown = estimateCost(model.Model, rResult.TokensIn, rResult.TokensOut)
+					br.CostPer1KTokens = estimateCostPer1K(br.CostUSD, rResult.TokensIn, rResult.TokensOut, br.CostKnown)
+				}
+			}
 
 			e.llm = origLLM
-
-			br := BenchResult{
-				Model:    model.Model,
-				Label:    model.Label,
-				Provider: model.Provider,
-				Preset:   bp.Name,
-				Query:    bp.Query,
-				WallTime: wallTime,
-			}
-
-			if reasonErr != nil {
-				br.Error = reasonErr.Error()
-			} else {
-				br.SearchTime = result.SearchTime
-				br.LLMTime = result.LLMTime
-				br.TokensIn = result.TokensIn
-				br.TokensOut = result.TokensOut
-				br.Content = result.Content
-				br.ContentLen = len(result.Content)
-				br.MemoryCount = result.MemoriesUsed
-				br.CostUSD = estimateCost(model.Model, result.TokensIn, result.TokensOut)
-			}
-
 			results = append(results, br)
 		}
 	}
 
-	// Build summary
 	summary := buildSummary(results, presets)
 
 	return &BenchReport{
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		Models:    len(models),
-		Presets:   len(presets),
-		Results:   results,
-		Summary:   summary,
+		Timestamp:      time.Now().UTC().Format(time.RFC3339),
+		Models:         len(models),
+		Presets:        len(presets),
+		Recursive:      opts.Recursive,
+		CompareMode:    opts.CompareMode,
+		ComparedModels: opts.ComparedModels,
+		Results:        results,
+		Summary:        summary,
 	}, nil
 }
 
-// estimateCost calculates the cost of a run based on token counts.
-func estimateCost(model string, tokensIn, tokensOut int) float64 {
-	pricing, ok := ModelPricing[model]
-	if !ok {
+func maxSubQueryDepth(r *RecursiveResult) int {
+	if r == nil {
 		return 0
 	}
-	return (float64(tokensIn) * pricing[0] / 1_000_000) + (float64(tokensOut) * pricing[1] / 1_000_000)
+	maxDepth := 0
+	for _, sq := range r.SubQueries {
+		if sq.Depth > maxDepth {
+			maxDepth = sq.Depth
+		}
+	}
+	if r.Depth > maxDepth {
+		maxDepth = r.Depth
+	}
+	return maxDepth
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// estimateCost calculates the cost of a run based on token counts.
+// Returns cost and whether cost is known.
+func estimateCost(model string, tokensIn, tokensOut int) (float64, bool) {
+	pricing, ok := ModelPricing[model]
+	if !ok {
+		return 0, false
+	}
+	if pricing[0] == 0 && pricing[1] == 0 {
+		// Free tier / preview / unknown pricing.
+		return 0, false
+	}
+	cost := (float64(tokensIn) * pricing[0] / 1_000_000) + (float64(tokensOut) * pricing[1] / 1_000_000)
+	return cost, true
+}
+
+func estimateCostPer1K(cost float64, tokensIn, tokensOut int, costKnown bool) float64 {
+	if !costKnown {
+		return 0
+	}
+	totalTokens := tokensIn + tokensOut
+	if totalTokens <= 0 {
+		return 0
+	}
+	return cost * 1000 / float64(totalTokens)
+}
+
+var (
+	headersRe        = regexp.MustCompile(`(?m)^\s{0,3}(#{1,6}\s+\S+|\d+\.\s+\*\*[^*]+\*\*)`)
+	checklistRe      = regexp.MustCompile(`(?m)^\s*[-*]\s+\[[ xX]\]`)
+	bulletRe         = regexp.MustCompile(`(?m)^\s*(?:[-*]|\d+\.)\s+`)
+	actionVerbRe     = regexp.MustCompile(`(?i)\b(should|must|recommend(?:ed|ation)?|next\s+step|action\s+item|implement|fix|update|review|investigate|monitor|run|create|prioritize|schedule)\b`)
+	wordRe           = regexp.MustCompile(`[A-Za-z0-9][A-Za-z0-9'/-]*`)
+	memoryRefRegexes = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\bmemory\s+#?(\d+)\b`),
+		regexp.MustCompile(`(?i)\bmem(?:ory)?[_ ]id\s*[:=# ]\s*(\d+)\b`),
+	}
+)
+
+func extractQualitySignals(content string) BenchQualitySignals {
+	signals := BenchQualitySignals{}
+	if strings.TrimSpace(content) == "" {
+		return signals
+	}
+
+	signals.HasHeaders = headersRe.MatchString(content)
+	hasBullets := bulletRe.MatchString(content)
+	hasActionVerbs := actionVerbRe.MatchString(content)
+	signals.HasActionableItems = checklistRe.MatchString(content) || (hasBullets && hasActionVerbs)
+	signals.WordCount = len(wordRe.FindAllString(content, -1))
+	signals.UniqueMemoryRefs = countUniqueMemoryRefs(content)
+
+	return signals
+}
+
+func countUniqueMemoryRefs(content string) int {
+	if content == "" {
+		return 0
+	}
+
+	seen := make(map[string]struct{})
+	for _, re := range memoryRefRegexes {
+		matches := re.FindAllStringSubmatch(content, -1)
+		for _, m := range matches {
+			if len(m) > 1 && m[1] != "" {
+				seen[m[1]] = struct{}{}
+			}
+		}
+	}
+	return len(seen)
 }
 
 // buildSummary aggregates results by model.
@@ -237,13 +411,24 @@ func buildSummary(results []BenchResult, presets []BenchPreset) []BenchSummary {
 			}
 			byModel[r.Label] = s
 		}
+
 		if r.Error != "" {
 			s.Errors++
 			continue
 		}
+
 		s.AvgTime += r.WallTime.Seconds()
 		s.AvgTokens += r.TokensOut
-		s.TotalCost += r.CostUSD
+		s.AvgIterations += float64(maxInt(1, r.Iterations))
+		s.AvgFactsUsed += float64(r.FactsUsed)
+
+		if r.CostKnown {
+			s.TotalCost += r.CostUSD
+			s.KnownCostRuns++
+			s.AvgCostPer1KTokens += r.CostPer1KTokens
+		} else {
+			s.CostUnknownRuns++
+		}
 	}
 
 	var summaries []BenchSummary
@@ -252,15 +437,24 @@ func buildSummary(results []BenchResult, presets []BenchPreset) []BenchSummary {
 		if runs > 0 {
 			s.AvgTime /= float64(runs)
 			s.AvgTokens /= runs
-			s.AvgCost = s.TotalCost / float64(runs)
+			s.AvgIterations /= float64(runs)
+			s.AvgFactsUsed /= float64(runs)
+		}
+		if s.KnownCostRuns > 0 {
+			s.AvgCost = s.TotalCost / float64(s.KnownCostRuns)
+			s.AvgCostPer1KTokens /= float64(s.KnownCostRuns)
 		}
 		s.Verdict = categorize(s)
 		summaries = append(summaries, *s)
 	}
 
-	// Sort by avg time
+	// Sort by avg time (errors last)
 	sort.Slice(summaries, func(i, j int) bool {
-		return summaries[i].AvgTime < summaries[j].AvgTime
+		a, b := summaries[i], summaries[j]
+		if a.Errors != b.Errors {
+			return a.Errors < b.Errors
+		}
+		return a.AvgTime < b.AvgTime
 	})
 
 	return summaries
@@ -270,6 +464,12 @@ func categorize(s *BenchSummary) string {
 	if s.Errors > 0 {
 		return "⚠️ errors"
 	}
+	if s.Provider == "ollama" {
+		return "🔒 private/local"
+	}
+	if s.KnownCostRuns == 0 {
+		return "🕵️ cost unknown"
+	}
 	switch {
 	case s.AvgTime < 2.0 && s.AvgCost < 0.002:
 		return "🏆 best overall"
@@ -277,49 +477,317 @@ func categorize(s *BenchSummary) string {
 		return "⚡ fast"
 	case s.AvgTime < 10.0:
 		return "✅ solid"
-	case s.AvgCost == 0:
-		return "🔒 private (local)"
 	default:
 		return "🐌 slow"
 	}
 }
 
-// FormatMarkdown renders the benchmark report as a markdown table.
+// FormatMarkdown renders the benchmark report as a publication-ready markdown report.
 func (r *BenchReport) FormatMarkdown() string {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("# Cortex Reason Benchmark\n"))
-	sb.WriteString(fmt.Sprintf("*%s — %d models × %d presets*\n\n", r.Timestamp[:10], r.Models, r.Presets))
-
-	// Summary table
-	sb.WriteString("## Summary\n\n")
-	sb.WriteString("| Model | Provider | Avg Time | Avg Tokens | Avg Cost | Verdict |\n")
-	sb.WriteString("|---|---|---|---|---|---|\n")
-	for _, s := range r.Summary {
-		sb.WriteString(fmt.Sprintf("| %s | %s | %.1fs | %d | $%.4f | %s |\n",
-			s.Label, s.Provider, s.AvgTime, s.AvgTokens, s.AvgCost, s.Verdict))
+	date := r.Timestamp
+	if len(date) >= 10 {
+		date = date[:10]
+	}
+	mode := "single-pass"
+	if r.Recursive {
+		mode = "recursive"
 	}
 
-	// Detailed results
-	sb.WriteString("\n## Detailed Results\n\n")
+	sb.WriteString("# Cortex Reason Benchmark Report\n")
+	sb.WriteString(fmt.Sprintf("*%s — %d models × %d presets · mode: %s*\n\n", date, r.Models, r.Presets, mode))
+	if r.CompareMode && len(r.ComparedModels) > 0 {
+		sb.WriteString(fmt.Sprintf("Compared models: `%s`\n\n", strings.Join(r.ComparedModels, "`, `")))
+	}
+
+	r.writeSummaryTable(&sb)
+	r.writeWinnerSection(&sb)
+	r.writePresetBreakdown(&sb)
+	r.writeCostAnalysis(&sb)
+
+	if r.CompareMode {
+		r.writeCompareSection(&sb)
+	}
+
+	r.writeDetailedResults(&sb)
+
+	return sb.String()
+}
+
+func (r *BenchReport) writeSummaryTable(sb *strings.Builder) {
+	sb.WriteString("## Summary\n\n")
+	sb.WriteString("| Model | Provider | Avg Time | Avg Iter | Avg Facts | Avg Tokens | Avg Cost | Cost / 1K tokens | Verdict |\n")
+	sb.WriteString("|---|---|---:|---:|---:|---:|---:|---:|---|\n")
+	for _, s := range r.Summary {
+		sb.WriteString(fmt.Sprintf(
+			"| %s | %s | %.2fs | %.1f | %.1f | %d | %s | %s | %s |\n",
+			s.Label,
+			s.Provider,
+			s.AvgTime,
+			s.AvgIterations,
+			s.AvgFactsUsed,
+			s.AvgTokens,
+			formatSummaryCost(s.AvgCost, s.KnownCostRuns, s.CostUnknownRuns),
+			formatSummaryCostPer1K(s.AvgCostPer1KTokens, s.KnownCostRuns),
+			s.Verdict,
+		))
+	}
+	sb.WriteString("\n")
+}
+
+func (r *BenchReport) writeWinnerSection(sb *strings.Builder) {
+	sb.WriteString("## Winners by Category\n\n")
+
+	valid := make([]BenchSummary, 0, len(r.Summary))
+	for _, s := range r.Summary {
+		if s.Errors == 0 {
+			valid = append(valid, s)
+		}
+	}
+	if len(valid) == 0 {
+		sb.WriteString("No successful runs to score.\n\n")
+		return
+	}
+
+	fastest := valid[0]
+	richest := valid[0]
+	for _, s := range valid[1:] {
+		if s.AvgTime < fastest.AvgTime {
+			fastest = s
+		}
+		if s.AvgTokens > richest.AvgTokens {
+			richest = s
+		}
+	}
+
+	sb.WriteString(fmt.Sprintf("- ⚡ **Fastest**: **%s** (%.2fs avg)\n", fastest.Label, fastest.AvgTime))
+	sb.WriteString(fmt.Sprintf("- 🧠 **Most verbose output**: **%s** (%d avg output tokens)\n", richest.Label, richest.AvgTokens))
+
+	cheapestFound := false
+	cheapest := BenchSummary{}
+	for _, s := range valid {
+		if s.KnownCostRuns == 0 {
+			continue
+		}
+		if !cheapestFound || s.AvgCostPer1KTokens < cheapest.AvgCostPer1KTokens {
+			cheapest = s
+			cheapestFound = true
+		}
+	}
+	if cheapestFound {
+		sb.WriteString(fmt.Sprintf("- 💸 **Cheapest (known pricing)**: **%s** ($%.4f / 1K tokens)\n", cheapest.Label, cheapest.AvgCostPer1KTokens))
+	} else {
+		sb.WriteString("- 💸 **Cheapest**: unavailable (all models have unknown pricing)\n")
+	}
+
+	sb.WriteString("\n")
+}
+
+func (r *BenchReport) writePresetBreakdown(sb *strings.Builder) {
+	sb.WriteString("## Per-Preset Breakdown\n\n")
+	byPreset := make(map[string][]BenchResult)
+	presetOrder := make([]string, 0)
+	seen := make(map[string]bool)
+	for _, res := range r.Results {
+		if !seen[res.Preset] {
+			seen[res.Preset] = true
+			presetOrder = append(presetOrder, res.Preset)
+		}
+		byPreset[res.Preset] = append(byPreset[res.Preset], res)
+	}
+
+	for _, preset := range presetOrder {
+		group := byPreset[preset]
+		sb.WriteString(fmt.Sprintf("### %s\n\n", preset))
+		sb.WriteString("| Model | Time | Iter | Memories | Facts | Tokens (in→out) | Cost | Quality Signals |\n")
+		sb.WriteString("|---|---:|---:|---:|---:|---|---:|---|\n")
+
+		for _, res := range group {
+			if res.Error != "" {
+				sb.WriteString(fmt.Sprintf("| %s | ❌ | - | - | - | - | - | %s |\n", res.Label, escapeTable(res.Error)))
+				continue
+			}
+			quality := fmt.Sprintf("hdr:%s act:%s words:%d refs:%d",
+				boolMark(res.QualitySignals.HasHeaders),
+				boolMark(res.QualitySignals.HasActionableItems),
+				res.QualitySignals.WordCount,
+				res.QualitySignals.UniqueMemoryRefs,
+			)
+			sb.WriteString(fmt.Sprintf("| %s | %.2fs | %d | %d | %d | %d→%d | %s | %s |\n",
+				res.Label,
+				res.WallTime.Seconds(),
+				maxInt(1, res.Iterations),
+				res.MemoryCount,
+				res.FactsUsed,
+				res.TokensIn,
+				res.TokensOut,
+				formatResultCost(res),
+				quality,
+			))
+		}
+		sb.WriteString("\n")
+	}
+}
+
+func (r *BenchReport) writeCostAnalysis(sb *strings.Builder) {
+	sb.WriteString("## Cost Analysis\n\n")
+	sb.WriteString("| Model | Known Cost Runs | Cost Unknown Runs | Total Cost (known) | Avg $ / 1K tokens |\n")
+	sb.WriteString("|---|---:|---:|---:|---:|\n")
+	for _, s := range r.Summary {
+		sb.WriteString(fmt.Sprintf("| %s | %d | %d | %s | %s |\n",
+			s.Label,
+			s.KnownCostRuns,
+			s.CostUnknownRuns,
+			formatSummaryCost(s.TotalCost, s.KnownCostRuns, s.CostUnknownRuns),
+			formatSummaryCostPer1K(s.AvgCostPer1KTokens, s.KnownCostRuns),
+		))
+	}
+	sb.WriteString("\n")
+	sb.WriteString("_Note: $0 models are treated as **cost unknown** for free/preview tiers unless pricing is explicitly known._\n\n")
+}
+
+func (r *BenchReport) writeCompareSection(sb *strings.Builder) {
+	if len(r.Summary) != 2 {
+		return
+	}
+
+	sb.WriteString("## A/B Comparison\n\n")
+
+	left := r.Summary[0].Label
+	right := r.Summary[1].Label
+	if len(r.ComparedModels) == 2 {
+		left = r.ComparedModels[0]
+		right = r.ComparedModels[1]
+	}
+	sb.WriteString(fmt.Sprintf("Comparing **%s** vs **%s**\n\n", left, right))
+
+	byPreset := make(map[string]map[string]BenchResult)
+	presetOrder := make([]string, 0)
+	seen := make(map[string]bool)
+	for _, res := range r.Results {
+		if !seen[res.Preset] {
+			seen[res.Preset] = true
+			presetOrder = append(presetOrder, res.Preset)
+		}
+		if byPreset[res.Preset] == nil {
+			byPreset[res.Preset] = make(map[string]BenchResult)
+		}
+		byPreset[res.Preset][res.Label] = res
+		byPreset[res.Preset][res.Model] = res
+	}
+
+	for _, preset := range presetOrder {
+		group := byPreset[preset]
+		a, okA := group[left]
+		b, okB := group[right]
+		if !okA || !okB {
+			continue
+		}
+
+		sb.WriteString(fmt.Sprintf("### %s\n", preset))
+		if a.Error != "" || b.Error != "" {
+			sb.WriteString(fmt.Sprintf("- ⚠️ Errors: `%s` vs `%s`\n\n", a.Error, b.Error))
+			continue
+		}
+
+		speedWinner := left
+		speedDelta := b.WallTime.Seconds() - a.WallTime.Seconds()
+		if b.WallTime < a.WallTime {
+			speedWinner = right
+			speedDelta = -speedDelta
+		}
+
+		wordsWinner := left
+		if b.QualitySignals.WordCount > a.QualitySignals.WordCount {
+			wordsWinner = right
+		}
+
+		sb.WriteString(fmt.Sprintf("- ⏱️ **Speed winner:** %s (Δ %.2fs)\n", speedWinner, speedDelta))
+		sb.WriteString(fmt.Sprintf("- 🧠 **Word count:** %s=%d vs %s=%d (winner: %s)\n",
+			left, a.QualitySignals.WordCount,
+			right, b.QualitySignals.WordCount,
+			wordsWinner,
+		))
+		sb.WriteString(fmt.Sprintf("- ✅ **Actionable items:** %s=%s, %s=%s\n",
+			left, boolMark(a.QualitySignals.HasActionableItems),
+			right, boolMark(b.QualitySignals.HasActionableItems),
+		))
+		sb.WriteString(fmt.Sprintf("- 🧾 **Memory refs:** %s=%d, %s=%d\n\n",
+			left, a.QualitySignals.UniqueMemoryRefs,
+			right, b.QualitySignals.UniqueMemoryRefs,
+		))
+	}
+}
+
+func (r *BenchReport) writeDetailedResults(sb *strings.Builder) {
+	sb.WriteString("## Detailed Results\n\n")
 	for _, res := range r.Results {
 		if res.Error != "" {
 			sb.WriteString(fmt.Sprintf("### %s × %s — ❌ %s\n\n", res.Label, res.Preset, res.Error))
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("### %s × %s — %.1fs, $%.4f\n", res.Label, res.Preset, res.WallTime.Seconds(), res.CostUSD))
-		sb.WriteString(fmt.Sprintf("*%d→%d tokens, search %dms, llm %dms, %d memories*\n\n",
+		sb.WriteString(fmt.Sprintf("### %s × %s — %.2fs, %s\n",
+			res.Label,
+			res.Preset,
+			res.WallTime.Seconds(),
+			formatResultCost(res),
+		))
+		sb.WriteString(fmt.Sprintf("*%d→%d tokens, search %dms, llm %dms, %d memories, %d facts, %d iteration(s), recursive=%t*\n\n",
 			res.TokensIn, res.TokensOut,
 			res.SearchTime.Milliseconds(), res.LLMTime.Milliseconds(),
-			res.MemoryCount))
+			res.MemoryCount, res.FactsUsed,
+			maxInt(1, res.Iterations),
+			res.Recursive,
+		))
+		sb.WriteString(fmt.Sprintf("Quality: headers=%s, actionable=%s, words=%d, unique_memory_refs=%d\n\n",
+			boolMark(res.QualitySignals.HasHeaders),
+			boolMark(res.QualitySignals.HasActionableItems),
+			res.QualitySignals.WordCount,
+			res.QualitySignals.UniqueMemoryRefs,
+		))
 
-		// Truncate content for report
 		content := res.Content
-		if len(content) > 500 {
-			content = content[:500] + "..."
+		if len(content) > 600 {
+			content = content[:600] + "..."
 		}
 		sb.WriteString("```\n" + content + "\n```\n\n")
 	}
+}
 
-	return sb.String()
+func boolMark(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func escapeTable(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return s
+}
+
+func formatResultCost(res BenchResult) string {
+	if !res.CostKnown {
+		return "cost unknown"
+	}
+	return fmt.Sprintf("$%.4f", res.CostUSD)
+}
+
+func formatSummaryCost(cost float64, knownRuns int, unknownRuns int) string {
+	if knownRuns == 0 {
+		if unknownRuns > 0 {
+			return "cost unknown"
+		}
+		return "-"
+	}
+	return fmt.Sprintf("$%.4f", cost)
+}
+
+func formatSummaryCostPer1K(costPer1K float64, knownRuns int) string {
+	if knownRuns == 0 {
+		return "cost unknown"
+	}
+	return fmt.Sprintf("$%.4f", costPer1K)
 }

--- a/internal/reason/bench_test.go
+++ b/internal/reason/bench_test.go
@@ -1,0 +1,152 @@
+package reason
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultBenchPresets_AllFive(t *testing.T) {
+	want := []string{"daily-digest", "fact-audit", "conflict-check", "weekly-dive", "agent-review"}
+	if len(DefaultBenchPresets) != len(want) {
+		t.Fatalf("expected %d presets, got %d", len(want), len(DefaultBenchPresets))
+	}
+	for i, name := range want {
+		if DefaultBenchPresets[i].Name != name {
+			t.Fatalf("preset[%d]=%q, want %q", i, DefaultBenchPresets[i].Name, name)
+		}
+		if strings.TrimSpace(DefaultBenchPresets[i].Query) == "" {
+			t.Fatalf("preset %q has empty default query", name)
+		}
+	}
+}
+
+func TestExtractQualitySignals(t *testing.T) {
+	content := `## Weekly Findings
+
+1. **Action Items**
+- Implement retry logic in importer
+- Review conflict queue
+- [ ] Schedule follow-up test run
+
+Referenced memory #42 and memory 105 for root cause.`
+
+	s := extractQualitySignals(content)
+	if !s.HasHeaders {
+		t.Fatal("expected headers=true")
+	}
+	if !s.HasActionableItems {
+		t.Fatal("expected actionable_items=true")
+	}
+	if s.WordCount < 15 {
+		t.Fatalf("expected word_count >= 15, got %d", s.WordCount)
+	}
+	if s.UniqueMemoryRefs != 2 {
+		t.Fatalf("expected 2 memory refs, got %d", s.UniqueMemoryRefs)
+	}
+}
+
+func TestEstimateCost_UnknownForPreviewAndUnknownModels(t *testing.T) {
+	cost, known := estimateCost("openai/gpt-oss-120b", 1000, 1000)
+	if known {
+		t.Fatal("expected preview model cost to be unknown")
+	}
+	if cost != 0 {
+		t.Fatalf("expected zero cost when unknown, got %f", cost)
+	}
+
+	cost, known = estimateCost("unknown/model", 1000, 1000)
+	if known {
+		t.Fatal("expected unknown model cost to be unknown")
+	}
+	if cost != 0 {
+		t.Fatalf("expected zero cost when unknown, got %f", cost)
+	}
+}
+
+func TestRunBenchmark_RecursiveMode(t *testing.T) {
+	engine := &Engine{}
+	opts := BenchOptions{
+		Models:        []BenchModel{{Label: "test-model", Provider: "openrouter", Model: "deepseek/deepseek-v3.2"}},
+		Presets:       []BenchPreset{{Name: "weekly-dive", Query: "weekly synthesis"}},
+		Recursive:     true,
+		MaxIterations: 6,
+		MaxDepth:      2,
+		llmFactory: func(model BenchModel) (*LLM, error) {
+			return &LLM{provider: model.Provider, model: model.Model}, nil
+		},
+		recursiveFn: func(_ context.Context, ropts RecursiveOptions) (*RecursiveResult, error) {
+			if ropts.MaxIterations != 6 {
+				t.Fatalf("expected max iterations 6, got %d", ropts.MaxIterations)
+			}
+			if ropts.MaxDepth != 2 {
+				t.Fatalf("expected max depth 2, got %d", ropts.MaxDepth)
+			}
+			return &RecursiveResult{
+				ReasonResult: ReasonResult{
+					Content:      "## Findings\n- Implement guardrails\n- Review Memory #42 and memory 77",
+					SearchTime:   25 * time.Millisecond,
+					LLMTime:      40 * time.Millisecond,
+					TokensIn:     120,
+					TokensOut:    240,
+					MemoriesUsed: 5,
+					FactsUsed:    3,
+				},
+				Iterations: 3,
+				SubQueries: []SubQueryResult{{Depth: 1}, {Depth: 2}},
+			}, nil
+		},
+	}
+
+	report, err := engine.RunBenchmark(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("RunBenchmark failed: %v", err)
+	}
+	if len(report.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(report.Results))
+	}
+
+	r := report.Results[0]
+	if !r.Recursive {
+		t.Fatal("expected recursive=true")
+	}
+	if r.Iterations != 3 {
+		t.Fatalf("expected 3 iterations, got %d", r.Iterations)
+	}
+	if r.FactsUsed != 3 {
+		t.Fatalf("expected facts_used=3, got %d", r.FactsUsed)
+	}
+	if r.RecursiveDepth != 2 {
+		t.Fatalf("expected recursive_depth=2, got %d", r.RecursiveDepth)
+	}
+	if !r.CostKnown {
+		t.Fatal("expected cost known for deepseek-v3.2")
+	}
+	if r.QualitySignals.UniqueMemoryRefs != 2 {
+		t.Fatalf("expected 2 unique memory refs, got %d", r.QualitySignals.UniqueMemoryRefs)
+	}
+}
+
+func TestBenchReport_CompareSection(t *testing.T) {
+	report := &BenchReport{
+		Timestamp:      time.Now().UTC().Format(time.RFC3339),
+		Models:         2,
+		Presets:        1,
+		CompareMode:    true,
+		ComparedModels: []string{"model-a", "model-b"},
+		Results: []BenchResult{
+			{Label: "model-a", Model: "model-a", Preset: "daily-digest", WallTime: 2 * time.Second, TokensOut: 100, QualitySignals: BenchQualitySignals{WordCount: 120, HasActionableItems: true}},
+			{Label: "model-b", Model: "model-b", Preset: "daily-digest", WallTime: 3 * time.Second, TokensOut: 80, QualitySignals: BenchQualitySignals{WordCount: 90, HasActionableItems: false}},
+		},
+		Summary: []BenchSummary{
+			{Label: "model-a", AvgTime: 2.0, Errors: 0},
+			{Label: "model-b", AvgTime: 3.0, Errors: 0},
+		},
+	}
+
+	md := report.FormatMarkdown()
+	if !strings.Contains(md, "## A/B Comparison") {
+		t.Fatalf("expected compare section in markdown, got:\n%s", md)
+	}
+}

--- a/internal/reason/reason_test.go
+++ b/internal/reason/reason_test.go
@@ -102,14 +102,20 @@ func TestGetPreset_Unknown(t *testing.T) {
 
 func TestEstimateCost(t *testing.T) {
 	// gemini-2.5-flash: $0.15/M in, $0.60/M out
-	cost := estimateCost("google/gemini-2.5-flash", 2000, 500)
+	cost, known := estimateCost("google/gemini-2.5-flash", 2000, 500)
 	// Expected: (2000 * 0.15 / 1M) + (500 * 0.60 / 1M) = 0.0003 + 0.0003 = 0.0006
+	if !known {
+		t.Fatal("expected known cost for gemini-2.5-flash")
+	}
 	if cost < 0.0005 || cost > 0.0007 {
 		t.Errorf("estimateCost = %f, want ~0.0006", cost)
 	}
 
-	// Unknown model returns 0
-	cost = estimateCost("unknown/model", 1000, 1000)
+	// Unknown model returns cost unknown
+	cost, known = estimateCost("unknown/model", 1000, 1000)
+	if known {
+		t.Fatal("expected unknown cost for unknown model")
+	}
 	if cost != 0 {
 		t.Errorf("unknown model cost = %f, want 0", cost)
 	}


### PR DESCRIPTION
## What this does
Implements a comprehensive overhaul of `cortex bench` for power-user model evaluation.

This PR upgrades benchmarking from a basic timing run into a trust-oriented evaluation suite with:
- all 5 default presets
- recursive benchmark mode (`--recursive`)
- quick A/B compare mode (`--compare model1,model2`)
- richer metrics (iterations, facts used, recursive metadata, quality signals)
- improved cost semantics (`$0` preview/free models are now surfaced as **cost unknown**)
- publication-ready markdown reporting (summary, winners, preset breakdown, cost analysis, compare diff)

## Problem / Context
Issue #47 identified that `cortex bench` only covered 3/5 presets and could not benchmark recursive reasoning. That made model shootouts incomplete and misleading, especially for deep-analysis workflows where `weekly-dive` and `agent-review` matter most.

Issue: https://github.com/hurttlocker/cortex/issues/47

## How it works
### 1) Default presets now include all 5
`DefaultBenchPresets` now ships with:
- `daily-digest`
- `fact-audit`
- `conflict-check`
- `weekly-dive`
- `agent-review`

Each has a meaningful default query.

### 2) Recursive benchmark mode
Added bench CLI support:
- `--recursive`
- `--max-iterations`
- `--max-depth`

When enabled, benchmark runs `ReasonRecursive` per model×preset and records recursive metrics.

### 3) Expanded BenchResult metrics
`BenchResult` now tracks:
- `iterations`
- `facts_used`
- `recursive`
- `recursive_depth`
- `quality_signals` (`has_headers`, `has_actionable_items`, `word_count`, `unique_memory_refs`)
- `cost_known`
- `cost_per_1k_tokens`

### 4) A/B compare mode
Added CLI parsing for:
- `--compare model1,model2`

Behavior:
- validates exactly 2 models
- disallows combining with `--models`
- runs only those two models
- report includes a dedicated **A/B Comparison** diff-style section

### 5) Markdown report overhaul
`FormatMarkdown()` now outputs publication-ready sections:
- summary table
- winners by category
- per-preset breakdown
- cost analysis
- A/B compare section (when `--compare` is used)
- detailed run blocks

### 6) Cost tracking improvements
Cost estimation now returns `(cost, known)`.

For unknown-priced or preview/free-tier models (`{0,0}` pricing), report marks cost as **cost unknown** instead of `$0.00`.
Also adds `$ / 1K tokens` normalization for meaningful cross-model comparison.

### 7) CLI refactor for bench parsing
Added `parseBenchArgs` + `splitCSVArgs` to centralize validation and make bench flags testable.

## Testing done
- `go test ./...` ✅

Added/updated tests:
- `TestDefaultBenchPresets_AllFive`
- `TestExtractQualitySignals`
- `TestEstimateCost_UnknownForPreviewAndUnknownModels`
- `TestRunBenchmark_RecursiveMode` (mocked recursive run)
- `TestBenchReport_CompareSection`
- `TestParseBenchArgs_Compare`
- `TestParseBenchArgs_CompareAndModelsConflict`
- `TestParseBenchArgs_InvalidCompareCount`
- updated `TestEstimateCost` for new `(cost, known)` contract

## Screenshots / before-after
Terminal validation:

```bash
go test ./...
ok   github.com/hurttlocker/cortex/cmd/cortex            8.850s
ok   github.com/hurttlocker/cortex/internal/ann          2.495s
ok   github.com/hurttlocker/cortex/internal/embed        6.892s
ok   github.com/hurttlocker/cortex/internal/extract      12.585s
ok   github.com/hurttlocker/cortex/internal/ingest       1.585s
ok   github.com/hurttlocker/cortex/internal/mcp          2.619s
ok   github.com/hurttlocker/cortex/internal/observe      1.334s
ok   github.com/hurttlocker/cortex/internal/reason       2.274s
ok   github.com/hurttlocker/cortex/internal/search       2.060s
ok   github.com/hurttlocker/cortex/internal/store        3.195s
```

## Breaking changes / risks
- Additive only; no schema or storage migrations.
- Bench JSON shape expanded (new fields added). Existing consumers reading old fields remain compatible.
- Cost display semantics changed intentionally: `$0` unknown-priced models now show `cost unknown`.

## Merge notes
- Merge normally to `main`.
- No migrations or environment changes required.
- Recommended post-merge spot-check:
  - `cortex bench --compare google/gemini-2.5-flash,deepseek/deepseek-v3.2 --output ab.md`
  - `cortex bench --recursive --max-iterations 8 --max-depth 1 --output recursive.md`
