### PR TITLE
fix: close #41 #42 #56 (fact typing, capture hygiene, update CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,16 @@ cortex import /tmp/auto-capture.md --capture-dedupe --similarity-threshold 0.95 
 The OpenClaw plugin also supports:
 - near-duplicate suppression (cosine threshold on recent captures)
 - burst coalescing windows for short rapid-fire turns
-- low-signal acknowledgement filters (`ok`, `got it`, etc.)
+- low-signal acknowledgement filters (`ok`, `got it`, `HEARTBEAT_OK`, `fire the test`)
+- recall-side dedupe before `<cortex-memories>` injection
+
+You can also update an existing memory in place:
+
+```bash
+cortex update 123 --content "Decision: use HNSW over FAISS" --extract
+# or
+cortex update 123 --file updated-note.md --extract
+```
 
 ### 🪦 Superseded/Tombstone Facts — Keep History, Hide Stale Truth
 
@@ -458,9 +467,10 @@ Generates a publication-ready markdown report with summary table, per-preset bre
 ### 👁️ Observability — Finally See What Your Agent Knows
 
 ```bash
-cortex stats        # Overview: counts, freshness, storage, top facts
+cortex stats        # Overview: counts, freshness, growth trends (24h/7d), storage, alerts
 cortex stale        # What's fading — reinforce, delete, or skip
-cortex conflicts    # Contradictions among active facts
+cortex conflicts    # Contradictions among active facts (compact grouped output)
+cortex conflicts --verbose  # Full per-conflict detail (no compacting)
 cortex conflicts --resolve highest-confidence  # Auto-resolve by confidence
 cortex conflicts --resolve newest --dry-run    # Preview before applying
 cortex conflicts --keep 12345 --drop 12346     # Surgical manual resolution

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hurttlocker/cortex/internal/observe"
+	"github.com/hurttlocker/cortex/internal/store"
 )
 
 // ==================== parseGlobalFlags ====================
@@ -286,6 +288,73 @@ func TestRunImport_InvalidDedupeWindow(t *testing.T) {
 	}
 }
 
+func TestRunImport_InvalidCaptureMinChars(t *testing.T) {
+	err := runImport([]string{"--capture-low-signal", "--capture-min-chars", "0", "/tmp/x.md"})
+	if err == nil {
+		t.Fatal("expected error for invalid capture min chars")
+	}
+	if !strings.Contains(err.Error(), "--capture-min-chars") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunUpdate_NoArgs(t *testing.T) {
+	err := runUpdate([]string{})
+	if err == nil {
+		t.Fatal("expected usage error")
+	}
+	if !strings.Contains(err.Error(), "usage: cortex update") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunUpdate_RequiresContentOrFile(t *testing.T) {
+	err := runUpdate([]string{"123"})
+	if err == nil {
+		t.Fatal("expected missing content/file error")
+	}
+	if !strings.Contains(err.Error(), "must provide either --content or --file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunUpdate_ContentPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "cortex.db")
+
+	oldDB := globalDBPath
+	globalDBPath = dbPath
+	t.Cleanup(func() { globalDBPath = oldDB })
+
+	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	ctx := context.Background()
+	memoryID, err := s.AddMemory(ctx, &store.Memory{Content: "old content", SourceFile: "note.md"})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	s.Close()
+
+	if err := runUpdate([]string{fmt.Sprintf("%d", memoryID), "--content", "new content"}); err != nil {
+		t.Fatalf("runUpdate: %v", err)
+	}
+
+	s2, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore reopen: %v", err)
+	}
+	defer s2.Close()
+	updated, err := s2.GetMemory(ctx, memoryID)
+	if err != nil {
+		t.Fatalf("GetMemory: %v", err)
+	}
+	if updated == nil || updated.Content != "new content" {
+		t.Fatalf("expected updated content, got %+v", updated)
+	}
+}
+
 // ==================== search arg parsing ====================
 
 func TestRunSearch_NoArgs(t *testing.T) {
@@ -380,6 +449,145 @@ func TestRunConflicts_UnexpectedArg(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unexpected argument") {
 		t.Errorf("expected 'unexpected argument' error, got: %v", err)
+	}
+}
+
+func TestOutputConflictsTTY_CompactsByDefault(t *testing.T) {
+	conflicts := make([]observe.Conflict, 0, 14)
+	for i := 0; i < 14; i++ {
+		c := observe.Conflict{ConflictType: "attribute", Similarity: 0.90}
+		c.Fact1.ID = int64(i + 1)
+		c.Fact1.Subject = "user"
+		c.Fact1.Predicate = "email"
+		c.Fact1.Object = fmt.Sprintf("old-%d@example.com", i)
+		c.Fact1.Confidence = 0.80
+		c.Fact2.ID = int64(100 + i)
+		c.Fact2.Subject = "user"
+		c.Fact2.Predicate = "email"
+		c.Fact2.Object = fmt.Sprintf("new-%d@example.com", i)
+		c.Fact2.Confidence = 0.92
+		conflicts = append(conflicts, c)
+	}
+
+	out := captureStdout(func() {
+		if err := outputConflictsTTY(conflicts, false); err != nil {
+			t.Fatalf("outputConflictsTTY: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Top conflict groups") {
+		t.Fatalf("expected grouped summary, got: %q", out)
+	}
+	if !strings.Contains(out, "Sample conflicts (showing 10 of 14)") {
+		t.Fatalf("expected sample header, got: %q", out)
+	}
+	if !strings.Contains(out, "additional conflicts hidden") {
+		t.Fatalf("expected hidden-details hint, got: %q", out)
+	}
+	if strings.Contains(out, "[11/14]") {
+		t.Fatalf("expected compact output to hide items after preview limit, got: %q", out)
+	}
+}
+
+func TestOutputConflictsTTY_VerboseShowsAll(t *testing.T) {
+	conflicts := make([]observe.Conflict, 0, 11)
+	for i := 0; i < 11; i++ {
+		c := observe.Conflict{ConflictType: "attribute", Similarity: 0.88}
+		c.Fact1.ID = int64(i + 1)
+		c.Fact1.Subject = "system"
+		c.Fact1.Predicate = "status"
+		c.Fact1.Object = fmt.Sprintf("old-%d", i)
+		c.Fact2.ID = int64(200 + i)
+		c.Fact2.Subject = "system"
+		c.Fact2.Predicate = "status"
+		c.Fact2.Object = fmt.Sprintf("new-%d", i)
+		conflicts = append(conflicts, c)
+	}
+
+	out := captureStdout(func() {
+		if err := outputConflictsTTY(conflicts, true); err != nil {
+			t.Fatalf("outputConflictsTTY: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Detailed conflicts") {
+		t.Fatalf("expected detailed header, got: %q", out)
+	}
+	if !strings.Contains(out, "[11/11]") {
+		t.Fatalf("expected full detail in verbose mode, got: %q", out)
+	}
+	if strings.Contains(out, "additional conflicts hidden") {
+		t.Fatalf("did not expect hidden-details hint in verbose mode, got: %q", out)
+	}
+}
+
+func TestOutputResolveBatchTTY_CompactsByDefault(t *testing.T) {
+	batch := &observe.ResolveBatch{Total: 15, Resolved: 15, Results: make([]observe.Resolution, 0, 15)}
+	for i := 0; i < 15; i++ {
+		c := observe.Conflict{ConflictType: "attribute", Similarity: 0.93}
+		c.Fact1.Subject = "user"
+		c.Fact1.Predicate = "timezone"
+		c.Fact2.Subject = "user"
+		c.Fact2.Predicate = "timezone"
+		batch.Results = append(batch.Results, observe.Resolution{
+			Conflict: c,
+			Winner:   "fact1",
+			WinnerID: int64(10 + i),
+			LoserID:  int64(100 + i),
+			Reason:   "higher confidence",
+			Applied:  true,
+		})
+	}
+
+	out := captureStdout(func() {
+		if err := outputResolveBatchTTY(batch, observe.StrategyHighestConfidence, false, false); err != nil {
+			t.Fatalf("outputResolveBatchTTY: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Resolution sample (showing 12 of 15)") {
+		t.Fatalf("expected sampled resolution header, got: %q", out)
+	}
+	if !strings.Contains(out, "additional resolution entries hidden") {
+		t.Fatalf("expected hidden-details hint, got: %q", out)
+	}
+	if strings.Contains(out, "[13/15]") {
+		t.Fatalf("expected compact output to hide items after preview limit, got: %q", out)
+	}
+}
+
+func TestOutputResolveBatchTTY_VerboseShowsAll(t *testing.T) {
+	batch := &observe.ResolveBatch{Total: 13, Resolved: 13, Results: make([]observe.Resolution, 0, 13)}
+	for i := 0; i < 13; i++ {
+		c := observe.Conflict{ConflictType: "attribute", Similarity: 0.91}
+		c.Fact1.Subject = "company"
+		c.Fact1.Predicate = "stage"
+		c.Fact2.Subject = "company"
+		c.Fact2.Predicate = "stage"
+		batch.Results = append(batch.Results, observe.Resolution{
+			Conflict: c,
+			Winner:   "fact2",
+			WinnerID: int64(200 + i),
+			LoserID:  int64(20 + i),
+			Reason:   "newest memory",
+			Applied:  true,
+		})
+	}
+
+	out := captureStdout(func() {
+		if err := outputResolveBatchTTY(batch, observe.StrategyNewest, false, true); err != nil {
+			t.Fatalf("outputResolveBatchTTY: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Resolution details") {
+		t.Fatalf("expected detailed header, got: %q", out)
+	}
+	if !strings.Contains(out, "[13/13]") {
+		t.Fatalf("expected full details in verbose mode, got: %q", out)
+	}
+	if strings.Contains(out, "additional resolution entries hidden") {
+		t.Fatalf("did not expect hidden-details hint in verbose mode, got: %q", out)
 	}
 }
 

--- a/internal/ingest/common.go
+++ b/internal/ingest/common.go
@@ -71,6 +71,9 @@ type ImportOptions struct {
 	CaptureDedupeEnabled       bool
 	CaptureSimilarityThreshold float64
 	CaptureDedupeWindowSec     int
+	CaptureLowSignalEnabled    bool
+	CaptureMinChars            int
+	CaptureLowSignalPatterns   []string
 }
 
 // Normalize applies sensible defaults for capture hygiene settings.
@@ -80,6 +83,15 @@ func (o *ImportOptions) Normalize() {
 	}
 	if o.CaptureDedupeWindowSec <= 0 {
 		o.CaptureDedupeWindowSec = 300 // 5 minutes
+	}
+	if o.CaptureMinChars <= 0 {
+		o.CaptureMinChars = 20
+	}
+	if len(o.CaptureLowSignalPatterns) == 0 {
+		o.CaptureLowSignalPatterns = []string{
+			"ok", "okay", "yes", "yep", "got it", "sounds good",
+			"thanks", "thank you", "heartbeat_ok", "fire the test",
+		}
 	}
 }
 

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -211,6 +211,7 @@ func (e *Engine) ImportDir(ctx context.Context, dir string, opts ImportOptions) 
 
 // processMemory handles dedup and storage for a single memory chunk.
 func (e *Engine) processMemory(ctx context.Context, raw RawMemory, opts ImportOptions, result *ImportResult) error {
+	opts.Normalize()
 	hash := store.HashMemoryContent(raw.Content, raw.SourceFile)
 
 	// Check for existing memory with same hash (dedup)
@@ -230,6 +231,11 @@ func (e *Engine) processMemory(ctx context.Context, raw RawMemory, opts ImportOp
 				return nil
 			}
 		}
+		result.MemoriesUnchanged++
+		return nil
+	}
+
+	if shouldSkipLowSignalCapture(raw.Content, opts) {
 		result.MemoriesUnchanged++
 		return nil
 	}

--- a/internal/store/facts.go
+++ b/internal/store/facts.go
@@ -270,6 +270,20 @@ func (s *SQLiteStore) getFactsByMemoryIDs(ctx context.Context, memoryIDs []int64
 	return facts, rows.Err()
 }
 
+// DeleteFactsByMemoryID removes all facts linked to a memory.
+// Returns number of rows deleted.
+func (s *SQLiteStore) DeleteFactsByMemoryID(ctx context.Context, memoryID int64) (int64, error) {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM facts WHERE memory_id = ?`, memoryID)
+	if err != nil {
+		return 0, fmt.Errorf("deleting facts for memory %d: %w", memoryID, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("checking deleted rows for memory %d: %w", memoryID, err)
+	}
+	return rows, nil
+}
+
 // ReinforceFactsByMemoryIDs updates last_reinforced for all facts linked to the given memory IDs.
 // Returns the number of facts reinforced.
 func (s *SQLiteStore) ReinforceFactsByMemoryIDs(ctx context.Context, memoryIDs []int64) (int, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -184,6 +184,7 @@ type Store interface {
 	ReinforceFactsByMemoryIDs(ctx context.Context, memoryIDs []int64) (int, error)
 	GetFactsByMemoryIDs(ctx context.Context, memoryIDs []int64) ([]*Fact, error)
 	GetFactsByMemoryIDsIncludingSuperseded(ctx context.Context, memoryIDs []int64) ([]*Fact, error)
+	DeleteFactsByMemoryID(ctx context.Context, memoryID int64) (int64, error)
 	GetConfidenceDistribution(ctx context.Context) (*ConfidenceDistribution, error)
 
 	// Search

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -83,6 +83,10 @@ Add to your OpenClaw config (`~/.openclaw/openclaw.json`):
 | `capture.similarityThreshold` | `0.95` | Cosine similarity cutoff for duplicate suppression |
 | `capture.dedupeWindowSec` | `300` | Recent lookback window for dedupe checks |
 | `capture.coalesceWindowSec` | `20` | Coalesce short rapid-fire captures into one memory |
+| `capture.minCaptureChars` | `20` | Suppress short low-signal captures below this length |
+| `capture.lowSignalPatterns` | built-in list | Additional low-signal phrases to suppress |
+| `recallDedupe.enabled` | `true` | Deduplicate exact/near-duplicate recall memories |
+| `recallDedupe.similarityThreshold` | `0.98` | Similarity cutoff used for recall dedupe |
 
 ## Features
 
@@ -97,10 +101,12 @@ Capture hygiene reduces memory bloat and retrieval noise:
 
 - **Near-duplicate suppression** with cosine similarity against recent captures
 - **Burst coalescing** for rapid-fire short exchanges
-- **Low-signal filter** for trivial acknowledgements (`ok`, `yes`, `got it`, etc.)
+- **Low-signal filter** for trivial acknowledgements/commands (`ok`, `yes`, `got it`, `HEARTBEAT_OK`, `fire the test`)
+- **Minimum capture length guard** (`capture.minCaptureChars`, default `20`)
+- **Recall-side dedupe** before `<cortex-memories>` injection
 - **Server-side dedupe** flags passed into `cortex import` for defense-in-depth
 
-These controls are configurable under `capture.*`.
+These controls are configurable under `capture.*` and `recallDedupe.*`.
 
 ### AI Tools
 The plugin registers 4 tools the AI can use:

--- a/plugin/hygiene.test.ts
+++ b/plugin/hygiene.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { dedupeRecallResults, isLowSignalMessage } from "./hygiene.ts";
+
+test("isLowSignalMessage filters trivial acknowledgements and HEARTBEAT_OK", () => {
+  assert.equal(isLowSignalMessage("HEARTBEAT_OK", [], 20), true);
+  assert.equal(isLowSignalMessage("Fire the test", [], 20), true);
+  assert.equal(isLowSignalMessage("ok", [], 20), true);
+  assert.equal(isLowSignalMessage("Q prefers Sonnet for coding tasks", [], 20), false);
+});
+
+test("isLowSignalMessage respects important tags", () => {
+  assert.equal(isLowSignalMessage("#important ok", [], 20), false);
+});
+
+test("dedupeRecallResults removes exact and near duplicates", () => {
+  const deduped = dedupeRecallResults(
+    [
+      {
+        content: "Fire the test",
+        source_file: "a.md",
+        source_line: 1,
+        source_section: "s",
+        score: 0.9,
+        match_type: "hybrid",
+        memory_id: 1,
+      },
+      {
+        content: "fire   the test",
+        source_file: "b.md",
+        source_line: 1,
+        source_section: "s",
+        score: 0.88,
+        match_type: "hybrid",
+        memory_id: 2,
+      },
+      {
+        content: "Q prefers Sonnet for coding tasks",
+        source_file: "c.md",
+        source_line: 1,
+        source_section: "s",
+        score: 0.8,
+        match_type: "hybrid",
+        memory_id: 3,
+      },
+    ],
+    0.95,
+  );
+
+  assert.equal(deduped.length, 2);
+  assert.equal(deduped[0].memory_id, 1);
+  assert.equal(deduped[1].memory_id, 3);
+});

--- a/plugin/hygiene.ts
+++ b/plugin/hygiene.ts
@@ -1,0 +1,95 @@
+export interface RecallResultLike {
+  content: string;
+}
+
+export function normalizeCaptureText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function wordFreq(text: string): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const token of normalizeCaptureText(text).split(" ")) {
+    if (!token || token.length < 2) continue;
+    out.set(token, (out.get(token) ?? 0) + 1);
+  }
+  return out;
+}
+
+export function cosineSimilarity(a: string, b: string): number {
+  const av = wordFreq(a);
+  const bv = wordFreq(b);
+  if (av.size === 0 || bv.size === 0) return 0;
+
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (const [token, v] of av.entries()) {
+    dot += v * (bv.get(token) ?? 0);
+    normA += v * v;
+  }
+  for (const v of bv.values()) {
+    normB += v * v;
+  }
+
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function hasImportantTag(text: string): boolean {
+  return /(#[ ]?important|\[important\]|important:|!important)/i.test(text);
+}
+
+export function isLowSignalMessage(text: string, patterns: string[], minCaptureChars: number): boolean {
+  if (!text || hasImportantTag(text)) return false;
+  const normalized = normalizeCaptureText(text);
+  if (!normalized) return true;
+
+  if (normalized.length < Math.max(1, minCaptureChars)) {
+    return true;
+  }
+
+  if (normalized.split(" ").length > 8) return false;
+
+  const normalizedPatterns = patterns.map((p) => normalizeCaptureText(p)).filter(Boolean);
+  if (normalizedPatterns.includes(normalized)) return true;
+
+  // Common one-liners, acknowledgements, and trivial command-like utterances.
+  return /^(ok|okay|yes|yep|got it|sounds good|sure|thanks|thank you|cool|heartbeat ok|fire the test|run test|do it)$/i.test(normalized);
+}
+
+export function dedupeRecallResults<T extends RecallResultLike>(results: T[], similarityThreshold: number): T[] {
+  const kept: T[] = [];
+
+  for (const candidate of results) {
+    const candidateNorm = normalizeCaptureText(candidate.content);
+    if (!candidateNorm) continue;
+
+    let duplicate = false;
+    for (const existing of kept) {
+      const existingNorm = normalizeCaptureText(existing.content);
+      if (!existingNorm) continue;
+
+      if (existingNorm === candidateNorm) {
+        duplicate = true;
+        break;
+      }
+
+      const sim = cosineSimilarity(candidateNorm, existingNorm);
+      if (sim >= similarityThreshold) {
+        duplicate = true;
+        break;
+      }
+    }
+
+    if (!duplicate) {
+      kept.push(candidate);
+    }
+  }
+
+  return kept;
+}

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -75,6 +75,23 @@
       "placeholder": "20",
       "help": "Merge rapid-fire short captures inside this time window.",
       "advanced": true
+    },
+    "capture.minCaptureChars": {
+      "label": "Capture Min Chars",
+      "placeholder": "20",
+      "help": "Skip very short captures below this length unless marked important.",
+      "advanced": true
+    },
+    "recallDedupe.enabled": {
+      "label": "Recall Dedupe Enabled",
+      "help": "Deduplicate exact/near-duplicate memories before injecting recall context.",
+      "advanced": true
+    },
+    "recallDedupe.similarityThreshold": {
+      "label": "Recall Dedupe Similarity Threshold",
+      "placeholder": "0.98",
+      "help": "Cosine similarity cutoff for near-duplicate recall suppression.",
+      "advanced": true
     }
   },
   "configSchema": {
@@ -109,10 +126,19 @@
           "dedupeWindowSec": { "type": "number", "minimum": 1, "maximum": 86400 },
           "coalesceWindowSec": { "type": "number", "minimum": 0, "maximum": 3600 },
           "shortCaptureMaxChars": { "type": "number", "minimum": 50, "maximum": 5000 },
+          "minCaptureChars": { "type": "number", "minimum": 1, "maximum": 5000 },
           "lowSignalPatterns": {
             "type": "array",
             "items": { "type": "string" }
           }
+        }
+      },
+      "recallDedupe": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "similarityThreshold": { "type": "number", "minimum": 0, "maximum": 1 }
         }
       }
     }


### PR DESCRIPTION
## Summary
This PR delivers the requested Cortex parallel sprint in one pass (no merge):

- **#41** fact extractor misclassification hardening
- **#42** auto-capture noise suppression + recall dedupe
- **#56** `cortex update` CLI wiring

## 1) Issue #41 — fact extractor misclassification
### Repro
Mixed corpora were over-classified as `kv` with no relationship/preference/decision/state/location coverage.

### Fix
- Added **KV semantic type inference** (`inferFactTypeFromKV`) for:
  - `relationship`, `preference`, `decision`, `state`, `location`
- Added **natural-language sentence extraction** for real phrases:
  - `prefers/likes/dislikes/wants`
  - `decided/chose/selected/approved`
  - `is engaged to` / possessive relationship forms
  - state/status lines (`is running`, `active`, etc., incl `on port <n>`)
  - location lines (`is in`, `located in`, `based in`, `is at`)
- Kept backwards compatibility with existing extraction pipeline (KV + regex still present).

### Tests
- Added tests for required real phrases:
  - "prefers"
  - "decided"
  - "is engaged to"
  - state/status text
- Added **distribution sanity guard** for mixed fixture corpus (assert not dominated by 94% KV-like behavior).

## 2) Issue #42 — auto-capture noise suppression
### Repro
Low-signal captures (e.g. `HEARTBEAT_OK`, trivial command/ack chatter) and duplicate recalls polluted `<cortex-memories>`.

### Fix
#### Plugin-side capture/recall
- Added reusable hygiene module: `plugin/hygiene.ts`
- Expanded low-signal defaults (`HEARTBEAT_OK`, `fire the test`, etc.)
- Added **minimum capture length guard** (`capture.minCaptureChars`, default 20)
- Added **recall dedupe** before injection (`recallDedupe.enabled`, `recallDedupe.similarityThreshold`)
- Over-fetch + dedupe + slice strategy for better recall quality under duplicates
- Improved auto-capture canonicalization by preserving raw short user text for filtering

#### Import pipeline defense-in-depth
- Added import options for low-signal filtering:
  - `CaptureLowSignalEnabled`
  - `CaptureMinChars`
  - `CaptureLowSignalPatterns`
- Added CLI import flags:
  - `--capture-low-signal`
  - `--capture-min-chars <N>`
  - `--capture-low-signal-pattern <phrase>` (repeatable)
- Added server-side low-signal suppression in ingest path (`processMemory`)

### Tests
- Go tests for low-signal suppression and duplicate behavior in ingest.
- Plugin unit tests (`node --test --experimental-strip-types plugin/hygiene.test.ts`) for:
  - low-signal ack filtering
  - important-tag bypass
  - recall dedupe behavior

## 3) Issue #56 — wire `cortex update` CLI command
### Fix
- Added new command dispatch + implementation:
  - `cortex update <id> --content "..." [--extract]`
  - `cortex update <id> --file <path> [--extract]`
- Validates argument shape and mutually-exclusive `--content` vs `--file`
- Reuses existing `UpdateMemory`
- For `--extract`:
  - clears prior facts for memory
  - re-extracts facts from updated content
  - stores refreshed facts
- Added `DeleteFactsByMemoryID` to store interface/SQLite implementation for clean re-extraction.
- Updated CLI usage/docs/help text + README examples.

### Tests
- Added CLI tests for:
  - usage / missing flags
  - import flag validation (`--capture-min-chars`)
  - end-to-end update path (`runUpdate` updates memory content)

## Validation
- `gofmt -w` on all touched Go files
- `go test ./...` ✅
- `node --test --experimental-strip-types plugin/hygiene.test.ts` ✅

## Risk / Compatibility
- Backwards compatible by default:
  - Existing import/search/update behavior preserved unless new hygiene flags/config are enabled.
  - `recallDedupe` defaults to enabled with conservative threshold.
- Main behavior change: better suppression of trivial capture noise + richer non-KV fact typing.

Closes #41
Closes #42
Closes #56
