### PR TITLE
ci: run PR workflows for stacked branches too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -2,7 +2,6 @@ name: PR Auto-Fix
 
 on:
   pull_request:
-    branches: [main]
 
 jobs:
   autofix:


### PR DESCRIPTION
## Why
Stacked PRs (base branch != main) currently show no check rollup because workflows were filtered to `pull_request.branches: [main]`.

## What
- Remove branch filter from CI workflow pull_request trigger
- Remove branch filter from PR Auto-Fix pull_request trigger

Push remains main-only for CI; only PR triggering is broadened.

## Result
Any PR (including stacked PRs) gets CI/autofix checks and status rollup visibility.
