### PR TITLE
feat: add codex rollout telemetry report + operating-mode docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,25 @@ cortex reason "query" --recursive --preset weekly-dive  # → auto-selects deeps
 export CORTEX_REASON_TELEMETRY=off
 ```
 
+### ⚙️ Codex rollout operating mode
+
+Use this as the default decision rule while Codex rollout is active:
+
+- **Codex one-shot (interactive default):** fastest turnaround for normal dev Q&A, quick audits, and lightweight synthesis.
+- **Cloud recursive (reliability default):** use `--recursive` for deep or high-stakes prompts (multi-step analysis, conflict-heavy memory, weekly/fact audits).
+- **When to switch from one-shot → recursive:**
+  - answer quality is shallow or misses context,
+  - query needs decomposition/sub-questions,
+  - you need stronger consistency over speed.
+
+Rollout report command (telemetry summary by mode, p50/p95 latency, cost, provider/model mix):
+
+```bash
+scripts/codex_rollout_report.sh
+# or
+go run ./cmd/codex-rollout-report --file ~/.cortex/reason-telemetry.jsonl
+```
+
 ### 📊 Benchmark Command — Test Any Model
 
 ```bash

--- a/cmd/codex-rollout-report/main.go
+++ b/cmd/codex-rollout-report/main.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type telemetryEvent struct {
+	Mode      string  `json:"mode"`
+	Provider  string  `json:"provider"`
+	Model     string  `json:"model"`
+	WallMS    int64   `json:"wall_ms"`
+	CostUSD   float64 `json:"cost_usd,omitempty"`
+	CostKnown bool    `json:"cost_known"`
+}
+
+type modeReport struct {
+	Mode          string
+	Runs          int
+	P50MS         int64
+	P95MS         int64
+	EstimatedCost float64
+	CostKnownRuns int
+	ModelMix      map[string]int
+}
+
+type report struct {
+	TotalRuns      int
+	SkippedLines   int
+	ModeReports    []modeReport
+	OverallModelMx map[string]int
+}
+
+func main() {
+	home, _ := os.UserHomeDir()
+	defaultPath := filepath.Join(home, ".cortex", "reason-telemetry.jsonl")
+
+	filePath := flag.String("file", defaultPath, "path to reason telemetry jsonl")
+	flag.Parse()
+
+	events, skipped, err := loadTelemetry(*filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	r := buildReport(events, skipped)
+	fmt.Println(renderReport(*filePath, r))
+}
+
+func loadTelemetry(path string) ([]telemetryEvent, int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []telemetryEvent{}, 0, nil
+		}
+		return nil, 0, fmt.Errorf("open telemetry file: %w", err)
+	}
+	defer f.Close()
+
+	var events []telemetryEvent
+	skipped := 0
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			continue
+		}
+
+		var ev telemetryEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			skipped++
+			continue
+		}
+		ev.Mode = normalizeMode(ev.Mode)
+		if ev.Provider == "" {
+			ev.Provider = "unknown"
+		}
+		if ev.Model == "" {
+			ev.Model = "unknown"
+		}
+		if ev.WallMS < 0 {
+			ev.WallMS = 0
+		}
+		events = append(events, ev)
+	}
+
+	if err := s.Err(); err != nil {
+		return nil, skipped, fmt.Errorf("scan telemetry file: %w", err)
+	}
+
+	return events, skipped, nil
+}
+
+func normalizeMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "recursive":
+		return "recursive"
+	default:
+		return "one-shot"
+	}
+}
+
+func buildReport(events []telemetryEvent, skipped int) report {
+	byMode := map[string][]telemetryEvent{
+		"one-shot":  {},
+		"recursive": {},
+	}
+	overallMix := map[string]int{}
+
+	for _, ev := range events {
+		byMode[ev.Mode] = append(byMode[ev.Mode], ev)
+		overallMix[fmt.Sprintf("%s/%s", ev.Provider, ev.Model)]++
+	}
+
+	modes := []string{"one-shot", "recursive"}
+	modeReports := make([]modeReport, 0, len(modes))
+	for _, mode := range modes {
+		runs := byMode[mode]
+		if len(runs) == 0 {
+			modeReports = append(modeReports, modeReport{Mode: mode, ModelMix: map[string]int{}})
+			continue
+		}
+
+		latencies := make([]int64, 0, len(runs))
+		cost := 0.0
+		costKnownRuns := 0
+		mix := map[string]int{}
+		for _, ev := range runs {
+			latencies = append(latencies, ev.WallMS)
+			if ev.CostKnown {
+				cost += ev.CostUSD
+				costKnownRuns++
+			}
+			mix[fmt.Sprintf("%s/%s", ev.Provider, ev.Model)]++
+		}
+
+		sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+
+		modeReports = append(modeReports, modeReport{
+			Mode:          mode,
+			Runs:          len(runs),
+			P50MS:         percentileInt64(latencies, 0.50),
+			P95MS:         percentileInt64(latencies, 0.95),
+			EstimatedCost: cost,
+			CostKnownRuns: costKnownRuns,
+			ModelMix:      mix,
+		})
+	}
+
+	return report{
+		TotalRuns:      len(events),
+		SkippedLines:   skipped,
+		ModeReports:    modeReports,
+		OverallModelMx: overallMix,
+	}
+}
+
+func percentileInt64(sorted []int64, p float64) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[len(sorted)-1]
+	}
+	idx := int(math.Ceil(float64(len(sorted))*p)) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func renderReport(path string, r report) string {
+	var b strings.Builder
+	b.WriteString("Cortex Codex rollout report\n")
+	b.WriteString(fmt.Sprintf("Telemetry file: %s\n", path))
+	b.WriteString(fmt.Sprintf("Runs parsed: %d", r.TotalRuns))
+	if r.SkippedLines > 0 {
+		b.WriteString(fmt.Sprintf(" (skipped malformed lines: %d)", r.SkippedLines))
+	}
+	b.WriteString("\n\n")
+
+	b.WriteString("By mode (one-shot vs recursive)\n")
+	b.WriteString("mode       runs  p50(ms)  p95(ms)  est_cost_usd  cost_runs\n")
+	for _, mr := range r.ModeReports {
+		b.WriteString(fmt.Sprintf("%-10s %-5d %-8d %-8d $%-12.6f %-9d\n",
+			mr.Mode,
+			mr.Runs,
+			mr.P50MS,
+			mr.P95MS,
+			mr.EstimatedCost,
+			mr.CostKnownRuns,
+		))
+	}
+
+	b.WriteString("\nProvider/model mix (overall)\n")
+	for _, line := range formatSortedMix(r.OverallModelMx) {
+		b.WriteString(line + "\n")
+	}
+
+	for _, mr := range r.ModeReports {
+		b.WriteString(fmt.Sprintf("\nProvider/model mix (%s)\n", mr.Mode))
+		for _, line := range formatSortedMix(mr.ModelMix) {
+			b.WriteString(line + "\n")
+		}
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func formatSortedMix(m map[string]int) []string {
+	if len(m) == 0 {
+		return []string{"(none)"}
+	}
+	type kv struct {
+		k string
+		v int
+	}
+	items := make([]kv, 0, len(m))
+	total := 0
+	for k, v := range m {
+		items = append(items, kv{k: k, v: v})
+		total += v
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].v == items[j].v {
+			return items[i].k < items[j].k
+		}
+		return items[i].v > items[j].v
+	})
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		pct := 0.0
+		if total > 0 {
+			pct = (float64(it.v) / float64(total)) * 100
+		}
+		out = append(out, fmt.Sprintf("- %s: %d (%.1f%%)", it.k, it.v, pct))
+	}
+	return out
+}

--- a/cmd/codex-rollout-report/main_test.go
+++ b/cmd/codex-rollout-report/main_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildReport_ModeStatsAndPercentiles(t *testing.T) {
+	events := []telemetryEvent{
+		{Mode: "one-shot", Provider: "openrouter", Model: "openai-codex/gpt-5.2", WallMS: 1000, CostKnown: true, CostUSD: 0.001},
+		{Mode: "one-shot", Provider: "openrouter", Model: "openai-codex/gpt-5.2", WallMS: 2000, CostKnown: true, CostUSD: 0.002},
+		{Mode: "one-shot", Provider: "openrouter", Model: "openai-codex/gpt-5.2", WallMS: 3000, CostKnown: false},
+		{Mode: "recursive", Provider: "openrouter", Model: "google/gemini-2.5-flash", WallMS: 10000, CostKnown: true, CostUSD: 0.010},
+		{Mode: "recursive", Provider: "openrouter", Model: "google/gemini-2.5-flash", WallMS: 20000, CostKnown: true, CostUSD: 0.020},
+	}
+
+	r := buildReport(events, 1)
+	if r.TotalRuns != 5 {
+		t.Fatalf("expected 5 runs, got %d", r.TotalRuns)
+	}
+	if r.SkippedLines != 1 {
+		t.Fatalf("expected skipped=1, got %d", r.SkippedLines)
+	}
+
+	oneShot := r.ModeReports[0]
+	if oneShot.Mode != "one-shot" || oneShot.Runs != 3 {
+		t.Fatalf("unexpected one-shot report: %+v", oneShot)
+	}
+	if oneShot.P50MS != 2000 {
+		t.Fatalf("expected one-shot p50=2000, got %d", oneShot.P50MS)
+	}
+	if oneShot.P95MS != 3000 {
+		t.Fatalf("expected one-shot p95=3000, got %d", oneShot.P95MS)
+	}
+	if oneShot.CostKnownRuns != 2 {
+		t.Fatalf("expected one-shot known cost runs=2, got %d", oneShot.CostKnownRuns)
+	}
+
+	recursive := r.ModeReports[1]
+	if recursive.Mode != "recursive" || recursive.Runs != 2 {
+		t.Fatalf("unexpected recursive report: %+v", recursive)
+	}
+	if recursive.P50MS != 10000 {
+		t.Fatalf("expected recursive p50=10000, got %d", recursive.P50MS)
+	}
+	if recursive.P95MS != 20000 {
+		t.Fatalf("expected recursive p95=20000, got %d", recursive.P95MS)
+	}
+}
+
+func TestLoadTelemetry_ParsesJSONLAndSkipsMalformed(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "reason-telemetry.jsonl")
+	content := strings.Join([]string{
+		`{"mode":"one-shot","provider":"openrouter","model":"openai-codex/gpt-5.2","wall_ms":1200,"cost_known":true,"cost_usd":0.0012}`,
+		`{"mode":"recursive","provider":"openrouter","model":"google/gemini-2.5-flash","wall_ms":8800,"cost_known":false}`,
+		`not-json`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	events, skipped, err := loadTelemetry(path)
+	if err != nil {
+		t.Fatalf("loadTelemetry: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if skipped != 1 {
+		t.Fatalf("expected skipped=1, got %d", skipped)
+	}
+	if events[0].Mode != "one-shot" || events[1].Mode != "recursive" {
+		t.Fatalf("unexpected mode normalization: %+v", events)
+	}
+
+	out := renderReport(path, buildReport(events, skipped))
+	if !strings.Contains(out, "By mode (one-shot vs recursive)") {
+		t.Fatalf("missing mode section: %s", out)
+	}
+	if !strings.Contains(out, "openrouter/openai-codex/gpt-5.2") {
+		t.Fatalf("missing provider/model mix: %s", out)
+	}
+}

--- a/scripts/codex_rollout_report.sh
+++ b/scripts/codex_rollout_report.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TELEMETRY_FILE="${1:-$HOME/.cortex/reason-telemetry.jsonl}"
+
+cd "$ROOT_DIR"
+go run ./cmd/codex-rollout-report --file "$TELEMETRY_FILE"


### PR DESCRIPTION
## Summary
Phase 2 follow-up to keep Codex rollout momentum with minimal, focused changes.

### Deliverables shipped
1. **Rollout report command + script**
   - Added Go cmd: `cmd/codex-rollout-report`
   - Added wrapper script: `scripts/codex_rollout_report.sh`
   - Reads `~/.cortex/reason-telemetry.jsonl` (or `--file`) and summarizes:
     - one-shot vs recursive run counts
     - p50/p95 wall latency per mode
     - estimated cost per mode (known-cost runs)
     - provider/model mix (overall + per mode)

2. **README docs: Codex rollout operating mode**
   - New section: **"Codex rollout operating mode"**
   - Explicit guidance:
     - Codex one-shot for interactive speed
     - cloud recursive for reliability/depth
     - switch criteria from one-shot → recursive
   - Added report invocation examples.

3. **Regression tests for parsing/report generation**
   - `TestBuildReport_ModeStatsAndPercentiles`
   - `TestLoadTelemetry_ParsesJSONLAndSkipsMalformed`

## Before / After
### Before
- Telemetry was being written, but no first-class report to monitor rollout quality by mode and model mix.
- No explicit "operating mode" guidance in docs for Codex one-shot vs cloud recursive usage.

### After
- Single command/script generates codex rollout telemetry report from JSONL.
- Docs now codify operating-mode defaults and escalation criteria.
- Regression coverage added for telemetry JSONL parsing + report stats.

## Validation
Commands run:
```bash
go test ./...
scripts/codex_rollout_report.sh
```

`go test ./...` summary:
- `ok github.com/hurttlocker/cortex/cmd/codex-rollout-report`
- `ok github.com/hurttlocker/cortex/cmd/cortex`
- `ok` all `internal/*` packages

Notes:
- `scripts/codex_rollout_report.sh` now handles missing telemetry file gracefully and reports zero runs instead of crashing.

## Risk Notes
- **Low risk**: additive only (new command + script + README section).
- No changes to existing `cortex` runtime paths or reason execution logic.
- Report parser tolerates malformed JSONL lines and continues with valid events.
