### PR TITLE
feat: add codex rollout guardrails + strict exit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,32 @@ scripts/codex_rollout_report.sh
 go run ./cmd/codex-rollout-report --file ~/.cortex/reason-telemetry.jsonl
 ```
 
+Quality gates (optional, for CI/cron guardrails):
+
+- **one-shot p95 latency warning threshold:** default `20000ms` (20s)
+- **recursive known-cost completeness threshold:** default `0.80` (80%)
+
+Recommended defaults:
+- Keep default thresholds for first rollout wave.
+- If you need tighter SLOs, lower one-shot p95 threshold (e.g. `15000`).
+- For billing visibility audits, increase recursive completeness threshold (e.g. `0.90`).
+
+Examples:
+
+```bash
+# Warn-only (default): prints warnings, exits 0
+scripts/codex_rollout_report.sh --warn-only
+
+# Strict CI/cron mode: non-zero exit on guardrail warnings
+scripts/codex_rollout_report.sh --warn-only=false
+
+# Custom thresholds
+scripts/codex_rollout_report.sh \
+  --one-shot-p95-warn-ms 15000 \
+  --recursive-known-cost-min-share 0.90 \
+  --warn-only=false
+```
+
 ### 📊 Benchmark Command — Test Any Model
 
 ```bash

--- a/scripts/codex_rollout_report.sh
+++ b/scripts/codex_rollout_report.sh
@@ -2,7 +2,13 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TELEMETRY_FILE="${1:-$HOME/.cortex/reason-telemetry.jsonl}"
+TELEMETRY_FILE="$HOME/.cortex/reason-telemetry.jsonl"
+
+# First non-flag positional arg (if provided) is treated as telemetry file path.
+if [[ $# -gt 0 && "$1" != --* ]]; then
+  TELEMETRY_FILE="$1"
+  shift
+fi
 
 cd "$ROOT_DIR"
-go run ./cmd/codex-rollout-report --file "$TELEMETRY_FILE"
+go run ./cmd/codex-rollout-report --file "$TELEMETRY_FILE" "$@"


### PR DESCRIPTION
## Summary
Phase 3 codex rollout guardrails for telemetry reporting (PR-only, minimal/backward-compatible).

### What changed
1. **Optional quality gates** added to `cmd/codex-rollout-report`:
   - Warn if **one-shot p95 latency** exceeds threshold (default: `20000ms`)
   - Warn if **recursive known-cost completeness** falls below threshold (default: `0.80`)

2. **Exit mode support for CI/cron**:
   - `--warn-only` (default `true`) keeps previous behavior (always exit 0)
   - `--warn-only=false` enables strict mode (exit code `2` when guardrails warn)

3. **Script passthrough updates**:
   - `scripts/codex_rollout_report.sh` now forwards extra flags and supports optional first positional telemetry file path.

4. **README updates**:
   - Added threshold guidance + recommended defaults
   - Added strict mode examples for CI/cron

5. **Regression tests**:
   - Added threshold evaluation tests in `cmd/codex-rollout-report/main_test.go`
   - Covers warning and pass paths for guardrail logic

## Before / After
### Before
- Telemetry report summarized stats only.
- No threshold-based guardrails.
- No strict/non-zero mode for CI/cron checks.

### After
- Report includes guardrail config + pass/warn status.
- Optional threshold warnings for latency and cost-completeness.
- Strict mode available via `--warn-only=false` for automated gating.

## Validation
Commands run:

```bash
go test ./...
```

Result summary:
- `ok github.com/hurttlocker/cortex/cmd/codex-rollout-report`
- `ok github.com/hurttlocker/cortex/cmd/cortex`
- `ok` all `internal/*` packages

Additional manual checks:

```bash
# warn-only default (exit 0)
scripts/codex_rollout_report.sh /tmp/reason-telemetry-fixture.jsonl

# strict mode (non-zero when thresholds fail)
scripts/codex_rollout_report.sh /tmp/reason-telemetry-fixture.jsonl --warn-only=false
```

## Risk notes
- **Low risk**: additive guardrail logic around an existing reporting command.
- Backward-compatible defaults preserved (`--warn-only=true`).
- No runtime changes to `cortex reason` execution path or telemetry write path.
