### PR TITLE
chore(release): prep v0.3.4-rc1 notes, changelog, and auditor pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.3.4-rc1] - 2026-02-20
+
+### Added
+- Runtime CLI command: `cortex codex-rollout-report`.
+- Shared rollout report package: `internal/codexrollout` (used by runtime command + helper binary).
+- Guardrail controls for rollout report:
+  - `--one-shot-p95-warn-ms`
+  - `--recursive-known-cost-min-share`
+  - `--warn-only` (strict mode exits non-zero on guardrail warnings)
+- Runtime/help behavior hardening so `--help` exits `0` on rollout report paths.
+- New tests for rollout report parsing, guardrail behavior, and strict-mode exits.
+
+### Changed
+- `scripts/codex_rollout_report.sh` now routes through runtime CLI while keeping backward-compatible positional telemetry file handling.
+- Updated `README.md` usage examples for warn-only vs strict rollout gating.
+
+### Fixed
+- Audit guide fixture for concurrent import test (`tests/AUDIT.md`, test 9e) now uses substantive content to avoid low-signal hygiene false negatives.

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 // version is set by goreleaser via ldflags at build time.
-var version = "0.3.3"
+var version = "0.3.4-rc1"
 
 var (
 	globalDBPath   string

--- a/docs/audits/v0.3.4-rc1-auditor-pack.md
+++ b/docs/audits/v0.3.4-rc1-auditor-pack.md
@@ -1,0 +1,100 @@
+# Cortex v0.3.4-rc1 Auditor Command Pack
+
+Audit target:
+- Repo: `hurttlocker/cortex`
+- Tag: `v0.3.4-rc1`
+- Expected focus: rollout report runtime integration + release hardening checks
+
+## 1) Environment / provenance
+
+```bash
+git clone https://github.com/hurttlocker/cortex.git
+cd cortex
+git checkout v0.3.4-rc1
+
+go version
+```
+
+## 2) Build + baseline tests
+
+```bash
+go test ./...
+go vet ./...
+go build -o ./bin/cortex ./cmd/cortex
+./bin/cortex version
+```
+
+Expected:
+- tests pass
+- vet pass
+- binary prints `cortex 0.3.4-rc1` (or release ldflags version)
+
+## 3) Rollout report command behavior
+
+### 3.1 Help path
+
+```bash
+./bin/cortex codex-rollout-report --help
+echo $?
+```
+
+Expected:
+- help text printed
+- exit code `0`
+
+### 3.2 No-file / missing-file path
+
+```bash
+./bin/cortex codex-rollout-report --file /tmp/does-not-exist.jsonl
+echo $?
+```
+
+Expected:
+- report renders with `Runs parsed: 0`
+- exit code `0`
+
+### 3.3 Strict guardrail failure signaling
+
+```bash
+cat > /tmp/cortex-audit-telemetry.jsonl <<'EOF'
+{"mode":"one-shot","provider":"openrouter","model":"openai-codex/gpt-5.2","wall_ms":25000,"cost_known":true,"cost_usd":0.001}
+{"mode":"recursive","provider":"openrouter","model":"google/gemini-2.5-flash","wall_ms":30000,"cost_known":false}
+EOF
+
+./bin/cortex codex-rollout-report --file /tmp/cortex-audit-telemetry.jsonl --warn-only=false
+echo $?
+```
+
+Expected:
+- WARN lines for one-shot p95 and recursive known-cost completeness
+- non-zero exit (runtime path should return `2`)
+
+## 4) Script compatibility path
+
+```bash
+./scripts/codex_rollout_report.sh /tmp/cortex-audit-telemetry.jsonl --warn-only=false
+echo $?
+```
+
+Expected:
+- report output
+- non-zero exit in strict mode
+- note: exact code may differ under `go run`; treat any non-zero as failure
+
+## 5) Guide fixture regression check (#59)
+
+```bash
+rg -n "Concurrent Note|substantive" tests/AUDIT.md
+```
+
+Expected:
+- test 9e fixtures include substantive content, not low-signal one-liners
+
+## 6) Audit notes template
+
+Capture:
+- commit/tag tested
+- full command transcript
+- mismatches vs expected behavior
+- pass/fail per section
+- suggested regressions / follow-ups

--- a/docs/releases/v0.3.4-rc1.md
+++ b/docs/releases/v0.3.4-rc1.md
@@ -1,0 +1,41 @@
+# Cortex v0.3.4-rc1 Release Notes
+
+Date: 2026-02-20
+Tag: `v0.3.4-rc1`
+
+## Highlights
+
+- **Runtime rollout report command is now first-class**
+  - `cortex codex-rollout-report`
+  - No more reliance on helper-only execution for production runtime checks.
+
+- **Rollout guardrails are now operationalized**
+  - one-shot p95 latency warning threshold
+  - recursive known-cost completeness warning threshold
+  - strict mode available via `--warn-only=false`
+
+- **Release-hardening + audit-fit improvements**
+  - Shared report logic centralized in `internal/codexrollout`
+  - Added tests for parse behavior, strict-mode failure signaling, and help path behavior
+  - Updated audit fixture content for concurrent import guide test (issue #59)
+
+## Commands
+
+```bash
+# Runtime command
+cortex codex-rollout-report
+
+# Strict gate mode
+cortex codex-rollout-report --warn-only=false
+
+# Tuned thresholds
+cortex codex-rollout-report \
+  --one-shot-p95-warn-ms 15000 \
+  --recursive-known-cost-min-share 0.90 \
+  --warn-only=false
+```
+
+## Notes for CI / Cron
+
+- Runtime command returns **exit code 2** in strict mode when guardrail warnings are present.
+- Script wrappers using `go run` may normalize exit code presentation; treat **any non-zero** as gate failure.


### PR DESCRIPTION
## Summary
Release prep for `v0.3.4-rc1`:

- bump fallback runtime version string to `0.3.4-rc1`
- add root `CHANGELOG.md` with `0.3.4-rc1` entries
- add release notes doc: `docs/releases/v0.3.4-rc1.md`
- add auditor command pack: `docs/audits/v0.3.4-rc1-auditor-pack.md`

## Why
We need an immutable RC target with explicit release notes + auditor-ready verification steps before external re-audit.

## Validation
```bash
go test ./...
```
All packages pass.
