### PR TITLE
docs: close #28/#32 and roll #38 into shipped roadmap + new meta wave

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ cortex reason "query" --recursive --preset weekly-dive  # → auto-selects deeps
 
 **Local models work great for scheduled/cron use** — even on CPU-only hardware, a 4B model can run recursive reasoning in 60-90s, perfect for nightly digests and audits. Users with GPUs (especially Apple Silicon with Metal) get interactive-speed local reasoning.
 
+For hardware-specific recommendations and benchmark workflow, see **[docs/LOCAL-LLM-PERFORMANCE.md](docs/LOCAL-LLM-PERFORMANCE.md)**.
+
 **Built-in reason telemetry (new):** every `cortex reason` run appends a JSONL event to `~/.cortex/reason-telemetry.jsonl` with mode (`one-shot` vs `recursive`), model/provider, tokens, durations, and estimated cost (when pricing is known). Disable with:
 
 ```bash
@@ -722,6 +724,7 @@ Real-world benchmark on 967 memories from a production agent workspace. Embeddin
 - ✅ **Project Tagging**: Auto-tag memories by project using path-based and content-keyword rules, search scoped to project ([#29](https://github.com/hurttlocker/cortex/issues/29))
 - ✅ **Recursive Reasoning (RLM)**: LLM reasoning layer with iterative search loop inspired by [Recursive Language Models](https://arxiv.org/abs/2512.24601). 5 built-in presets, smart model routing, confidence-aware prompting, `cortex bench` for model comparison ([#31](https://github.com/hurttlocker/cortex/issues/31))
 - ✅ **Metadata Capture**: Session context (agent, channel, model, tokens) automatically captured with every memory — enables "who said what, when" queries ([#30](https://github.com/hurttlocker/cortex/issues/30))
+- ✅ **Memory Reliability Wave (#33–#37)**: embedding freshness, class-aware retrieval, capture hygiene, superseded fact model, and retrieval explainability shipped as a coordinated rollout ([#38](https://github.com/hurttlocker/cortex/issues/38))
 - ✅ **Conflict Resolution**: 4 strategies (last-write-wins, highest-confidence, newest, manual) with dry-run, Ebbinghaus-aware scoring, O(N) detection rewrite ([#14](https://github.com/hurttlocker/cortex/issues/14))
 - ✅ **Context-Aware Search**: Multi-column FTS5 (content + source_file + source_section) and context-enriched embeddings — BM25 and semantic search now match section headers and filenames, not just chunk body ([#26](https://github.com/hurttlocker/cortex/issues/26))
 - **Web Dashboard**: Browser-based memory exploration and management

--- a/docs/LOCAL-LLM-PERFORMANCE.md
+++ b/docs/LOCAL-LLM-PERFORMANCE.md
@@ -1,0 +1,68 @@
+# Local LLM Performance Guide (`cortex reason`)
+
+This guide helps you choose local models based on hardware, expected speed, and use case.
+
+## TL;DR
+
+- **Intel CPU-only**: use local models for scheduled/cron workloads, not interactive chat.
+- **Apple Silicon (Metal)**: local interactive use is viable for 4B–8B models.
+- **GPU Linux/NVIDIA**: best local throughput; suitable for larger models and recursive runs.
+- If latency matters more than privacy: use cloud models via OpenRouter.
+
+## Known Baseline (Intel i7-10700K, CPU-only)
+
+| Model | Approx tok/s | Typical latency | Notes |
+|---|---:|---:|---|
+| `phi4-mini` (3.8B) | ~7.5 | ~60s (263 toks) | Best local Intel pick |
+| `qwen3:4b` | ~7.1 | ~44s (short outputs) | May need no-think setting |
+| `gemma2:9b` | ~4.9 | 36s short / 90s+ long | Better quality, slower |
+
+**Recommendation:** Intel CPU-only should default to cron/scheduled usage for `cortex reason`.
+
+## Hardware Tiers & Model Recommendations
+
+| Tier | Recommended Models | Best Use |
+|---|---|---|
+| Intel Mac / CPU-only | `phi4-mini`, `qwen3:4b` | Nightly digests, audits, batched jobs |
+| Apple Silicon 8GB | `phi4-mini`, `qwen3:4b` | Light interactive + cron |
+| Apple Silicon 16GB+ | `qwen3:8b`, `deepseek-r1:8b`, `gemma2:9b` | Interactive + recursive runs |
+| Apple Silicon Pro/Max | 8B–14B class models | Deeper recursive analysis |
+| Linux + NVIDIA GPU | 8B+ and larger | Highest throughput local inference |
+
+## Decision Rule
+
+Use this quick routing rule:
+
+1. **Need privacy + can tolerate latency** → local model
+2. **Need fast interactive answers** → cloud model (`--model google/gemini-2.5-flash` etc.)
+3. **Need deep recursive reliability** → cloud recursive by default, local recursive when GPU-class hardware is available
+
+## Benchmark Your Own Machine
+
+Run this sequence with your real memory set:
+
+```bash
+# 1) Ensure embeddings are available
+cortex embed ollama/nomic-embed-text --batch-size 10
+
+# 2) Compare local models on presets
+cortex bench --local --embed ollama/nomic-embed-text --output local-bench.md
+
+# 3) Compare one local model vs cloud
+cortex bench --compare "phi4-mini,google/gemini-2.5-flash" \
+  --embed ollama/nomic-embed-text \
+  --output local-vs-cloud.md
+
+# 4) Test recursive mode explicitly
+cortex bench --recursive --max-iterations 6 --max-depth 1 --output recursive-local.md
+```
+
+## Ops Notes
+
+- Prefer `nomic-embed-text` for local hybrid/semantic search embeddings.
+- Long recursive runs should be scheduled off hot paths if local CPU-only.
+- Track quality and latency with telemetry (`~/.cortex/reason-telemetry.jsonl`) and `cortex codex-rollout-report`.
+
+## Privacy Note
+
+Local inference keeps model execution on your machine. This is useful for sensitive data and compliance-constrained workflows.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -212,6 +212,22 @@ Plugin settings must be nested under `config`, not alongside `enabled`:
 
 **Fix:** Edit `~/.openclaw/openclaw.json` manually and nest settings under `config`.
 
+**Cause 1b: "Unrecognized keys" warnings even when config is correct**
+
+You may still see warnings like:
+
+```text
+plugins.entries.openclaw-cortex: Unrecognized keys: "autoRecall", "autoCapture", ...
+```
+
+when your config is correctly nested under `config`. In current OpenClaw builds, this can happen because core config validation may not fully apply extension `configSchema` before warning.
+
+- **Impact:** noisy logs only (plugin still works)
+- **Safety:** non-blocking for runtime behavior
+- **What to do:** keep config nested under `config` and continue
+
+We'll track upstream validator behavior; until then, treat this as known log noise, not a plugin failure.
+
 **Cause 2: Missing dependencies**
 If you see `Cannot find module '@sinclair/typebox'`, run:
 ```bash


### PR DESCRIPTION
## Summary
Implements the next-wave docs/meta cleanup for issues #28, #32, #38:

- Add **local LLM performance guide** for `cortex reason`:
  - `docs/LOCAL-LLM-PERFORMANCE.md`
  - hardware tier recommendations, decision rule, benchmark workflow, ops/privacy notes
- Link the new guide from `README.md` local model section
- Document OpenClaw plugin validator warning behavior in `plugin/README.md`:
  - clarifies non-blocking "Unrecognized keys" log noise when config is correctly nested
- Update roadmap in `README.md` to mark the #33–#37 reliability wave as shipped (tracked by #38)

## Issue mapping
- Closes #32
- Closes #28
- For #38: this PR documents completion in roadmap; follow-on work now tracked in #74

## Validation
```bash
go test ./...
```
All packages passing.
