### PR TITLE
docs(audit): add v0.3.4-rc1 go/no-go handoff package

### DIFF
--- a/docs/audits/v0.3.4-rc1-auditor-pack.md
+++ b/docs/audits/v0.3.4-rc1-auditor-pack.md
@@ -4,6 +4,7 @@ Audit target:
 - Repo: `hurttlocker/cortex`
 - Tag: `v0.3.4-rc1`
 - Expected focus: rollout report runtime integration + release hardening checks
+- Gate summary: see `docs/audits/v0.3.4-rc1-go-no-go.md`
 
 ## 1) Environment / provenance
 

--- a/docs/audits/v0.3.4-rc1-go-no-go.md
+++ b/docs/audits/v0.3.4-rc1-go-no-go.md
@@ -1,0 +1,50 @@
+# v0.3.4-rc1 Pre-Audit Go/No-Go Handoff
+
+Date: 2026-02-20
+Scope: Pre-audit hardening + gate package readiness for external auditor.
+
+## Gate Checklist
+
+### Release integrity
+- [x] `v0.3.4-rc1` pre-release published
+- [x] Assets present (6): darwin/linux/windows tarballs + checksums
+- [x] Checksum verified for `cortex-darwin-amd64.tar.gz`
+
+### Runtime behavior gates
+- [x] `cortex version` reports `0.3.4-rc1`
+- [x] `cortex codex-rollout-report --help` exits `0`
+- [x] strict mode fixture (`--warn-only=false`) exits `2`
+- [x] strict mode fixture emits expected guardrail `WARN:` lines
+
+### RC smoke package
+- [x] `scripts/audit_rc_smoke.sh` exists and is executable
+- [x] RC smoke run passed end-to-end (`go test`, `go vet`, help gate, strict gate)
+
+### Audit-track hygiene
+- [x] #60 closed (dedupe race)
+- [x] #61 closed (malformed embed lock reclaim)
+- [x] #62 closed (stale migration claim reclaim)
+- [ ] #63 open (Niot active)
+- [ ] #64 open (ops growth guardrails follow-through)
+
+## Current Decision
+
+## ✅ GO for external audit (RC)
+
+Rationale:
+- Release artifact integrity and runtime guardrail behavior are validated.
+- Gate package is codified and reproducible.
+- Remaining open issues (#63/#64) are known, scoped, and explicitly tracked.
+
+## Auditor Notes
+
+- Audit target should be pinned to `v0.3.4-rc1` tag.
+- Runtime strict mode semantics are authoritative:
+  - runtime CLI returns exit `2` on guardrail warnings
+  - script/go-run paths guarantee non-zero (exact code can vary by launcher)
+
+## Owner Follow-ups After Auditor Round
+
+1. Resolve #63 findings/PR from Niot and re-run gate package.
+2. Convert #64 into concrete threshold/operator defaults if auditor flags operational risk.
+3. Decide promote-to-stable (`v0.3.4`) vs `v0.3.4-rc2` based on critical findings.

--- a/docs/audits/v0.3.4-rc1-release-artifact-smoke.md
+++ b/docs/audits/v0.3.4-rc1-release-artifact-smoke.md
@@ -23,3 +23,11 @@ chmod +x cortex
 - `./cortex codex-rollout-report --help` exit: `0` ✅
 - strict fixture (`--warn-only=false`) exit: `2` ✅
 - strict fixture output includes guardrail `WARN:` lines ✅
+
+## Re-validation (2026-02-20)
+A second independent run reproduced the same results:
+
+- checksum expected/actual: match ✅
+- help exit code: `0` ✅
+- strict fixture exit code: `2` ✅
+- strict fixture output: includes both expected `WARN:` lines ✅


### PR DESCRIPTION
## Summary
Pre-audit hardening + gate package handoff updates for `v0.3.4-rc1`:

- add `docs/audits/v0.3.4-rc1-go-no-go.md` (single decision checklist + status)
- add second-run revalidation section to release artifact smoke doc
- link auditor pack to go/no-go summary

## Why
Make the auditor handoff explicit, reproducible, and decision-oriented before the #63 work lands.

## Scope
Docs-only.
