### PR TITLE
fix(search): close #63 NULL memory_class hardening + leaner conflict output

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ cortex search "deploy requirements" --no-class-boost   # disable weighting when 
 cortex list --class rule,decision
 ```
 
-Unclassified data remains fully searchable (backward compatible). Class boosts are conservative defaults and can be disabled per-query.
+Unclassified data remains fully searchable (backward compatible). On startup, Cortex backfills legacy `NULL memory_class` rows to `''` and normalizes scan paths so mixed historical/new datasets stay query-safe. Class boosts are conservative defaults and can be disabled per-query.
 
 ### 🔎 Retrieval Explainability — Why This Result Ranked
 

--- a/internal/store/migrations_test.go
+++ b/internal/store/migrations_test.go
@@ -1,7 +1,9 @@
 package store
 
 import (
+	"database/sql"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -90,5 +92,63 @@ func TestMigrateFTSMultiColumn_RecoverStaleInProgressMarker(t *testing.T) {
 	}
 	if state != "true" {
 		t.Fatalf("expected fts_multi_column=true after recovery, got %q", state)
+	}
+}
+
+func TestMigrateMemoryClassNullBackfill_RewritesLegacyNulls(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "legacy-null-class.db")
+	rawDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw sqlite: %v", err)
+	}
+
+	// Simulate a legacy schema where memory_class exists and allows NULL.
+	if _, err := rawDB.Exec(`
+		CREATE TABLE memories (
+			id             INTEGER PRIMARY KEY AUTOINCREMENT,
+			content        TEXT NOT NULL,
+			source_file    TEXT,
+			source_line    INTEGER,
+			source_section TEXT,
+			content_hash   TEXT UNIQUE NOT NULL,
+			project        TEXT NOT NULL DEFAULT '',
+			memory_class   TEXT DEFAULT NULL,
+			metadata       TEXT DEFAULT NULL,
+			imported_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at     DATETIME DEFAULT CURRENT_TIMESTAMP,
+			deleted_at     DATETIME
+		)
+	`); err != nil {
+		t.Fatalf("create legacy memories table: %v", err)
+	}
+	if _, err := rawDB.Exec(`
+		INSERT INTO memories (content, source_file, source_line, source_section, content_hash, project, memory_class)
+		VALUES ('legacy row with nullable class', 'legacy.md', 1, 'legacy', 'legacy-hash-1', '', NULL)
+	`); err != nil {
+		t.Fatalf("insert legacy NULL row: %v", err)
+	}
+	ss := &SQLiteStore{db: rawDB}
+	if err := ss.migrateMemoryClassNullBackfill(); err != nil {
+		t.Fatalf("migrateMemoryClassNullBackfill on legacy schema: %v", err)
+	}
+
+	var nullCount int
+	if err := rawDB.QueryRow(`SELECT COUNT(*) FROM memories WHERE memory_class IS NULL`).Scan(&nullCount); err != nil {
+		t.Fatalf("count NULL memory_class: %v", err)
+	}
+	if nullCount != 0 {
+		t.Fatalf("expected NULL memory_class rows to be backfilled, still found %d", nullCount)
+	}
+
+	var class string
+	if err := rawDB.QueryRow(`SELECT memory_class FROM memories WHERE content_hash = 'legacy-hash-1'`).Scan(&class); err != nil {
+		t.Fatalf("read backfilled class: %v", err)
+	}
+	if class != "" {
+		t.Fatalf("expected empty-string sentinel after backfill, got %q", class)
+	}
+
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("close raw sqlite: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
Closes #63 with a single scoped hardening PR:

1) **NULL `memory_class` robustness across search paths**
- Added startup migration backfill: `migrateMemoryClassNullBackfill()`
  - rewrites legacy `NULL memory_class` rows to empty-string sentinel (`''`)
  - runs during `migrate()` immediately after `migrateMemoryClassColumn()`
- Keeps scan behavior safe for mixed historical/new datasets while preserving backward compatibility.

2) **Regression tests for mixed legacy/new rows**
- Added `TestSearch_MixedLegacyNullMemoryClass_AllModes` in `internal/search/search_test.go`
  - seeds mixed rows
  - forces legacy row `memory_class = NULL`
  - verifies search works (no scan crash) and returns empty class safely across:
    - keyword (BM25/FTS)
    - semantic
    - hybrid
- Added `TestMigrateMemoryClassNullBackfill_RewritesLegacyNulls` in `internal/store/migrations_test.go`
  - simulates legacy schema where `memory_class` allows NULL
  - verifies startup backfill normalizes NULL → `''`

3) **Output bloat follow-up (minimal/practical)**
- Tightened default conflict output preview from 10 → 8 entries
- Prioritize higher-similarity conflicts first in default TTY output (`rankConflictsForDisplay`)
- Verbose mode remains full-detail
- Added CLI regression test: `TestOutputConflictsTTY_PrioritizesHigherSimilarity`

4) **Docs**
- README updated to document NULL backfill strategy for mixed historical/new datasets.

---

## Explicit before/after repro from #63

Fixture setup (create DB + force legacy NULL class):
```bash
go run ./cmd/cortex --db "$DB" import "$NOTE"
python3 - <<'PY' "$DB"
import sqlite3, sys
p=sys.argv[1]
con=sqlite3.connect(p)
cur=con.cursor()
cur.execute("UPDATE memories SET memory_class = NULL")
con.commit()
cur.execute("select count(*) from memories where memory_class is null")
print(cur.fetchone()[0])
con.close()
PY
```

### Before (v0.3.3 release binary)
Command:
```bash
/tmp/.../v033/cortex --db "$DB" search "memory" --mode keyword --limit 1 --json
```
Exit: `1`
Output:
```text
Error: search failed: scanning FTS result: sql: Scan error on column index 7, name "memory_class": converting NULL to string is unsupported
```

### After (this branch)
Command:
```bash
/tmp/.../cortex-current --db "$DB" search "memory" --mode keyword --limit 1 --json
```
Exit: `0`
Output:
```json
[
  {
    "content": "legacy memory token for #63 repro",
    "source_file": "/tmp/cortex-63-repro.xUjseX/note.md",
    "source_line": 1,
    "score": 9.999999999999968e-8,
    "snippet": "legacy <b>memory</b> token for #63 repro",
    "match_type": "bm25",
    "memory_id": 1,
    "imported_at": "2026-02-20T04:27:17.466478Z"
  }
]
```

---

## Exact tests run

```bash
go test ./...
go vet ./...
```

```text
ok   github.com/hurttlocker/cortex/cmd/codex-rollout-report (cached)
ok   github.com/hurttlocker/cortex/cmd/cortex (cached)
ok   github.com/hurttlocker/cortex/internal/ann (cached)
ok   github.com/hurttlocker/cortex/internal/codexrollout (cached)
ok   github.com/hurttlocker/cortex/internal/embed (cached)
ok   github.com/hurttlocker/cortex/internal/extract (cached)
ok   github.com/hurttlocker/cortex/internal/ingest (cached)
ok   github.com/hurttlocker/cortex/internal/mcp (cached)
ok   github.com/hurttlocker/cortex/internal/observe (cached)
ok   github.com/hurttlocker/cortex/internal/reason (cached)
ok   github.com/hurttlocker/cortex/internal/search (cached)
ok   github.com/hurttlocker/cortex/internal/store (cached)
```

---

## Risk notes
- **Low risk / focused**: migration backfill is idempotent (`UPDATE ... WHERE memory_class IS NULL`).
- Backfill runs at startup; on very large legacy DBs this is a one-time write sweep over NULL-class rows.
- Conflict output default is intentionally more compact; `--verbose`/`--json` still expose full detail.

## Rollback note
Single-commit revert restores prior behavior:
```bash
git revert a04cfa8
```

This will remove NULL backfill + new regressions + conflict output shaping adjustments.
