### PR TITLE
docs(audit): sync go/no-go status after #63 closure

### DIFF
--- a/docs/audits/v0.3.4-rc1-go-no-go.md
+++ b/docs/audits/v0.3.4-rc1-go-no-go.md
@@ -24,7 +24,7 @@ Scope: Pre-audit hardening + gate package readiness for external auditor.
 - [x] #60 closed (dedupe race)
 - [x] #61 closed (malformed embed lock reclaim)
 - [x] #62 closed (stale migration claim reclaim)
-- [ ] #63 open (Niot active)
+- [x] #63 closed (NULL `memory_class` hardening merged)
 - [ ] #64 open (ops growth guardrails follow-through)
 
 ## Current Decision
@@ -34,7 +34,7 @@ Scope: Pre-audit hardening + gate package readiness for external auditor.
 Rationale:
 - Release artifact integrity and runtime guardrail behavior are validated.
 - Gate package is codified and reproducible.
-- Remaining open issues (#63/#64) are known, scoped, and explicitly tracked.
+- Remaining open issue (#64) is known, scoped, and explicitly tracked.
 
 ## Auditor Notes
 
@@ -45,6 +45,6 @@ Rationale:
 
 ## Owner Follow-ups After Auditor Round
 
-1. Resolve #63 findings/PR from Niot and re-run gate package.
-2. Convert #64 into concrete threshold/operator defaults if auditor flags operational risk.
-3. Decide promote-to-stable (`v0.3.4`) vs `v0.3.4-rc2` based on critical findings.
+1. Track #64 to closure with concrete threshold/operator defaults and maintenance runbook.
+2. Promote audited candidate commit to stable (`v0.3.4`) unless new Critical/High findings emerge.
+3. Continue post-release reliability wave under #74.


### PR DESCRIPTION
## Summary
Sync `docs/audits/v0.3.4-rc1-go-no-go.md` with current issue state after #63 closure.

- mark #63 as closed
- update rationale to reflect only #64 remains open
- refresh owner follow-ups for post-audit/post-promotion execution

## Why
Delta audit flagged low-severity status drift in the go/no-go doc (`#63 open` text was stale).

## Scope
Docs-only.
