### PR TITLE
chore(post-release): bump dev version + add #64 growth guardrail runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,8 @@ cortex search "deployment policy" --include-superseded
 
 No more black-box memory. No more hoping the agent remembers correctly.
 
+For ops posture at scale, see the DB growth runbook: [`docs/ops-db-growth-guardrails.md`](docs/ops-db-growth-guardrails.md).
+
 ### 📤 Export & Portability — Your Memory Is Yours
 
 ```bash

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 // version is set by goreleaser via ldflags at build time.
-var version = "0.3.4-rc1"
+var version = "0.3.5-dev"
 
 var (
 	globalDBPath   string

--- a/docs/ops-db-growth-guardrails.md
+++ b/docs/ops-db-growth-guardrails.md
@@ -1,0 +1,102 @@
+# DB Growth Guardrails & Maintenance Runbook
+
+This runbook defines when to intervene on Cortex DB growth and how to do it safely.
+
+## Why this exists
+As memory/fact volume grows, output and operator workflows can degrade before correctness fails.
+This guide tracks thresholds and a repeatable maintenance path.
+
+## Daily / Weekly Checks
+
+### Daily (quick)
+```bash
+cortex stats
+```
+Review:
+- `storage_bytes`
+- 24h growth in memories/facts
+- `alerts` (if present)
+
+### Weekly (operator)
+```bash
+cortex stats --json
+cortex stale 7
+```
+Confirm whether growth is expected (imports, captures) vs noise churn.
+
+## Thresholds
+
+Treat these as intervention triggers:
+
+1. **DB size notice**: `storage_bytes > 1.0 GB`
+   - Action: schedule weekly review and confirm expected growth source.
+
+2. **DB size warning**: `storage_bytes > 1.5 GB`
+   - Action: run maintenance window (below) and verify post-maintenance deltas.
+
+3. **Fact growth spike alert** (24h)
+   - Action: inspect recent imports/capture sources and conflict/stale outputs for noise.
+
+4. **Memory growth spike alert** (24h)
+   - Action: validate capture hygiene and source dedupe behavior.
+
+## Maintenance Window (Safe)
+
+Run during low-traffic windows.
+
+1) Backup DB file:
+```bash
+cp ~/.cortex/cortex.db ~/.cortex/cortex.db.backup.$(date +%Y%m%d%H%M%S)
+```
+
+2) Run integrity check:
+```bash
+sqlite3 ~/.cortex/cortex.db "PRAGMA integrity_check;"
+```
+Expected output: `ok`
+
+3) Reclaim space:
+```bash
+sqlite3 ~/.cortex/cortex.db "VACUUM;"
+```
+
+4) Refresh planner stats:
+```bash
+sqlite3 ~/.cortex/cortex.db "ANALYZE;"
+```
+
+5) Verify post-state:
+```bash
+cortex stats --json
+```
+Compare size and growth metrics to pre-maintenance snapshot.
+
+## Output Scaling Guidance
+
+For large conflict sets:
+- default to compact output:
+  ```bash
+  cortex conflicts
+  ```
+- use `--verbose` only when deep triage is required:
+  ```bash
+  cortex conflicts --verbose
+  ```
+- for machine workflows, prefer JSON + downstream filtering:
+  ```bash
+  cortex conflicts --json
+  ```
+
+## SLO Checkpoints (Operator)
+
+Track these checkpoints during growth reviews:
+
+- `cortex stats`: completes under **3s** on current production-scale DBs.
+- `cortex search "<common query>" --mode hybrid --limit 10`: under **5s** baseline on warmed local DB.
+- `cortex conflicts` (default compact mode): returns summary output without terminal spam or hangs.
+
+If checkpoints regress materially, file/track under #64 and attach command output + DB size context.
+
+## Related Tracking
+- #64 — DB growth guardrails follow-through
+- #74 — post-v0.3.4 reliability wave


### PR DESCRIPTION
## Summary
Post-v0.3.4 hygiene + #64 follow-through scaffolding:

1. bump runtime fallback version in source from `0.3.4-rc1` -> `0.3.5-dev`
2. add DB growth guardrails runbook (`docs/ops-db-growth-guardrails.md`)
3. link runbook from README observability section

## Why
- Prevent local-from-source builds from reporting stale RC fallback.
- Close #64 operational ambiguity with concrete thresholds, maintenance path (VACUUM/ANALYZE), and SLO checkpoints.

## Validation
- `bash scripts/audit_rc_smoke.sh` ✅
- release artifact smoke (`v0.3.4` darwin-amd64): checksum match, help exit 0, strict exit 2 ✅

## Notes
- This is docs/process + fallback version hygiene; no runtime behavioral change to released `v0.3.4` artifacts.
