### PR TITLE
feat(cli): add cortex optimize command (v0.3.5 lane 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ cortex stats        # Overview: counts, freshness, growth trends (24h/7d), stora
 cortex stale        # What's fading — reinforce, delete, or skip
 cortex conflicts    # Contradictions among active facts (compact grouped output)
 cortex conflicts --verbose  # Full per-conflict detail (no compacting)
+cortex optimize     # Manual maintenance: integrity_check + VACUUM + ANALYZE
 cortex conflicts --resolve highest-confidence  # Auto-resolve by confidence
 cortex conflicts --resolve newest --dry-run    # Preview before applying
 cortex conflicts --keep 12345 --drop 12346     # Surgical manual resolution

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -226,7 +226,7 @@ cortex bench --recursive --max-iterations 8 --max-depth 1 --output recursive.md
 |---|---|
 | After important conversations | Import daily log or key decisions |
 | Before answering recall questions | Search Cortex first |
-| Weekly | Run `cortex stats` + `cortex stale 7` |
+| Weekly | Run `cortex stats` + `cortex stale 7` (and `cortex optimize --check-only` on larger DBs) |
 | After corrections/learnings | Store the lesson immediately |
 
 ## 8. OpenClaw Plugin (Optional)


### PR DESCRIPTION
## Summary
Starts v0.3.5 lane 1 by adding a first-class maintenance command:

- new CLI command: `cortex optimize`
- modes:
  - default: integrity_check + VACUUM + ANALYZE
  - `--check-only`
  - `--vacuum-only`
  - `--analyze-only`
- `--json` output support
- blocked in `--read-only` mode
- help/usage wiring + docs updates
- tests for flag/error paths + check-only JSON behavior

Closes #80.

## Files
- `cmd/cortex/main.go`
- `cmd/cortex/main_test.go`
- `README.md`
- `docs/setup-guide.md`

## Validation
- `go test ./...` ✅
- `go vet ./...` ✅

## Notes
- This command is manual/operator-invoked only (no auto-maintenance behavior added).
