### PR TITLE
ci(release): enforce tag checklist before publish (v0.3.5 lane 4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           go-version: "1.24"
 
+      - name: Release checklist guard
+        run: scripts/release_checklist.sh --tag "${{ github.ref_name }}"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.4] - 2026-02-20
+
+### Added
+- Stable release promotion from audited RC path (`v0.3.4-rc1..a62f11e`).
+- Release go/no-go handoff docs and artifact revalidation notes for auditor continuity.
+
+### Changed
+- Search hardening for legacy `NULL memory_class` rows with startup backfill safeguards.
+- Conflict output defaults tuned for readability (compact preview + higher-similarity prioritization).
+
+### Validation
+- Delta audit result: **GO_WITH_CONDITIONS** (no Critical/High findings in audited scope).
+- Stable artifacts published for darwin/linux/windows with checksums.
+
 ## [0.3.4-rc1] - 2026-02-20
 
 ### Added

--- a/docs/releases/v0.3.4.md
+++ b/docs/releases/v0.3.4.md
@@ -1,0 +1,40 @@
+# Cortex v0.3.4 Release Notes
+
+Date: 2026-02-20
+Tag: `v0.3.4`
+
+## Summary
+
+`v0.3.4` promotes the audited release-candidate path to stable with additional hardening merged in the audited delta.
+
+## Highlights
+
+- **Search robustness for historical datasets**
+  - Legacy rows with `NULL memory_class` are backfilled safely at startup.
+  - Regression coverage added for keyword/semantic/hybrid mixed datasets.
+
+- **Conflict output quality improvements**
+  - Compact conflict preview defaults tightened for readability.
+  - Higher-similarity conflicts are prioritized in default TTY output.
+
+- **Audit and release gate maturity**
+  - RC smoke automation and formal go/no-go handoff docs were validated pre-promotion.
+  - Stable artifacts published with checksum verification.
+
+## Audit Position
+
+- RC audit (`v0.3.4-rc1`): **Go with Conditions**
+- Delta audit (`v0.3.4-rc1..a62f11e`): **GO_WITH_CONDITIONS**
+- No Critical/High findings in audited scope for promotion.
+
+## Known Follow-through
+
+- Operational hardening follow-up tracked post-release and completed via later v0.3.5 lane work (`cortex optimize`, SLO snapshot tooling, CI drift guard).
+
+## Quick Verify
+
+```bash
+cortex version
+cortex codex-rollout-report --help
+```
+

--- a/scripts/release_checklist.sh
+++ b/scripts/release_checklist.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+release_checklist.sh — Validate release checklist prerequisites for a tag
+
+Usage:
+  scripts/release_checklist.sh --tag vX.Y.Z[-rcN]
+
+Options:
+  --tag <tag>          Release tag (defaults to GITHUB_REF_NAME)
+  -h, --help           Show help
+
+Checks:
+1) tag format is valid (v<semver>[-rcN])
+2) CHANGELOG contains a matching section: ## [<version>]
+3) docs/releases/v<version>.md exists
+4) go/no-go doc structural guard passes (offline mode)
+EOF
+}
+
+TAG="${GITHUB_REF_NAME:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      TAG="${2:-}"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1 ;;
+  esac
+done
+
+if [[ -z "$TAG" ]]; then
+  echo "ERROR: --tag is required (or set GITHUB_REF_NAME)" >&2
+  exit 1
+fi
+
+if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-rc[0-9]+)?$ ]]; then
+  echo "ERROR: invalid tag format '$TAG' (expected v<major>.<minor>.<patch>[-rcN])" >&2
+  exit 1
+fi
+
+VERSION="${TAG#v}"
+CHANGELOG="CHANGELOG.md"
+RELEASE_NOTES="docs/releases/v${VERSION}.md"
+
+if [[ ! -f "$CHANGELOG" ]]; then
+  echo "ERROR: missing $CHANGELOG" >&2
+  exit 1
+fi
+
+if ! rg -q "^## \[${VERSION//./\.}\]" "$CHANGELOG"; then
+  echo "ERROR: $CHANGELOG missing section for version [$VERSION]" >&2
+  exit 1
+fi
+
+if [[ ! -f "$RELEASE_NOTES" ]]; then
+  echo "ERROR: missing release notes file $RELEASE_NOTES" >&2
+  exit 1
+fi
+
+if ! rg -q "Tag:\s*\`$TAG\`" "$RELEASE_NOTES"; then
+  echo "ERROR: $RELEASE_NOTES missing exact tag line 'Tag: `$TAG`'" >&2
+  exit 1
+fi
+
+scripts/ci_release_guard.sh --offline
+
+echo "release-checklist: PASS (tag=$TAG, version=$VERSION)"


### PR DESCRIPTION
## Summary
Implements v0.3.5 lane 4: release checklist enforcement before publish.

### Added
- `scripts/release_checklist.sh`
  - validates tag format (`vX.Y.Z[-rcN]`)
  - validates matching changelog section (`## [X.Y.Z...]`)
  - validates release notes file exists (`docs/releases/v<version>.md`)
  - validates release notes include exact tag line
  - runs go/no-go doc structural guard (`scripts/ci_release_guard.sh --offline`)

### Workflow enforcement
- `.github/workflows/release.yml` now runs:
  - `scripts/release_checklist.sh --tag "${{ github.ref_name }}"`
  - before GoReleaser publish step

### Doc completeness backfill
- Added `docs/releases/v0.3.4.md`
- Added `CHANGELOG` entry for `[0.3.4]`

Closes #86.

## Validation
- `scripts/release_checklist.sh --tag v0.3.4` ✅
- `scripts/release_checklist.sh --tag v0.3.4-rc1` ✅
- `go test ./...` ✅
- `go vet ./...` ✅
