### PR TITLE
ci(ops): add scheduled SLO canary workflow (v0.3.5 lane 5)

### DIFF
--- a/.github/workflows/slo-canary.yml
+++ b/.github/workflows/slo-canary.yml
@@ -1,0 +1,58 @@
+name: SLO Canary
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily at 13:15 UTC
+    - cron: "15 13 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  slo-canary:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Build cortex binary
+        run: go build -o /tmp/cortex ./cmd/cortex
+
+      - name: Seed canary DB fixture
+        run: |
+          cat > /tmp/canary-memory.md <<'EOF'
+          # Canary Fixture
+
+          Deployment policy: use staged rollout with strict rollback gates.
+          On-call owner: reliability.
+          EOF
+
+          /tmp/cortex --db /tmp/canary.db import /tmp/canary-memory.md
+
+      - name: Run SLO snapshot
+        run: |
+          scripts/slo_snapshot.sh \
+            --cortex-bin /tmp/cortex \
+            --db /tmp/canary.db \
+            --query "deployment policy" \
+            --mode keyword \
+            --output /tmp/slo-canary.json \
+            --markdown /tmp/slo-canary.md
+
+      - name: Add markdown summary to run
+        run: |
+          cat /tmp/slo-canary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload SLO artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: slo-canary-${{ github.run_id }}
+          path: |
+            /tmp/slo-canary.json
+            /tmp/slo-canary.md
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ No more black-box memory. No more hoping the agent remembers correctly.
 
 For ops posture at scale, see the DB growth runbook: [`docs/ops-db-growth-guardrails.md`](docs/ops-db-growth-guardrails.md).
 For checkpoint timing artifacts, run: `scripts/slo_snapshot.sh --output /tmp/slo.json --markdown /tmp/slo.md`.
+A scheduled CI canary uploads daily SLO artifacts (`.github/workflows/slo-canary.yml`).
 
 ### 📤 Export & Portability — Your Memory Is Yours
 

--- a/docs/ops-db-growth-guardrails.md
+++ b/docs/ops-db-growth-guardrails.md
@@ -116,6 +116,8 @@ scripts/slo_snapshot.sh \
 
 The script exits non-zero if any checkpoint fails.
 
+CI canary is also available via GitHub Actions workflow: `.github/workflows/slo-canary.yml`.
+
 ## Related Tracking
 - #64 — DB growth guardrails follow-through
 - #74 — post-v0.3.4 reliability wave


### PR DESCRIPTION
## Summary
Implements v0.3.5 lane 5 by adding automated SLO canary runs with artifact history.

### Added
- New workflow: `.github/workflows/slo-canary.yml`
  - triggers: daily schedule + manual dispatch
  - builds cortex binary
  - seeds a tiny canary DB fixture
  - runs `scripts/slo_snapshot.sh`
  - uploads JSON + markdown artifacts
  - posts markdown summary to job summary

### Docs
- README mentions scheduled SLO canary workflow
- DB growth runbook references the CI canary workflow

Closes #88.

## Validation
- `go test ./...` ✅
- `go vet ./...` ✅
- local canary run ✅
  - `scripts/slo_snapshot.sh --cortex-bin /tmp/cortex --db /tmp/canary-local.db ...`
