### PR TITLE
feat(ops): add threshold bands to SLO snapshot + canary gating (lane 6)

### DIFF
--- a/.github/workflows/slo-canary.yml
+++ b/.github/workflows/slo-canary.yml
@@ -41,6 +41,12 @@ jobs:
             --db /tmp/canary.db \
             --query "deployment policy" \
             --mode keyword \
+            --warn-stats-ms 1500 \
+            --warn-search-ms 1500 \
+            --warn-conflicts-ms 2000 \
+            --fail-stats-ms 5000 \
+            --fail-search-ms 5000 \
+            --fail-conflicts-ms 7000 \
             --output /tmp/slo-canary.json \
             --markdown /tmp/slo-canary.md
 

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ cortex search "deployment policy" --include-superseded
 No more black-box memory. No more hoping the agent remembers correctly.
 
 For ops posture at scale, see the DB growth runbook: [`docs/ops-db-growth-guardrails.md`](docs/ops-db-growth-guardrails.md).
-For checkpoint timing artifacts, run: `scripts/slo_snapshot.sh --output /tmp/slo.json --markdown /tmp/slo.md`.
+For checkpoint timing artifacts, run: `scripts/slo_snapshot.sh --warn-stats-ms 3000 --warn-search-ms 5000 --warn-conflicts-ms 5000 --fail-stats-ms 7000 --fail-search-ms 10000 --fail-conflicts-ms 12000 --output /tmp/slo.json --markdown /tmp/slo.md`.
 A scheduled CI canary uploads daily SLO artifacts (`.github/workflows/slo-canary.yml`).
 
 ### 📤 Export & Portability — Your Memory Is Yours

--- a/docs/ops-db-growth-guardrails.md
+++ b/docs/ops-db-growth-guardrails.md
@@ -99,7 +99,10 @@ If checkpoints regress materially, file/track under #64 and attach command outpu
 Use the helper script to capture checkpoint timing + status in one artifact:
 
 ```bash
-scripts/slo_snapshot.sh --output /tmp/slo.json --markdown /tmp/slo.md
+scripts/slo_snapshot.sh \
+  --warn-stats-ms 3000 --warn-search-ms 5000 --warn-conflicts-ms 5000 \
+  --fail-stats-ms 7000 --fail-search-ms 10000 --fail-conflicts-ms 12000 \
+  --output /tmp/slo.json --markdown /tmp/slo.md
 ```
 
 Optional production-style run (hybrid search):
@@ -114,7 +117,7 @@ scripts/slo_snapshot.sh \
   --markdown /tmp/slo-hybrid.md
 ```
 
-The script exits non-zero if any checkpoint fails.
+The script emits `PASS`, `WARN`, or `FAIL` status in output artifacts and exits non-zero on command failures or fail-threshold breaches (unless `--warn-only-thresholds` is set).
 
 CI canary is also available via GitHub Actions workflow: `.github/workflows/slo-canary.yml`.
 

--- a/scripts/slo_snapshot.sh
+++ b/scripts/slo_snapshot.sh
@@ -9,21 +9,30 @@ Usage:
   scripts/slo_snapshot.sh [options]
 
 Options:
-  --db <path>              Cortex DB path (optional)
-  --cortex-bin <path>      Cortex binary/command (default: cortex)
-  --query <text>           Search query for checkpoint (default: "memory")
-  --mode <mode>            Search mode: keyword|semantic|hybrid (default: keyword)
-  --embed <provider/model> Embed model for semantic/hybrid search (optional)
-  --limit <n>              Search result limit (default: 10)
-  --conflict-limit <n>     Conflict limit for checkpoint (default: 100)
-  --output <file>          JSON report output path
-  --markdown <file>        Optional markdown summary output path
-  -h, --help               Show this help
+  --db <path>                  Cortex DB path (optional)
+  --cortex-bin <path>          Cortex binary/command (default: cortex)
+  --query <text>               Search query for checkpoint (default: "memory")
+  --mode <mode>                Search mode: keyword|semantic|hybrid (default: keyword)
+  --embed <provider/model>     Embed model for semantic/hybrid search (optional)
+  --limit <n>                  Search result limit (default: 10)
+  --conflict-limit <n>         Conflict limit for checkpoint (default: 100)
+  --warn-stats-ms <n>          Warn threshold for stats duration (ms, 0=disabled)
+  --warn-search-ms <n>         Warn threshold for search duration (ms, 0=disabled)
+  --warn-conflicts-ms <n>      Warn threshold for conflicts duration (ms, 0=disabled)
+  --fail-stats-ms <n>          Fail threshold for stats duration (ms, 0=disabled)
+  --fail-search-ms <n>         Fail threshold for search duration (ms, 0=disabled)
+  --fail-conflicts-ms <n>      Fail threshold for conflicts duration (ms, 0=disabled)
+  --warn-only-thresholds       Do not fail exit code on threshold fail breaches
+  --output <file>              JSON report output path
+  --markdown <file>            Optional markdown summary output path
+  -h, --help                   Show this help
 
 Examples:
   scripts/slo_snapshot.sh
   scripts/slo_snapshot.sh --db ~/.cortex/cortex.db --query "deployment" --mode hybrid --embed ollama/nomic-embed-text
   scripts/slo_snapshot.sh --output /tmp/slo.json --markdown /tmp/slo.md
+  scripts/slo_snapshot.sh --warn-stats-ms 3000 --warn-search-ms 5000 --warn-conflicts-ms 5000 \
+    --fail-stats-ms 7000 --fail-search-ms 10000 --fail-conflicts-ms 12000
 EOF
 }
 
@@ -41,6 +50,13 @@ MODE="keyword"
 EMBED=""
 LIMIT="10"
 CONFLICT_LIMIT="100"
+WARN_STATS_MS="0"
+WARN_SEARCH_MS="0"
+WARN_CONFLICTS_MS="0"
+FAIL_STATS_MS="0"
+FAIL_SEARCH_MS="0"
+FAIL_CONFLICTS_MS="0"
+WARN_ONLY_THRESHOLDS=0
 OUTPUT_PATH=""
 MARKDOWN_PATH=""
 
@@ -60,6 +76,20 @@ while [[ $# -gt 0 ]]; do
       LIMIT="${2:-}"; shift 2 ;;
     --conflict-limit)
       CONFLICT_LIMIT="${2:-}"; shift 2 ;;
+    --warn-stats-ms)
+      WARN_STATS_MS="${2:-}"; shift 2 ;;
+    --warn-search-ms)
+      WARN_SEARCH_MS="${2:-}"; shift 2 ;;
+    --warn-conflicts-ms)
+      WARN_CONFLICTS_MS="${2:-}"; shift 2 ;;
+    --fail-stats-ms)
+      FAIL_STATS_MS="${2:-}"; shift 2 ;;
+    --fail-search-ms)
+      FAIL_SEARCH_MS="${2:-}"; shift 2 ;;
+    --fail-conflicts-ms)
+      FAIL_CONFLICTS_MS="${2:-}"; shift 2 ;;
+    --warn-only-thresholds)
+      WARN_ONLY_THRESHOLDS=1; shift ;;
     --output)
       OUTPUT_PATH="${2:-}"; shift 2 ;;
     --markdown)
@@ -86,6 +116,31 @@ if ! [[ "$LIMIT" =~ ^[0-9]+$ ]] || [[ "$LIMIT" -le 0 ]]; then
 fi
 if ! [[ "$CONFLICT_LIMIT" =~ ^[0-9]+$ ]] || [[ "$CONFLICT_LIMIT" -le 0 ]]; then
   echo "Invalid --conflict-limit: $CONFLICT_LIMIT" >&2
+  exit 1
+fi
+
+for threshold_name in WARN_STATS_MS WARN_SEARCH_MS WARN_CONFLICTS_MS FAIL_STATS_MS FAIL_SEARCH_MS FAIL_CONFLICTS_MS; do
+  threshold_val="${!threshold_name}"
+  if ! [[ "$threshold_val" =~ ^[0-9]+$ ]]; then
+    echo "Invalid threshold value for $threshold_name: $threshold_val" >&2
+    exit 1
+  fi
+  if [[ "$threshold_val" -lt 0 ]]; then
+    echo "Threshold must be >= 0 for $threshold_name" >&2
+    exit 1
+  fi
+done
+
+if [[ "$FAIL_STATS_MS" -gt 0 && "$WARN_STATS_MS" -gt "$FAIL_STATS_MS" ]]; then
+  echo "Invalid thresholds: WARN_STATS_MS > FAIL_STATS_MS" >&2
+  exit 1
+fi
+if [[ "$FAIL_SEARCH_MS" -gt 0 && "$WARN_SEARCH_MS" -gt "$FAIL_SEARCH_MS" ]]; then
+  echo "Invalid thresholds: WARN_SEARCH_MS > FAIL_SEARCH_MS" >&2
+  exit 1
+fi
+if [[ "$FAIL_CONFLICTS_MS" -gt 0 && "$WARN_CONFLICTS_MS" -gt "$FAIL_CONFLICTS_MS" ]]; then
+  echo "Invalid thresholds: WARN_CONFLICTS_MS > FAIL_CONFLICTS_MS" >&2
   exit 1
 fi
 
@@ -125,23 +180,42 @@ cleanup() {
 trap cleanup EXIT
 
 append_step() {
-  local name="$1" cmd="$2" rc="$3" duration="$4"
-  python3 - "$steps_file" "$name" "$cmd" "$rc" "$duration" <<'PY'
+  local name="$1" cmd="$2" rc="$3" duration="$4" warn_ms="$5" fail_ms="$6" warn_only="$7"
+  python3 - "$steps_file" "$name" "$cmd" "$rc" "$duration" "$warn_ms" "$fail_ms" "$warn_only" <<'PY'
 import json, sys
-path, name, cmd, rc, dur = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4]), int(sys.argv[5])
+path = sys.argv[1]
+name = sys.argv[2]
+cmd = sys.argv[3]
+rc = int(sys.argv[4])
+dur = int(sys.argv[5])
+warn_ms = int(sys.argv[6])
+fail_ms = int(sys.argv[7])
+warn_only = bool(int(sys.argv[8]))
+
+threshold_status = "none"
+if fail_ms > 0 and dur > fail_ms:
+    threshold_status = "fail"
+elif warn_ms > 0 and dur > warn_ms:
+    threshold_status = "warn"
+
+ok = (rc == 0) and (threshold_status != "fail" or warn_only)
+
 with open(path, "a", encoding="utf-8") as f:
     f.write(json.dumps({
         "name": name,
         "command": cmd,
         "exit_code": rc,
         "duration_ms": dur,
-        "ok": rc == 0,
+        "threshold_warn_ms": warn_ms,
+        "threshold_fail_ms": fail_ms,
+        "threshold_status": threshold_status,
+        "ok": ok,
     }) + "\n")
 PY
 }
 
 run_checkpoint() {
-  local name="$1"; shift
+  local name="$1" warn_ms="$2" fail_ms="$3"; shift 3
   local -a cmd=("$@")
   local cmd_str
   cmd_str="$(printf '%q ' "${cmd[@]}")"
@@ -155,7 +229,7 @@ run_checkpoint() {
   end="$(now_ms)"
   dur=$((end - start))
 
-  append_step "$name" "$cmd_str" "$rc" "$dur"
+  append_step "$name" "$cmd_str" "$rc" "$dur" "$warn_ms" "$fail_ms" "$WARN_ONLY_THRESHOLDS"
 }
 
 common_prefix=("$CORTEX_BIN")
@@ -170,19 +244,36 @@ if [[ -n "$EMBED" ]]; then
 fi
 conflicts_cmd=("${common_prefix[@]}" conflicts --limit "$CONFLICT_LIMIT" --json)
 
-run_checkpoint "stats" "${stats_cmd[@]}"
-run_checkpoint "search" "${search_cmd[@]}"
-run_checkpoint "conflicts" "${conflicts_cmd[@]}"
+run_checkpoint "stats" "$WARN_STATS_MS" "$FAIL_STATS_MS" "${stats_cmd[@]}"
+run_checkpoint "search" "$WARN_SEARCH_MS" "$FAIL_SEARCH_MS" "${search_cmd[@]}"
+run_checkpoint "conflicts" "$WARN_CONFLICTS_MS" "$FAIL_CONFLICTS_MS" "${conflicts_cmd[@]}"
 
-python3 - "$steps_file" "$OUTPUT_PATH" "$DB_PATH" "$CORTEX_BIN" "$QUERY" "$MODE" "$LIMIT" "$CONFLICT_LIMIT" <<'PY'
+python3 - "$steps_file" "$OUTPUT_PATH" "$DB_PATH" "$CORTEX_BIN" "$QUERY" "$MODE" "$LIMIT" "$CONFLICT_LIMIT" "$WARN_ONLY_THRESHOLDS" <<'PY'
 import json, sys, datetime
-steps_path, out_path, db_path, cortex_bin, query, mode, limit, conflict_limit = sys.argv[1:9]
+steps_path, out_path, db_path, cortex_bin, query, mode, limit, conflict_limit, warn_only_raw = sys.argv[1:10]
+warn_only = bool(int(warn_only_raw))
 steps = []
 with open(steps_path, "r", encoding="utf-8") as f:
     for line in f:
         line = line.strip()
         if line:
             steps.append(json.loads(line))
+
+threshold_warn_count = sum(1 for s in steps if s.get("threshold_status") == "warn")
+threshold_fail_count = sum(1 for s in steps if s.get("threshold_status") == "fail")
+command_fail_count = sum(1 for s in steps if int(s.get("exit_code", 1)) != 0)
+overall_ok = all(bool(s.get("ok")) for s in steps)
+
+if command_fail_count > 0:
+    overall_status = "FAIL"
+elif threshold_fail_count > 0 and warn_only:
+    overall_status = "WARN"
+elif threshold_fail_count > 0:
+    overall_status = "FAIL"
+elif threshold_warn_count > 0:
+    overall_status = "WARN"
+else:
+    overall_status = "PASS"
 
 report = {
     "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
@@ -196,8 +287,13 @@ report = {
     "conflicts": {
         "limit": int(conflict_limit),
     },
+    "thresholds_warn_only": warn_only,
     "checkpoints": steps,
-    "overall_ok": all(step.get("ok") for step in steps),
+    "threshold_warn_count": threshold_warn_count,
+    "threshold_fail_count": threshold_fail_count,
+    "command_fail_count": command_fail_count,
+    "overall_status": overall_status,
+    "overall_ok": overall_ok,
 }
 
 with open(out_path, "w", encoding="utf-8") as f:
@@ -221,12 +317,19 @@ lines.append(f"- Binary: `{report['cortex_bin']}`")
 lines.append(f"- Search: `{report['search']['query']}` (mode={report['search']['mode']}, limit={report['search']['limit']})")
 lines.append(f"- Conflicts limit: `{report['conflicts']['limit']}`")
 lines.append("")
-lines.append("| Checkpoint | Exit | Duration (ms) |")
-lines.append("|---|---:|---:|")
+lines.append("| Checkpoint | Exit | Duration (ms) | Threshold (warn/fail) | Threshold status |")
+lines.append("|---|---:|---:|---:|---:|")
 for step in report["checkpoints"]:
-    lines.append(f"| {step['name']} | {step['exit_code']} | {step['duration_ms']} |")
+    warn_ms = step.get("threshold_warn_ms", 0)
+    fail_ms = step.get("threshold_fail_ms", 0)
+    lines.append(f"| {step['name']} | {step['exit_code']} | {step['duration_ms']} | {warn_ms}/{fail_ms} | {step.get('threshold_status', 'none')} |")
 lines.append("")
-lines.append(f"Overall: **{'PASS' if report['overall_ok'] else 'FAIL'}**")
+lines.append(f"- Threshold warn count: `{report.get('threshold_warn_count', 0)}`")
+lines.append(f"- Threshold fail count: `{report.get('threshold_fail_count', 0)}`")
+lines.append(f"- Command fail count: `{report.get('command_fail_count', 0)}`")
+lines.append(f"- Warn-only thresholds: `{report.get('thresholds_warn_only', False)}`")
+lines.append("")
+lines.append(f"Overall: **{report.get('overall_status', 'FAIL')}**")
 
 with open(dst, "w", encoding="utf-8") as f:
     f.write("\n".join(lines) + "\n")
@@ -237,7 +340,7 @@ python3 - "$OUTPUT_PATH" <<'PY'
 import json, sys
 with open(sys.argv[1], 'r', encoding='utf-8') as f:
     report = json.load(f)
-status = "PASS" if report.get("overall_ok") else "FAIL"
+status = report.get("overall_status", "FAIL")
 print(f"SLO snapshot: {status}")
 print(f"JSON: {sys.argv[1]}")
 PY


### PR DESCRIPTION
## Summary
Implements lane 6 by upgrading SLO snapshot/canary with configurable threshold bands.

### Added to `scripts/slo_snapshot.sh`
- warn thresholds:
  - `--warn-stats-ms`
  - `--warn-search-ms`
  - `--warn-conflicts-ms`
- fail thresholds:
  - `--fail-stats-ms`
  - `--fail-search-ms`
  - `--fail-conflicts-ms`
- `--warn-only-thresholds` to downgrade fail-threshold breaches to WARN for exit behavior

### Output improvements
- JSON now includes per-checkpoint threshold metadata and status (`none|warn|fail`)
- report-level fields:
  - `threshold_warn_count`
  - `threshold_fail_count`
  - `command_fail_count`
  - `thresholds_warn_only`
  - `overall_status` (`PASS|WARN|FAIL`)
- markdown summary includes threshold columns/status

### Canary workflow
- `.github/workflows/slo-canary.yml` now passes explicit warn/fail thresholds.

### Docs
- README and ops runbook updated with thresholded snapshot examples and status semantics.

Closes #92.

## Validation
- `go test ./...` ✅
- `go vet ./...` ✅
- PASS case ✅
- WARN case ✅
- FAIL case (exit 1) ✅
- WARN-only threshold downgrade ✅
