### PR TITLE
feat(ops): lane 8 budget policy overlays for canary + release gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   release:
@@ -21,7 +22,9 @@ jobs:
           go-version: "1.24"
 
       - name: Release checklist guard
-        run: scripts/release_checklist.sh --tag "${{ github.ref_name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: scripts/release_checklist.sh --tag "${{ github.ref_name }}" --repo "${{ github.repository }}" --require-latest-slo-pass
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/slo-canary.yml
+++ b/.github/workflows/slo-canary.yml
@@ -149,11 +149,23 @@ jobs:
               --output-markdown /tmp/slo-trend.md
           fi
 
+      - name: Run SLO budget policy guard
+        run: |
+          python3 scripts/slo_budget_guard.py \
+            --snapshot /tmp/slo-canary.json \
+            --trend /tmp/slo-trend.json \
+            --warn-total-ms 5000 \
+            --fail-total-ms 15000 \
+            --output-json /tmp/slo-budget.json \
+            --output-markdown /tmp/slo-budget.md
+
       - name: Add markdown summary to run
         run: |
           cat /tmp/slo-canary.md >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           cat /tmp/slo-trend.md >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/slo-budget.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload SLO artifacts
         uses: actions/upload-artifact@v4
@@ -164,4 +176,6 @@ jobs:
             /tmp/slo-canary.md
             /tmp/slo-trend.json
             /tmp/slo-trend.md
+            /tmp/slo-budget.json
+            /tmp/slo-budget.md
           retention-days: 30

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ No more black-box memory. No more hoping the agent remembers correctly.
 
 For ops posture at scale, see the DB growth runbook: [`docs/ops-db-growth-guardrails.md`](docs/ops-db-growth-guardrails.md).
 For checkpoint timing artifacts, run: `scripts/slo_snapshot.sh --warn-stats-ms 3000 --warn-search-ms 5000 --warn-conflicts-ms 5000 --fail-stats-ms 7000 --fail-search-ms 10000 --fail-conflicts-ms 12000 --output /tmp/slo.json --markdown /tmp/slo.md`.
-A scheduled CI canary uploads daily SLO artifacts and trend-comparison outputs against the previous successful run (`.github/workflows/slo-canary.yml`).
+A scheduled CI canary uploads daily SLO artifacts, trend comparisons, and budget-policy results against previous successful runs (`.github/workflows/slo-canary.yml`).
 
 ### 📤 Export & Portability — Your Memory Is Yours
 

--- a/docs/ops-db-growth-guardrails.md
+++ b/docs/ops-db-growth-guardrails.md
@@ -120,7 +120,7 @@ scripts/slo_snapshot.sh \
 The script emits `PASS`, `WARN`, or `FAIL` status in output artifacts and exits non-zero on command failures or fail-threshold breaches (unless `--warn-only-thresholds` is set).
 
 CI canary is also available via GitHub Actions workflow: `.github/workflows/slo-canary.yml`.
-It now performs trend comparison against the previous successful canary artifact (`scripts/slo_trend_compare.py`) to detect relative regressions.
+It performs trend comparison against the previous successful canary artifact (`scripts/slo_trend_compare.py`) and applies budget policy overlays (`scripts/slo_budget_guard.py`) before artifact publish.
 
 ## Related Tracking
 - #64 — DB growth guardrails follow-through

--- a/scripts/release_checklist.sh
+++ b/scripts/release_checklist.sh
@@ -9,23 +9,32 @@ Usage:
   scripts/release_checklist.sh --tag vX.Y.Z[-rcN]
 
 Options:
-  --tag <tag>          Release tag (defaults to GITHUB_REF_NAME)
-  -h, --help           Show help
+  --tag <tag>                   Release tag (defaults to GITHUB_REF_NAME)
+  --repo <owner/repo>           GitHub repo (defaults to GITHUB_REPOSITORY)
+  --require-latest-slo-pass     Require latest completed SLO Canary run to be success
+  -h, --help                    Show help
 
 Checks:
 1) tag format is valid (v<semver>[-rcN])
 2) CHANGELOG contains a matching section: ## [<version>]
 3) docs/releases/v<version>.md exists
 4) go/no-go doc structural guard passes (offline mode)
+5) (optional) latest SLO Canary workflow run status is success
 EOF
 }
 
 TAG="${GITHUB_REF_NAME:-}"
+REPO="${GITHUB_REPOSITORY:-}"
+REQUIRE_LATEST_SLO_PASS=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --tag)
       TAG="${2:-}"; shift 2 ;;
+    --repo)
+      REPO="${2:-}"; shift 2 ;;
+    --require-latest-slo-pass)
+      REQUIRE_LATEST_SLO_PASS=1; shift ;;
     -h|--help)
       usage; exit 0 ;;
     *)
@@ -70,5 +79,47 @@ if ! rg -q "Tag:\s*\`$TAG\`" "$RELEASE_NOTES"; then
 fi
 
 scripts/ci_release_guard.sh --offline
+
+if [[ "$REQUIRE_LATEST_SLO_PASS" -eq 1 ]]; then
+  if [[ -z "$REPO" ]]; then
+    echo "ERROR: --repo or GITHUB_REPOSITORY required when --require-latest-slo-pass is set" >&2
+    exit 1
+  fi
+  if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "ERROR: GITHUB_TOKEN required for --require-latest-slo-pass" >&2
+    exit 1
+  fi
+
+  python3 - "$REPO" <<'PY'
+import json
+import os
+import sys
+import urllib.request
+
+repo = sys.argv[1]
+token = os.environ.get("GITHUB_TOKEN", "")
+
+url = f"https://api.github.com/repos/{repo}/actions/workflows/slo-canary.yml/runs?status=completed&per_page=10"
+req = urllib.request.Request(url)
+req.add_header("Accept", "application/vnd.github+json")
+req.add_header("Authorization", f"Bearer {token}")
+req.add_header("User-Agent", "cortex-release-checklist")
+
+with urllib.request.urlopen(req, timeout=20) as resp:
+    data = json.loads(resp.read().decode("utf-8"))
+
+runs = data.get("workflow_runs", [])
+if not runs:
+    raise SystemExit("ERROR: no completed SLO Canary runs found")
+
+latest = runs[0]
+conclusion = str(latest.get("conclusion", "")).lower()
+run_id = latest.get("id")
+if conclusion != "success":
+    raise SystemExit(f"ERROR: latest SLO Canary run {run_id} is not successful (conclusion={conclusion})")
+
+print(f"release-checklist: latest SLO Canary run {run_id} is success")
+PY
+fi
 
 echo "release-checklist: PASS (tag=$TAG, version=$VERSION)"

--- a/scripts/slo_budget_guard.py
+++ b/scripts/slo_budget_guard.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Budget-policy guard for SLO canary artifacts.
+
+Evaluates canary/runtime budget constraints (total duration + trend status) and
+emits PASS/WARN/FAIL with machine-readable + markdown outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Evaluate SLO budget policy")
+    p.add_argument("--snapshot", required=True, help="Path to slo snapshot JSON")
+    p.add_argument("--trend", help="Path to slo trend JSON (optional)")
+    p.add_argument("--warn-total-ms", type=int, default=4000)
+    p.add_argument("--fail-total-ms", type=int, default=12000)
+    p.add_argument("--warn-only-fail-thresholds", action="store_true")
+    p.add_argument("--output-json", required=True)
+    p.add_argument("--output-markdown")
+    return p.parse_args()
+
+
+def load_json(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_markdown(path: str, report: dict[str, Any]) -> None:
+    lines: list[str] = []
+    lines.append("# Cortex SLO Budget Guard")
+    lines.append("")
+    lines.append(f"- Overall status: **{report['overall_status']}**")
+    lines.append(f"- Snapshot status: `{report['snapshot_status']}`")
+    lines.append(f"- Trend status: `{report['trend_status']}`")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|---|---:|")
+    lines.append(f"| Total duration (ms) | {report['total_duration_ms']} |")
+    lines.append(f"| Warn total threshold (ms) | {report['warn_total_ms']} |")
+    lines.append(f"| Fail total threshold (ms) | {report['fail_total_ms']} |")
+    lines.append("")
+    if report.get("reasons"):
+        lines.append("## Reasons")
+        for r in report["reasons"]:
+            lines.append(f"- {r}")
+        lines.append("")
+
+    lines.append(f"- Warn-only fail thresholds: `{report['warn_only_fail_thresholds']}`")
+    Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.warn_total_ms < 0 or args.fail_total_ms < 0:
+        raise SystemExit("thresholds must be >= 0")
+    if args.fail_total_ms > 0 and args.warn_total_ms > args.fail_total_ms:
+        raise SystemExit("warn threshold cannot exceed fail threshold")
+
+    snapshot = load_json(args.snapshot)
+    trend = None
+    if args.trend and Path(args.trend).exists():
+        trend = load_json(args.trend)
+
+    checkpoints = snapshot.get("checkpoints", [])
+    total_duration_ms = int(sum(int(cp.get("duration_ms", 0)) for cp in checkpoints))
+
+    snapshot_status = str(snapshot.get("overall_status", "UNKNOWN"))
+    trend_status = str(trend.get("overall_status", "NO_TREND")) if trend else "NO_TREND"
+
+    overall_status = "PASS"
+    reasons: list[str] = []
+
+    if snapshot_status == "FAIL":
+        overall_status = "FAIL"
+        reasons.append("snapshot reported FAIL")
+    elif snapshot_status == "WARN":
+        if overall_status != "FAIL":
+            overall_status = "WARN"
+        reasons.append("snapshot reported WARN")
+
+    if args.fail_total_ms > 0 and total_duration_ms > args.fail_total_ms:
+        overall_status = "FAIL"
+        reasons.append(
+            f"total duration {total_duration_ms}ms exceeded fail threshold {args.fail_total_ms}ms"
+        )
+    elif args.warn_total_ms > 0 and total_duration_ms > args.warn_total_ms:
+        if overall_status != "FAIL":
+            overall_status = "WARN"
+        reasons.append(
+            f"total duration {total_duration_ms}ms exceeded warn threshold {args.warn_total_ms}ms"
+        )
+
+    if trend_status == "FAIL":
+        overall_status = "FAIL"
+        reasons.append("trend comparison reported FAIL")
+    elif trend_status == "WARN":
+        if overall_status != "FAIL":
+            overall_status = "WARN"
+        reasons.append("trend comparison reported WARN")
+
+    if overall_status == "FAIL" and args.warn_only_fail_thresholds:
+        overall_status = "WARN"
+        reasons.append("FAIL downgraded to WARN by warn-only policy")
+
+    report = {
+        "snapshot_status": snapshot_status,
+        "trend_status": trend_status,
+        "total_duration_ms": total_duration_ms,
+        "warn_total_ms": args.warn_total_ms,
+        "fail_total_ms": args.fail_total_ms,
+        "warn_only_fail_thresholds": args.warn_only_fail_thresholds,
+        "overall_status": overall_status,
+        "reasons": reasons,
+    }
+
+    Path(args.output_json).write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if args.output_markdown:
+        write_markdown(args.output_markdown, report)
+
+    print(f"SLO budget guard: {overall_status}")
+    print(f"JSON: {args.output_json}")
+    if args.output_markdown:
+        print(f"Markdown: {args.output_markdown}")
+
+    return 1 if overall_status == "FAIL" and not args.warn_only_fail_thresholds else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Implements lane 8: budget policy overlays for canary + release gates.

### Added
- `scripts/slo_budget_guard.py`
  - evaluates canary budget policy from snapshot + trend artifacts
  - supports total-duration warn/fail thresholds
  - consumes trend status (`PASS|WARN|FAIL|NO_BASELINE`)
  - emits JSON + markdown
  - exits non-zero on FAIL (unless warn-only)

### Canary workflow integration
- `.github/workflows/slo-canary.yml`
  - runs `slo_budget_guard.py` after trend compare
  - appends budget markdown to run summary
  - uploads `slo-budget.json` + `slo-budget.md` artifacts

### Release gate overlay
- `scripts/release_checklist.sh`
  - new option: `--require-latest-slo-pass`
  - when enabled, checks latest completed `slo-canary.yml` run is success via GitHub API
- `.github/workflows/release.yml`
  - checklist now runs with `--require-latest-slo-pass`
  - step gets `GITHUB_TOKEN` and workflow adds `actions: read` permission

### Docs
- README + `docs/ops-db-growth-guardrails.md` updated to mention budget-policy overlay.

Closes #105.

## Validation
- `go test ./...` ✅
- `go vet ./...` ✅
- `slo_budget_guard.py` pass/warn/fail/warn-only paths ✅
- `release_checklist.sh --require-latest-slo-pass` ✅
