### PR TITLE
feat(visualizer): ship Memory Quality Engine composite + explainability

### DIFF
--- a/docs/visualizer/contracts-v1.md
+++ b/docs/visualizer/contracts-v1.md
@@ -77,17 +77,57 @@ Contract notes:
 {
   "schema_version": "v1",
   "data": {
+    "formula_version": "mqe-v1",
     "score": 78,
-    "delta_24h": -4,
-    "factors": [
-      { "key": "conflict_density", "value": 0.32, "weight": 0.25, "impact": -7 },
-      { "key": "stale_pressure", "value": 0.44, "weight": 0.20, "impact": -5 },
-      { "key": "confidence_health", "value": 0.79, "weight": 0.30, "impact": 8 },
-      { "key": "extraction_yield", "value": 0.69, "weight": 0.25, "impact": 2 }
+    "score_status": "PASS|WARN|FAIL|NO_DATA",
+    "delta_24h": -1.6,
+    "trend_24h": [
+      { "ts": "2026-02-20T10:24:53Z", "score": 79.1 },
+      { "ts": "2026-02-20T16:24:58Z", "score": 77.5 }
+    ],
+    "factors": {
+      "conflict_density": 0.22,
+      "stale_pressure": 0.18,
+      "confidence_health": 0.86,
+      "extraction_yield": 0.74
+    },
+    "factors_v2": [
+      {
+        "key": "stale_ratio",
+        "label": "Stale Ratio",
+        "definition": "Share of records in freshness.older over total freshness buckets.",
+        "source": "stats.freshness.older / (today + this_week + this_month + older)",
+        "direction": "penalty|bonus",
+        "weight": 0.22,
+        "value": 0.18,
+        "quality_value": 0.82,
+        "status": "PASS|WARN|FAIL|NO_DATA",
+        "weighted_score": 18.0,
+        "remediation": "Run stale-fact cleanup and reinforce active facts used in current workflows."
+      }
+    ],
+    "top_drivers": [
+      {
+        "key": "duplication_noise",
+        "label": "Duplication / Noise Pressure",
+        "status": "WARN",
+        "impact_points": 6.2,
+        "why": "KV fact dominance plus growth-spike penalties to flag likely ingestion noise.",
+        "remediation": "Tighten low-signal ingestion filters and dedupe thresholds for repetitive captures."
+      }
     ],
     "actions": [
-      "tighten low-signal ingestion filter window"
-    ]
+      "Tighten low-signal ingestion filters and dedupe thresholds for repetitive captures.",
+      "Review conflict clusters and add supersession/tombstones for contradictory facts."
+    ],
+    "reproducibility": {
+      "formula": "score = round(sum(weight_i * quality_i) / sum(weight_i) * 100); quality_i = metric_i for bonus factors, (1 - metric_i) for penalty factors",
+      "inputs": {
+        "stats.confidence_distribution": { "high": 0, "medium": 0, "low": 0, "total": 0 },
+        "stats.freshness": { "today": 0, "this_week": 0, "this_month": 0, "older": 0 },
+        "stats.growth": { "memories_24h": 0, "facts_24h": 0 }
+      }
+    }
   }
 }
 ```
@@ -217,9 +257,12 @@ Contract notes:
   "graph": {
     "focus": "fact_123",
     "bounds": { "max_hops": 2, "max_nodes": 200, "default_radius": 1 },
-    "vault_dir": "/abs/path/to/obsidian-vault",
-    "index_path": "/abs/path/to/obsidian-vault/index.md",
-    "obsidian_index_uri": "obsidian://open?path=/abs/path/to/obsidian-vault/index.md",
+    "vault_dir": "/abs/path/to/obsidian-vault/_cortex_visualizer",
+    "index_path": "/abs/path/to/obsidian-vault/_cortex_visualizer/cortex-visualizer-dashboard.md",
+    "obsidian_index_uri": "obsidian://open?path=/abs/path/to/obsidian-vault/_cortex_visualizer/cortex-visualizer-dashboard.md",
+    "dashboard_file": "cortex-visualizer-dashboard.md",
+    "dashboard_path": "/abs/path/to/obsidian-vault/_cortex_visualizer/cortex-visualizer-dashboard.md",
+    "obsidian_dashboard_uri": "obsidian://open?path=/abs/path/to/obsidian-vault/_cortex_visualizer/cortex-visualizer-dashboard.md",
     "nodes": [
       {
         "id": "fact_123",
@@ -229,9 +272,10 @@ Contract notes:
         "timestamp": "2026-02-20T15:50:00Z",
         "source_ref": "docs/ops-db-growth-guardrails.md",
         "links": ["mem_88", "out_12"],
-        "note_file": "canary-regression-threshold-exceeded.md",
-        "note_path": "/abs/path/to/obsidian-vault/canary-regression-threshold-exceeded.md",
-        "obsidian_uri": "obsidian://open?path=/abs/path/to/obsidian-vault/canary-regression-threshold-exceeded.md"
+        "note_file": "cortex-visualizer-dashboard.md",
+        "note_path": "/abs/path/to/obsidian-vault/_cortex_visualizer/cortex-visualizer-dashboard.md",
+        "obsidian_uri": "obsidian://open?path=/abs/path/to/obsidian-vault/_cortex_visualizer/cortex-visualizer-dashboard.md",
+        "note_heading": "canary regression threshold exceeded"
       }
     ],
     "edges": [
@@ -240,6 +284,11 @@ Contract notes:
   }
 }
 ```
+
+Notes:
+- Adapter now targets a **single visual dashboard note** by default.
+- Dashboard note contains Mermaid diagrams + summary blocks derived from canonical payload.
+- Node-level open actions resolve to the same dashboard file (with node metadata in `note_heading`).
 
 ## Versioning Rules
 - Non-breaking additions: add nullable fields only

--- a/docs/visualizer/prototype-v1.html
+++ b/docs/visualizer/prototype-v1.html
@@ -127,11 +127,24 @@
           </div>
         </article>
         <article class="card">
-          <div class="title"><span>Memory Quality Engine</span><span class="pill">composite</span></div>
+          <div class="title"><span>Memory Quality Engine</span><span class="pill">composite + explainability</span></div>
+          <div class="small" id="qualityFormula">formula: —</div>
+          <div class="spark" style="height:76px;margin:8px 0 10px"><svg id="qualityTrendSvg" viewBox="0 0 500 120" preserveAspectRatio="none"></svg></div>
+
           <div class="small">Conflict density</div><div class="meter"><span id="mConflict" style="width:0%"></span></div>
           <div class="small">Stale ratio pressure</div><div class="meter"><span id="mStale" style="width:0%"></span></div>
           <div class="small">Confidence health</div><div class="meter"><span id="mConf" style="width:0%"></span></div>
           <div class="small">Extraction yield</div><div class="meter"><span id="mYield" style="width:0%"></span></div>
+
+          <div class="small" style="margin-top:8px">Top degradation drivers</div>
+          <ul id="qualityDrivers"></ul>
+
+          <table class="table" style="margin-top:8px">
+            <thead><tr><th>Factor</th><th>Status</th><th>Metric</th><th>W</th><th>Impact</th></tr></thead>
+            <tbody id="qualityFactorsBody"></tbody>
+          </table>
+
+          <div class="small" style="margin-top:8px">Recommended actions (top 2)</div>
           <ul id="actions"></ul>
         </article>
       </section>
@@ -510,7 +523,8 @@
       document.getElementById('releaseReadiness').textContent = ov.release_readiness || '—';
       document.getElementById('releaseReason').textContent = (d.ops?.events?.[0]?.message) || 'no active warnings';
       document.getElementById('qualityScore').textContent = `${d.quality?.score ?? '—'}/100`;
-      document.getElementById('qualityDelta').textContent = `${d.quality?.delta_24h ?? 0} in last 24h`;
+      const qDelta = Number(d.quality?.delta_24h ?? 0);
+      document.getElementById('qualityDelta').textContent = `${qDelta >= 0 ? '+' : ''}${qDelta.toFixed(1)} in last 24h`;
       document.getElementById('reasonP95').textContent = `${ov.reason_p95_latency_s ?? 0}s`;
       document.getElementById('factsGrowth').textContent = `+${fmtNum(ov.facts_24h_growth || 0)}`;
 
@@ -539,17 +553,52 @@
 
       renderTrend(document.getElementById('trendSvg'), d.ops?.trend || []);
 
-      const f = d.quality?.factors || {};
+      const q = d.quality || {};
+      document.getElementById('qualityFormula').textContent = `formula: ${q.formula_version || 'unknown'}`;
+      renderTrend(document.getElementById('qualityTrendSvg'), q.trend_24h || []);
+
+      const f = q.factors || {};
       document.getElementById('mConflict').style.width = `${Math.round((f.conflict_density || 0) * 100)}%`;
       document.getElementById('mStale').style.width = `${Math.round((f.stale_pressure || 0) * 100)}%`;
       document.getElementById('mConf').style.width = `${Math.round((f.confidence_health || 0) * 100)}%`;
       document.getElementById('mYield').style.width = `${Math.round((f.extraction_yield || 0) * 100)}%`;
 
+      const drivers = document.getElementById('qualityDrivers');
+      drivers.innerHTML = '';
+      (q.top_drivers || []).slice(0, 3).forEach(dv => {
+        const li = document.createElement('li');
+        li.textContent = `${dv.label} (${dv.status}) • impact ${Number(dv.impact_points || 0).toFixed(1)}pts`;
+        li.title = `${dv.why || ''}\nRemediation: ${dv.remediation || ''}`;
+        drivers.appendChild(li);
+      });
+      if (!drivers.children.length) {
+        const li = document.createElement('li');
+        li.textContent = 'No active degradation drivers.';
+        drivers.appendChild(li);
+      }
+
+      const qualityRows = document.getElementById('qualityFactorsBody');
+      qualityRows.innerHTML = '';
+      (q.factors_v2 || []).forEach(fx => {
+        const tr = document.createElement('tr');
+        const metric = fx.value == null ? 'n/a' : `${(Number(fx.value) * 100).toFixed(1)}%`;
+        const impact = fx.weighted_score == null ? '0.0' : Number(fx.weighted_score).toFixed(1);
+        const statusClass = gateStatusClass(fx.status);
+        tr.innerHTML = `<td>${fx.label}</td><td><span class="dot ${statusClass}"></span>${fx.status}</td><td>${metric}</td><td>${Number(fx.weight || 0).toFixed(2)}</td><td>${impact}</td>`;
+        tr.title = `${fx.definition || 'No definition'}\nSource: ${fx.source || 'n/a'}`;
+        qualityRows.appendChild(tr);
+      });
+
       const actions = document.getElementById('actions');
       actions.innerHTML = '';
-      (d.quality?.actions || []).forEach(a => {
+      (q.actions || []).slice(0, 2).forEach(a => {
         const li = document.createElement('li'); li.textContent = a; actions.appendChild(li);
       });
+      if (!actions.children.length) {
+        const li = document.createElement('li');
+        li.textContent = 'No immediate action required.';
+        actions.appendChild(li);
+      }
 
       const bm25 = document.getElementById('bm25List');
       bm25.innerHTML = '';

--- a/scripts/validate_visualizer_contract.py
+++ b/scripts/validate_visualizer_contract.py
@@ -53,6 +53,46 @@ def validate_canonical(path: pathlib.Path) -> None:
             for link_key in ["label", "href"]:
                 require(link, link_key, f"{where}.evidence_links[{j}]")
 
+    quality = d["quality"]
+    for k in [
+        "formula_version",
+        "score",
+        "score_status",
+        "delta_24h",
+        "trend_24h",
+        "factors",
+        "factors_v2",
+        "top_drivers",
+        "actions",
+        "reproducibility",
+    ]:
+        require(quality, k, "quality")
+
+    if quality.get("score_status") not in allowed:
+        fail("quality.score_status not in PASS|WARN|FAIL|NO_DATA")
+
+    if not isinstance(quality.get("factors_v2"), list):
+        fail("quality.factors_v2 must be an array")
+
+    for idx, factor in enumerate(quality.get("factors_v2", [])):
+        where = f"quality.factors_v2[{idx}]"
+        for key in [
+            "key",
+            "label",
+            "definition",
+            "source",
+            "direction",
+            "weight",
+            "value",
+            "quality_value",
+            "weighted_score",
+            "status",
+            "remediation",
+        ]:
+            require(factor, key, where)
+        if factor["status"] not in allowed:
+            fail(f"{where}.status not in PASS|WARN|FAIL|NO_DATA")
+
     graph = d["graph"]
     for k in ["focus", "bounds", "nodes", "edges"]:
         require(graph, k, "graph")

--- a/tests/fixtures/visualizer/canonical-v1.json
+++ b/tests/fixtures/visualizer/canonical-v1.json
@@ -96,18 +96,140 @@
       ]
     },
     "quality": {
+      "formula_version": "mqe-v1",
       "score": 80,
-      "delta_24h": -4,
+      "score_status": "PASS",
+      "delta_24h": -1.6,
+      "trend_24h": [
+        {
+          "ts": "2026-02-20T04:24:41Z",
+          "score": 81.2
+        },
+        {
+          "ts": "2026-02-20T10:24:53Z",
+          "score": 80.5
+        },
+        {
+          "ts": "2026-02-20T16:24:58Z",
+          "score": 79.6
+        }
+      ],
       "factors": {
         "conflict_density": 0.22,
         "stale_pressure": 0.18,
         "confidence_health": 0.867,
         "extraction_yield": 0.74
       },
+      "factors_v2": [
+        {
+          "key": "stale_ratio",
+          "label": "Stale Ratio",
+          "definition": "Share of records in freshness.older over total freshness buckets.",
+          "source": "stats.freshness.older / (today + this_week + this_month + older)",
+          "direction": "penalty",
+          "weight": 0.22,
+          "value": 0.18,
+          "quality_value": 0.82,
+          "status": "PASS",
+          "weighted_score": 18.04,
+          "remediation": "Run stale-fact cleanup and reinforce active facts used in current workflows."
+        },
+        {
+          "key": "conflict_density",
+          "label": "Conflict Density (proxy)",
+          "definition": "Proxy derived from low/medium confidence mix plus explicit conflict alerts.",
+          "source": "stats.confidence_distribution + stats.alerts",
+          "direction": "penalty",
+          "weight": 0.2,
+          "value": 0.22,
+          "quality_value": 0.78,
+          "status": "WARN",
+          "weighted_score": 15.6,
+          "remediation": "Review conflict clusters and add supersession/tombstones for contradictory facts."
+        },
+        {
+          "key": "confidence_health",
+          "label": "Confidence Distribution Health",
+          "definition": "High-confidence share plus half-weighted medium-confidence share.",
+          "source": "stats.confidence_distribution.high/medium/total",
+          "direction": "bonus",
+          "weight": 0.24,
+          "value": 0.867,
+          "quality_value": 0.867,
+          "status": "PASS",
+          "weighted_score": 20.81,
+          "remediation": "Improve extraction quality on noisy sources and reinforce high-value facts."
+        },
+        {
+          "key": "extraction_yield",
+          "label": "Extraction Yield Health",
+          "definition": "Health band based on facts generated per memory over the last 24h.",
+          "source": "stats.growth.facts_24h / stats.growth.memories_24h",
+          "direction": "bonus",
+          "weight": 0.18,
+          "value": 0.74,
+          "quality_value": 0.74,
+          "status": "WARN",
+          "weighted_score": 13.32,
+          "remediation": "Tune extraction prompts/chunking to maintain high-signal yield without over-generation."
+        },
+        {
+          "key": "duplication_noise",
+          "label": "Duplication / Noise Pressure",
+          "definition": "KV fact dominance plus growth-spike penalties to flag likely ingestion noise.",
+          "source": "stats.facts_by_type.kv / stats.facts + stats.alerts",
+          "direction": "penalty",
+          "weight": 0.16,
+          "value": 0.35,
+          "quality_value": 0.65,
+          "status": "WARN",
+          "weighted_score": 10.4,
+          "remediation": "Tighten low-signal ingestion filters and dedupe thresholds for repetitive captures."
+        }
+      ],
+      "top_drivers": [
+        {
+          "key": "duplication_noise",
+          "label": "Duplication / Noise Pressure",
+          "status": "WARN",
+          "impact_points": 5.6,
+          "why": "KV fact dominance plus growth-spike penalties to flag likely ingestion noise.",
+          "remediation": "Tighten low-signal ingestion filters and dedupe thresholds for repetitive captures."
+        },
+        {
+          "key": "conflict_density",
+          "label": "Conflict Density (proxy)",
+          "status": "WARN",
+          "impact_points": 4.4,
+          "why": "Proxy derived from low/medium confidence mix plus explicit conflict alerts.",
+          "remediation": "Review conflict clusters and add supersession/tombstones for contradictory facts."
+        }
+      ],
       "actions": [
-        "tighten low-signal ingestion filters for high-volume sources",
-        "run optimize + growth guardrails, then verify canary trend"
-      ]
+        "Tighten low-signal ingestion filters and dedupe thresholds for repetitive captures.",
+        "Review conflict clusters and add supersession/tombstones for contradictory facts."
+      ],
+      "reproducibility": {
+        "formula": "score = round(sum(weight_i * quality_i) / sum(weight_i) * 100); quality_i = metric_i for bonus factors, (1 - metric_i) for penalty factors",
+        "inputs": {
+          "stats.confidence_distribution": {
+            "high": 2387365,
+            "medium": 463975,
+            "low": 0,
+            "total": 2851340
+          },
+          "stats.freshness": {
+            "today": 602,
+            "this_week": 1967,
+            "this_month": 0,
+            "older": 0
+          },
+          "stats.growth": {
+            "memories_24h": 880,
+            "facts_24h": 1231720
+          }
+        }
+      }
     },
     "reason": {
       "runs": [


### PR DESCRIPTION
## Summary
Implements **#102 Memory Quality Engine** with a reproducible composite score, explainability-first factor breakdown, and fast remediation guidance.

### What shipped
#### 1) Composite scoring engine (`scripts/visualizer_export.py`)
- Replaced static quality scoring with **versioned formula**: `mqe-v1`
- Produces reproducible quality payload:
  - `formula_version`
  - `score`
  - `score_status` (`PASS|WARN|FAIL|NO_DATA`)
  - `delta_24h`
  - `trend_24h`
  - `factors` (legacy meter map)
  - `factors_v2` (explainable factor records)
  - `top_drivers`
  - `actions` (top 1-2 remediation actions)
  - `reproducibility` (formula + source inputs)

#### 2) Explainability payload (factor-level provenance)
Each `factors_v2` entry now includes:
- `key`, `label`, `definition`
- `source` (metric provenance)
- `direction` (bonus|penalty)
- `weight`
- `value`, `quality_value`, `weighted_score`
- `status` (`PASS|WARN|FAIL|NO_DATA`)
- `remediation`

This gives tooltip-level definitions + direct metric provenance.

#### 3) UI updates (`docs/visualizer/prototype-v1.html`)
Memory Quality module now shows:
- formula/version label
- trend sparkline
- top degradation drivers
- factor breakdown table (status/metric/weight/impact + tooltip definitions/provenance)
- prioritized remediation actions list (top 2)

#### 4) Contract + fixture updates
- Updated `docs/visualizer/contracts-v1.md` Memory Quality contract to reflect new schema.
- Updated canonical fixture `tests/fixtures/visualizer/canonical-v1.json` with mqe-v1 fields.

#### 5) Contract validation gate
- Extended `scripts/validate_visualizer_contract.py` canonical checks for Memory Quality Engine fields (`formula_version`, `score_status`, `factors_v2`, etc.).

## Why
Issue #102 requires:
- reproducible scoring
- explainable factors with provenance
- quick identification of top remediation actions

This PR delivers all three in the canonical producer + prototype consumer path.

## Validation
- `python3 -m py_compile scripts/visualizer_export.py scripts/visualizer_api.py scripts/validate_visualizer_contract.py`
- `python3 scripts/validate_visualizer_contract.py`
- `go test ./...`
- `go vet ./...`
- Manual export check:
  - `python3 scripts/visualizer_export.py --output /tmp/vis102.json --obsidian-output /tmp/vis102-obs.json --obsidian-vault-dir /tmp/vis102-vault`
  - verified `data.quality` contains `mqe-v1`, factor breakdown, top drivers, and actions.

Closes #102.
Relates to #99.
