### PR TITLE
feat(core): add CI+release connectivity smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Vet
         run: go vet ./...
+
+      - name: Connectivity smoke (runtime path)
+        run: scripts/connectivity_smoke.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Deterministic runtime connectivity smoke gate: `scripts/connectivity_smoke.sh` (import → extract → stats → search → list facts → optimize integrity).
+
+### Changed
+- CI now runs the connectivity smoke gate on every PR/push.
+- `scripts/release_checklist.sh` now requires the same connectivity smoke gate before release publish checks pass.
+
 ## [0.3.4] - 2026-02-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ Shipped on `main`:
 - **Lane 4:** tag-release checklist enforcement before publish (`scripts/release_checklist.sh`)
 - **Lane 5:** scheduled SLO canary workflow with artifact uploads
 - **Lane 6:** thresholded canary warn/fail bands (`PASS|WARN|FAIL`)
+- **Lane 7:** deterministic runtime connectivity smoke gate (`scripts/connectivity_smoke.sh`)
 
 ### 🔭 Phase 5 — Next Priorities
 - SLO trend comparison across canary history (relative regression detection)
@@ -761,6 +762,7 @@ git clone https://github.com/hurttlocker/cortex.git
 cd cortex
 go build ./cmd/cortex/
 go test ./...
+scripts/connectivity_smoke.sh   # end-to-end runtime gate (import→extract→search→optimize)
 ```
 
 - 📖 Read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines

--- a/scripts/connectivity_smoke.sh
+++ b/scripts/connectivity_smoke.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+connectivity_smoke.sh — deterministic end-to-end Cortex runtime smoke
+
+Usage:
+  scripts/connectivity_smoke.sh [--cortex-bin /path/to/cortex]
+
+Checks:
+1) Build or use cortex binary
+2) Import sample corpus with --extract into temp DB
+3) Verify stats --json has memories>0 and facts>0
+4) Verify keyword search returns expected hit
+5) Verify list --facts returns at least one fact
+6) Verify optimize --check-only --json returns integrity_check=ok
+EOF
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CORTEX_BIN=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cortex-bin)
+      CORTEX_BIN="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+TMP_DIR="$(mktemp -d -t cortex-connectivity.XXXXXX)"
+BUILT_BIN=""
+cleanup() {
+  if [[ -n "$BUILT_BIN" && -f "$BUILT_BIN" ]]; then
+    rm -f "$BUILT_BIN"
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+if [[ -z "$CORTEX_BIN" ]]; then
+  BUILT_BIN="$(mktemp -t cortex-connectivity-bin.XXXXXX)"
+  echo "==> [1/6] building runtime binary"
+  go build -o "$BUILT_BIN" ./cmd/cortex
+  CORTEX_BIN="$BUILT_BIN"
+else
+  if [[ ! -x "$CORTEX_BIN" ]]; then
+    echo "ERROR: --cortex-bin is not executable: $CORTEX_BIN" >&2
+    exit 1
+  fi
+  echo "==> [1/6] using provided binary: $CORTEX_BIN"
+fi
+
+DB_PATH="$TMP_DIR/connectivity.db"
+CORPUS_PATH="$TMP_DIR/corpus.md"
+cat > "$CORPUS_PATH" <<'EOF'
+# Cortex Connectivity Smoke Corpus
+
+Release policy: canary-first rollout with reversible guardrails.
+The ops owner validates PASS/WARN/FAIL budgets before production cutover.
+Optimization routines must report integrity check status as ok.
+EOF
+
+echo "==> [2/6] import sample corpus with extraction"
+IMPORT_LOG="$TMP_DIR/import.log"
+if ! "$CORTEX_BIN" --db "$DB_PATH" import "$CORPUS_PATH" --extract >"$IMPORT_LOG" 2>&1; then
+  echo "ERROR: import --extract failed" >&2
+  cat "$IMPORT_LOG" >&2
+  exit 1
+fi
+
+
+echo "==> [3/6] validate stats JSON"
+STATS_JSON="$TMP_DIR/stats.json"
+"$CORTEX_BIN" --db "$DB_PATH" stats --json > "$STATS_JSON"
+python3 - "$STATS_JSON" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+data = json.loads(path.read_text(encoding="utf-8"))
+memories = int(data.get("memories", 0) or 0)
+facts = int(data.get("facts", 0) or 0)
+if memories <= 0:
+    raise SystemExit(f"ERROR: expected memories>0, got {memories}")
+if facts <= 0:
+    raise SystemExit(f"ERROR: expected facts>0, got {facts}")
+print(f"stats ok: memories={memories}, facts={facts}")
+PY
+
+
+echo "==> [4/6] validate keyword search hit"
+SEARCH_JSON="$TMP_DIR/search.json"
+"$CORTEX_BIN" --db "$DB_PATH" search "canary-first" --json --limit 5 > "$SEARCH_JSON"
+python3 - "$SEARCH_JSON" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+rows = json.loads(path.read_text(encoding="utf-8"))
+if not isinstance(rows, list) or not rows:
+    raise SystemExit("ERROR: search returned no rows")
+needle = "canary-first"
+joined = "\n".join(str(r.get("content", "")) + "\n" + str(r.get("snippet", "")) for r in rows).lower()
+if needle not in joined:
+    raise SystemExit("ERROR: search results missing expected marker 'canary-first'")
+print(f"search ok: rows={len(rows)}")
+PY
+
+
+echo "==> [5/6] validate list --facts output"
+FACTS_JSON="$TMP_DIR/facts.json"
+"$CORTEX_BIN" --db "$DB_PATH" list --facts --limit 5 --json > "$FACTS_JSON"
+python3 - "$FACTS_JSON" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+rows = json.loads(path.read_text(encoding="utf-8"))
+if not isinstance(rows, list) or not rows:
+    raise SystemExit("ERROR: list --facts returned no rows")
+print(f"facts ok: rows={len(rows)}")
+PY
+
+
+echo "==> [6/6] validate optimize integrity"
+OPT_JSON="$TMP_DIR/optimize.json"
+"$CORTEX_BIN" --db "$DB_PATH" optimize --check-only --json > "$OPT_JSON"
+python3 - "$OPT_JSON" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+row = json.loads(path.read_text(encoding="utf-8"))
+integrity = str(row.get("integrity_check", "")).lower()
+if integrity != "ok":
+    raise SystemExit(f"ERROR: integrity_check expected 'ok', got '{integrity}'")
+print("optimize ok: integrity_check=ok")
+PY
+
+echo "✅ connectivity smoke passed"

--- a/scripts/release_checklist.sh
+++ b/scripts/release_checklist.sh
@@ -19,7 +19,8 @@ Checks:
 2) CHANGELOG contains a matching section: ## [<version>]
 3) docs/releases/v<version>.md exists
 4) go/no-go doc structural guard passes (offline mode)
-5) (optional) latest SLO Canary workflow run status is success
+5) deterministic runtime connectivity smoke passes
+6) (optional) latest SLO Canary workflow run status is success
 EOF
 }
 
@@ -79,6 +80,7 @@ if ! rg -q "Tag:\s*\`$TAG\`" "$RELEASE_NOTES"; then
 fi
 
 scripts/ci_release_guard.sh --offline
+scripts/connectivity_smoke.sh
 
 if [[ "$REQUIRE_LATEST_SLO_PASS" -eq 1 ]]; then
   if [[ -z "$REPO" ]]; then


### PR DESCRIPTION
## Summary
Closes #117 with a non-visualization reliability lane that validates Cortex as one connected runtime system.

This PR adds a deterministic **connectivity smoke gate** that exercises the end-to-end local path:

`import --extract -> stats --json -> search --json -> list --facts --json -> optimize --check-only --json`

## What changed
### 1) New script: `scripts/connectivity_smoke.sh`
- Builds (or accepts) a Cortex binary
- Creates an isolated temp DB + corpus
- Verifies all key runtime connections in one deterministic pass
- Uses Python JSON assertions (no jq dependency)
- Fails fast with actionable errors

### 2) CI enforcement
- `.github/workflows/ci.yml` now runs `scripts/connectivity_smoke.sh` on PR/push.

### 3) Release gate enforcement
- `scripts/release_checklist.sh` now includes connectivity smoke as a required check.
- Help text/check list updated accordingly.

### 4) Docs/changelog updates
- `README.md`: added Lane 7 in Ops Maturity and local command under Contributing.
- `CHANGELOG.md`: added Unreleased entries for connectivity gate + CI/release wiring.

## Why
Visualizer is being advanced in parallel. This lane intentionally avoids visualization and upgrades core release confidence by proving subsystem connectivity under a fresh DB path before we cut the next version.

## Validation evidence
- `bash -n scripts/connectivity_smoke.sh`
- `scripts/connectivity_smoke.sh`
- `go test ./...`
- `go vet ./...`
- `python3 scripts/validate_visualizer_contract.py`
- `scripts/release_checklist.sh --tag v0.3.4`

