### PR TITLE
feat(core): add one-command external audit preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Deterministic runtime connectivity smoke gate: `scripts/connectivity_smoke.sh` (import → extract → stats → search → list facts → optimize integrity).
+- One-command external audit preflight pack generator: `scripts/audit_preflight.sh --tag ...` (writes markdown summary + per-step logs under `docs/audits/`).
 
 ### Changed
 - CI now runs the connectivity smoke gate on every PR/push.
 - `scripts/release_checklist.sh` now requires the same connectivity smoke gate before release publish checks pass.
+- `scripts/audit_rc_smoke.sh` now includes the runtime connectivity smoke as part of its RC validation flow.
 
 ## [0.3.4] - 2026-02-20
 

--- a/README.md
+++ b/README.md
@@ -737,6 +737,7 @@ Shipped on `main`:
 - **Lane 5:** scheduled SLO canary workflow with artifact uploads
 - **Lane 6:** thresholded canary warn/fail bands (`PASS|WARN|FAIL`)
 - **Lane 7:** deterministic runtime connectivity smoke gate (`scripts/connectivity_smoke.sh`)
+- **Lane 8:** one-command external audit preflight artifact (`scripts/audit_preflight.sh`)
 
 ### 🔭 Phase 5 — Next Priorities
 - SLO trend comparison across canary history (relative regression detection)
@@ -763,6 +764,7 @@ cd cortex
 go build ./cmd/cortex/
 go test ./...
 scripts/connectivity_smoke.sh   # end-to-end runtime gate (import→extract→search→optimize)
+scripts/audit_preflight.sh --tag v0.3.4   # generate audit-ready markdown + logs
 ```
 
 - 📖 Read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines

--- a/scripts/audit_preflight.sh
+++ b/scripts/audit_preflight.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+audit_preflight.sh — one-command external audit preflight with evidence artifact
+
+Usage:
+  scripts/audit_preflight.sh --tag vX.Y.Z[-rcN] [--out docs/audits/<name>.md]
+
+Runs:
+  1) scripts/release_checklist.sh --tag <tag>
+  2) scripts/audit_rc_smoke.sh
+  3) python3 scripts/validate_visualizer_contract.py
+
+Output:
+  - Markdown summary report (default: docs/audits/<tag>-preflight.md)
+  - Per-step logs in docs/audits/<tag>-preflight-logs/
+
+Exit codes:
+  0 = all checks passed
+  1 = one or more checks failed
+EOF
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TAG=""
+OUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      TAG="${2:-}"
+      shift 2
+      ;;
+    --out)
+      OUT="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TAG" ]]; then
+  echo "ERROR: --tag is required" >&2
+  exit 1
+fi
+
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+  echo "ERROR: invalid --tag '$TAG' (expected v<major>.<minor>.<patch>[-rcN])" >&2
+  exit 1
+fi
+
+if [[ -z "$OUT" ]]; then
+  OUT="docs/audits/${TAG}-preflight.md"
+fi
+
+mkdir -p "$(dirname "$OUT")"
+LOG_DIR="${OUT%.md}-logs"
+mkdir -p "$LOG_DIR"
+
+RESULTS_TSV="$(mktemp -t cortex-audit-preflight-results.XXXXXX)"
+trap 'rm -f "$RESULTS_TSV"' EXIT
+
+OVERALL_FAIL=0
+
+run_step() {
+  local name="$1"
+  local cmd="$2"
+  local slug
+  slug="$(echo "$name" | tr ' ' '-' | tr '[:upper:]' '[:lower:]')"
+  local log_file="$LOG_DIR/${slug}.log"
+
+  echo "==> $name"
+  set +e
+  bash -lc "$cmd" >"$log_file" 2>&1
+  local rc=$?
+  set -e
+
+  local status="PASS"
+  if [[ $rc -ne 0 ]]; then
+    status="FAIL"
+    OVERALL_FAIL=1
+  fi
+
+  printf '%s\t%s\t%s\t%s\n' "$status" "$name" "$cmd" "$log_file" >> "$RESULTS_TSV"
+
+  if [[ "$status" == "PASS" ]]; then
+    echo "    PASS"
+  else
+    echo "    FAIL (see $log_file)"
+  fi
+}
+
+run_step "release checklist" "scripts/release_checklist.sh --tag $TAG"
+run_step "audit rc smoke" "scripts/audit_rc_smoke.sh"
+run_step "visualizer contract validator" "python3 scripts/validate_visualizer_contract.py"
+
+UTC_NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+GIT_SHA="$(git rev-parse HEAD)"
+GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+{
+  echo "# External Audit Preflight — $TAG"
+  echo
+  echo "- Generated at (UTC): \`$UTC_NOW\`"
+  echo "- Git SHA: \`$GIT_SHA\`"
+  echo "- Git branch: \`$GIT_BRANCH\`"
+  echo "- Overall: **$([[ $OVERALL_FAIL -eq 0 ]] && echo PASS || echo FAIL)**"
+  echo
+  echo "## Step Results"
+  echo
+  echo "| Status | Step | Command | Log |"
+  echo "|---|---|---|---|"
+
+  while IFS=$'\t' read -r status name cmd log_file; do
+    rel_log="${log_file#${ROOT_DIR}/}"
+    echo "| $status | $name | \`$cmd\` | \`$rel_log\` |"
+  done < "$RESULTS_TSV"
+
+  echo
+  echo "## Notes"
+  echo
+  if [[ $OVERALL_FAIL -eq 0 ]]; then
+    echo "All preflight gates passed for \`$TAG\`."
+  else
+    echo "One or more gates failed. See logs above before requesting external audit."
+  fi
+} > "$OUT"
+
+if [[ $OVERALL_FAIL -eq 0 ]]; then
+  echo "✅ audit preflight passed"
+  echo "report: $OUT"
+  exit 0
+fi
+
+echo "❌ audit preflight failed"
+echo "report: $OUT"
+exit 1

--- a/scripts/audit_rc_smoke.sh
+++ b/scripts/audit_rc_smoke.sh
@@ -28,7 +28,10 @@ if ! grep -q "Usage of codex-rollout-report" <<<"$help_output"; then
   exit 1
 fi
 
-echo "==> [5/5] strict-mode fixture check"
+echo "==> [5/6] runtime connectivity smoke"
+scripts/connectivity_smoke.sh --cortex-bin "$runtime_bin"
+
+echo "==> [6/6] strict-mode fixture check"
 cat > "$telemetry_file" <<'EOF'
 {"mode":"one-shot","provider":"openrouter","model":"openai-codex/gpt-5.2","wall_ms":25000,"cost_known":true,"cost_usd":0.001}
 {"mode":"recursive","provider":"openrouter","model":"google/gemini-2.5-flash","wall_ms":30000,"cost_known":false}


### PR DESCRIPTION
## Summary
Closes #119 with a non-visualization reliability upgrade for external audit readiness.

This PR adds a one-command preflight that stitches existing release/audit gates into a reproducible evidence artifact.

## What shipped
### 1) `scripts/audit_preflight.sh` (new)
- Usage: `scripts/audit_preflight.sh --tag vX.Y.Z[-rcN] [--out docs/audits/<name>.md]`
- Runs, in order:
  1. `scripts/release_checklist.sh --tag <tag>`
  2. `scripts/audit_rc_smoke.sh`
  3. `python3 scripts/validate_visualizer_contract.py`
- Writes:
  - Markdown summary report (default: `docs/audits/<tag>-preflight.md`)
  - Per-step logs (`docs/audits/<tag>-preflight-logs/*.log`)
- Exits non-zero if any gate fails.

### 2) Strengthened RC smoke chain
- `scripts/audit_rc_smoke.sh` now includes runtime connectivity smoke (`scripts/connectivity_smoke.sh --cortex-bin ...`) as part of RC validation.

### 3) Documentation/changelog
- README roadmap updated with Lane 8 (external audit preflight artifact).
- README contributing quickstart includes preflight command.
- CHANGELOG Unreleased updated.

## Why
We now have a deterministic, auditor-friendly handoff command that proves system connectivity + release/documentation gates together, while visualizer work proceeds independently.

## Validation
- `bash -n scripts/audit_preflight.sh`
- `bash -n scripts/audit_rc_smoke.sh`
- `scripts/audit_preflight.sh --tag v0.3.4`

The preflight run passed and produced markdown + logs as expected.
