### PR TITLE
[Visualizer] close #104: Retrieval Debug + bounded Provenance Explorer

### DIFF
--- a/docs/visualizer/contracts-v1.md
+++ b/docs/visualizer/contracts-v1.md
@@ -202,12 +202,27 @@ Contract notes:
   "data": {
     "query": "...",
     "results": {
-      "bm25": [ { "rank": 1, "id": "...", "score": 0.88, "title": "..." } ],
-      "semantic": [ { "rank": 1, "id": "...", "score": 0.76, "title": "..." } ],
-      "hybrid": [ { "rank": 1, "id": "...", "score": 0.91, "title": "..." } ]
+      "bm25": [
+        { "id": "ops-db-growth-guardrails", "rank": 1, "score": 0.88, "title": "docs/ops-db-growth-guardrails.md", "why": "exact keyword overlap" }
+      ],
+      "semantic": [
+        { "id": "cortex-deep-dive", "rank": 1, "score": 0.93, "title": "docs/CORTEX_DEEP_DIVE.md", "why": "strong conceptual match" }
+      ],
+      "hybrid": [
+        { "id": "cortex-deep-dive", "rank": 1, "score": 0.91, "title": "docs/CORTEX_DEEP_DIVE.md", "why": "semantic + lexical rerank win" }
+      ]
     },
     "deltas": [
-      { "id": "...", "bm25_rank": 9, "hybrid_rank": 2, "reason": "semantic boost" }
+      {
+        "id": "cortex-deep-dive",
+        "title": "docs/CORTEX_DEEP_DIVE.md",
+        "bm25_rank": null,
+        "semantic_rank": 1,
+        "hybrid_rank": 1,
+        "movement_vs_bm25": null,
+        "movement_vs_semantic": 0,
+        "reason": "semantic strength lifted this result in hybrid rerank"
+      }
     ]
   }
 }

--- a/docs/visualizer/data/latest.json
+++ b/docs/visualizer/data/latest.json
@@ -140,39 +140,126 @@
       "results": {
         "bm25": [
           {
+            "id": "ops-db-growth-guardrails",
             "rank": 1,
             "title": "docs/ops-db-growth-guardrails.md",
-            "score": 0.87
+            "score": 0.87,
+            "why": "Exact keyword overlap for release/canary guardrails."
           },
           {
+            "id": "release-v0-3-4",
             "rank": 2,
             "title": "docs/releases/v0.3.4.md",
-            "score": 0.82
+            "score": 0.82,
+            "why": "Strong lexical overlap with release/regression terms."
           },
           {
+            "id": "readme",
             "rank": 3,
             "title": "README.md",
-            "score": 0.71
+            "score": 0.71,
+            "why": "General release keywords appear, but context is broad."
+          }
+        ],
+        "semantic": [
+          {
+            "id": "cortex-deep-dive",
+            "rank": 1,
+            "title": "docs/CORTEX_DEEP_DIVE.md",
+            "score": 0.93,
+            "why": "Closest conceptual match to regressions and operational diagnostics."
+          },
+          {
+            "id": "release-v0-3-4",
+            "rank": 2,
+            "title": "docs/releases/v0.3.4.md",
+            "score": 0.89,
+            "why": "Release notes semantically align with gate movement context."
+          },
+          {
+            "id": "memory-2026-02-19",
+            "rank": 3,
+            "title": "memory/2026-02-19.md",
+            "score": 0.83,
+            "why": "Temporal memory captures regression chatter and follow-up actions."
           }
         ],
         "hybrid": [
           {
+            "id": "cortex-deep-dive",
             "rank": 1,
             "title": "docs/CORTEX_DEEP_DIVE.md",
-            "score": 0.92
+            "score": 0.92,
+            "why": "Semantic strength plus confidence-weighted rerank moved it to the top."
           },
           {
+            "id": "release-v0-3-4",
             "rank": 2,
             "title": "docs/releases/v0.3.4.md",
-            "score": 0.88
+            "score": 0.88,
+            "why": "Consistent top performer across lexical and semantic modes."
           },
           {
+            "id": "ops-db-growth-guardrails",
             "rank": 3,
-            "title": "memory/2026-02-19.md",
-            "score": 0.81
+            "title": "docs/ops-db-growth-guardrails.md",
+            "score": 0.85,
+            "why": "Still highly relevant, but reranker favored richer explanatory docs."
           }
         ]
-      }
+      },
+      "deltas": [
+        {
+          "id": "ops-db-growth-guardrails",
+          "title": "docs/ops-db-growth-guardrails.md",
+          "bm25_rank": 1,
+          "semantic_rank": null,
+          "hybrid_rank": 3,
+          "movement_vs_bm25": -2,
+          "movement_vs_semantic": null,
+          "reason": "Still highly relevant, but reranker favored richer explanatory docs."
+        },
+        {
+          "id": "cortex-deep-dive",
+          "title": "docs/CORTEX_DEEP_DIVE.md",
+          "bm25_rank": null,
+          "semantic_rank": 1,
+          "hybrid_rank": 1,
+          "movement_vs_bm25": null,
+          "movement_vs_semantic": 0,
+          "reason": "Semantic strength plus confidence-weighted rerank moved it to the top."
+        },
+        {
+          "id": "release-v0-3-4",
+          "title": "docs/releases/v0.3.4.md",
+          "bm25_rank": 2,
+          "semantic_rank": 2,
+          "hybrid_rank": 2,
+          "movement_vs_bm25": 0,
+          "movement_vs_semantic": 0,
+          "reason": "Consistent top performer across lexical and semantic modes."
+        },
+        {
+          "id": "readme",
+          "title": "README.md",
+          "bm25_rank": 3,
+          "semantic_rank": null,
+          "hybrid_rank": null,
+          "movement_vs_bm25": null,
+          "movement_vs_semantic": null,
+          "reason": "General release keywords appear, but context is broad."
+        },
+        {
+          "id": "memory-2026-02-19",
+          "title": "memory/2026-02-19.md",
+          "bm25_rank": null,
+          "semantic_rank": 3,
+          "hybrid_rank": null,
+          "movement_vs_bm25": null,
+          "movement_vs_semantic": null,
+          "reason": "Temporal memory captures regression chatter and follow-up actions."
+        }
+      ]
     },
     "graph": {
       "focus": "fact_canary_regression",

--- a/docs/visualizer/prototype-v1.html
+++ b/docs/visualizer/prototype-v1.html
@@ -173,10 +173,15 @@
           </div>
         </article>
         <article class="card">
-          <div class="title"><span>Retrieval Debug (query replay)</span><span class="pill">bm25 vs hybrid</span></div>
-          <div class="split">
+          <div class="title"><span>Retrieval Debug (query replay)</span><span class="pill">bm25 vs semantic vs hybrid</span></div>
+          <div class="split" style="grid-template-columns: 1fr 1fr 1fr;">
             <div class="panel"><div class="small">BM25 top</div><ul id="bm25List"></ul></div>
+            <div class="panel"><div class="small">Semantic top</div><ul id="semanticList"></ul></div>
             <div class="panel"><div class="small">Hybrid top</div><ul id="hybridList"></ul></div>
+          </div>
+          <div class="panel" style="margin-top:10px">
+            <div class="small">Rank movement + reason</div>
+            <ul id="retrievalDeltaList"></ul>
           </div>
         </article>
       </section>
@@ -602,10 +607,46 @@
 
       const bm25 = document.getElementById('bm25List');
       bm25.innerHTML = '';
-      (d.retrieval?.results?.bm25 || []).forEach(x => { const li = document.createElement('li'); li.textContent = `#${x.rank} ${x.title}`; bm25.appendChild(li); });
+      (d.retrieval?.results?.bm25 || []).forEach(x => {
+        const li = document.createElement('li');
+        li.textContent = `#${x.rank} ${x.title}`;
+        li.title = x.why || '';
+        bm25.appendChild(li);
+      });
+
+      const semantic = document.getElementById('semanticList');
+      semantic.innerHTML = '';
+      (d.retrieval?.results?.semantic || []).forEach(x => {
+        const li = document.createElement('li');
+        li.textContent = `#${x.rank} ${x.title}`;
+        li.title = x.why || '';
+        semantic.appendChild(li);
+      });
+
       const hy = document.getElementById('hybridList');
       hy.innerHTML = '';
-      (d.retrieval?.results?.hybrid || []).forEach(x => { const li = document.createElement('li'); li.textContent = `#${x.rank} ${x.title}`; hy.appendChild(li); });
+      (d.retrieval?.results?.hybrid || []).forEach(x => {
+        const li = document.createElement('li');
+        li.textContent = `#${x.rank} ${x.title}`;
+        li.title = x.why || '';
+        hy.appendChild(li);
+      });
+
+      const deltaList = document.getElementById('retrievalDeltaList');
+      deltaList.innerHTML = '';
+      (d.retrieval?.deltas || []).forEach(row => {
+        const li = document.createElement('li');
+        const movement = row.movement_vs_bm25 == null
+          ? 'n/a'
+          : (row.movement_vs_bm25 > 0 ? `↑ ${row.movement_vs_bm25}` : row.movement_vs_bm25 < 0 ? `↓ ${Math.abs(row.movement_vs_bm25)}` : '→ 0');
+        li.textContent = `${row.title} • bm25→hybrid: ${movement} • ${row.reason || 'no reason provided'}`;
+        deltaList.appendChild(li);
+      });
+      if (!deltaList.children.length) {
+        const li = document.createElement('li');
+        li.textContent = 'No retrieval rank deltas available.';
+        deltaList.appendChild(li);
+      }
 
       activeGraph = d.graph || {};
       renderGraph(activeGraph);

--- a/tests/fixtures/visualizer/canonical-v1.json
+++ b/tests/fixtures/visualizer/canonical-v1.json
@@ -262,39 +262,126 @@
       "results": {
         "bm25": [
           {
+            "id": "ops-db-growth-guardrails",
             "rank": 1,
             "title": "docs/ops-db-growth-guardrails.md",
-            "score": 0.87
+            "score": 0.87,
+            "why": "Exact keyword overlap for release/canary guardrails."
           },
           {
+            "id": "release-v0-3-4",
             "rank": 2,
             "title": "docs/releases/v0.3.4.md",
-            "score": 0.82
+            "score": 0.82,
+            "why": "Strong lexical overlap with release/regression terms."
           },
           {
+            "id": "readme",
             "rank": 3,
             "title": "README.md",
-            "score": 0.71
+            "score": 0.71,
+            "why": "General release keywords appear, but context is broad."
+          }
+        ],
+        "semantic": [
+          {
+            "id": "cortex-deep-dive",
+            "rank": 1,
+            "title": "docs/CORTEX_DEEP_DIVE.md",
+            "score": 0.93,
+            "why": "Closest conceptual match to regressions and operational diagnostics."
+          },
+          {
+            "id": "release-v0-3-4",
+            "rank": 2,
+            "title": "docs/releases/v0.3.4.md",
+            "score": 0.89,
+            "why": "Release notes semantically align with gate movement context."
+          },
+          {
+            "id": "memory-2026-02-19",
+            "rank": 3,
+            "title": "memory/2026-02-19.md",
+            "score": 0.83,
+            "why": "Temporal memory captures regression chatter and follow-up actions."
           }
         ],
         "hybrid": [
           {
+            "id": "cortex-deep-dive",
             "rank": 1,
             "title": "docs/CORTEX_DEEP_DIVE.md",
-            "score": 0.92
+            "score": 0.92,
+            "why": "Semantic strength plus confidence-weighted rerank moved it to the top."
           },
           {
+            "id": "release-v0-3-4",
             "rank": 2,
             "title": "docs/releases/v0.3.4.md",
-            "score": 0.88
+            "score": 0.88,
+            "why": "Consistent top performer across lexical and semantic modes."
           },
           {
+            "id": "ops-db-growth-guardrails",
             "rank": 3,
-            "title": "memory/2026-02-19.md",
-            "score": 0.81
+            "title": "docs/ops-db-growth-guardrails.md",
+            "score": 0.85,
+            "why": "Still highly relevant, but reranker favored richer explanatory docs."
           }
         ]
-      }
+      },
+      "deltas": [
+        {
+          "id": "ops-db-growth-guardrails",
+          "title": "docs/ops-db-growth-guardrails.md",
+          "bm25_rank": 1,
+          "semantic_rank": null,
+          "hybrid_rank": 3,
+          "movement_vs_bm25": -2,
+          "movement_vs_semantic": null,
+          "reason": "Still highly relevant, but reranker favored richer explanatory docs."
+        },
+        {
+          "id": "cortex-deep-dive",
+          "title": "docs/CORTEX_DEEP_DIVE.md",
+          "bm25_rank": null,
+          "semantic_rank": 1,
+          "hybrid_rank": 1,
+          "movement_vs_bm25": null,
+          "movement_vs_semantic": 0,
+          "reason": "Semantic strength plus confidence-weighted rerank moved it to the top."
+        },
+        {
+          "id": "release-v0-3-4",
+          "title": "docs/releases/v0.3.4.md",
+          "bm25_rank": 2,
+          "semantic_rank": 2,
+          "hybrid_rank": 2,
+          "movement_vs_bm25": 0,
+          "movement_vs_semantic": 0,
+          "reason": "Consistent top performer across lexical and semantic modes."
+        },
+        {
+          "id": "readme",
+          "title": "README.md",
+          "bm25_rank": 3,
+          "semantic_rank": null,
+          "hybrid_rank": null,
+          "movement_vs_bm25": null,
+          "movement_vs_semantic": null,
+          "reason": "General release keywords appear, but context is broad."
+        },
+        {
+          "id": "memory-2026-02-19",
+          "title": "memory/2026-02-19.md",
+          "bm25_rank": null,
+          "semantic_rank": 3,
+          "hybrid_rank": null,
+          "movement_vs_bm25": null,
+          "movement_vs_semantic": null,
+          "reason": "Temporal memory captures regression chatter and follow-up actions."
+        }
+      ]
     },
     "graph": {
       "focus": "fact_canary_regression",


### PR DESCRIPTION
## Summary
Scoped closure for #104 with minimal, deterministic diff on top of latest `main`.

This PR completes retrieval-debug contract + UI path and keeps provenance explorer bounded.

## Scope (trimmed to #104 only)
- `scripts/visualizer_export.py`
  - Added retrieval-debug payload with full contract path:
    - `retrieval.results.bm25[]`
    - `retrieval.results.semantic[]`
    - `retrieval.results.hybrid[]`
    - `retrieval.deltas[]` (rank movement + reason)
- `docs/visualizer/prototype-v1.html`
  - Retrieval UI now shows **all 3 result lists** (BM25, semantic, hybrid)
  - Added explicit **rank movement + reason** panel from `retrieval.deltas`
- `scripts/validate_visualizer_contract.py`
  - Enforces retrieval schema deeply (arrays + required fields), not just top-level presence
  - Enforces bounded graph fields (`graph.bounds.max_hops`, `graph.bounds.max_nodes`)
- Fixtures/docs refreshed minimally for contract alignment:
  - `tests/fixtures/visualizer/canonical-v1.json`
  - `docs/visualizer/data/latest.json`
  - `docs/visualizer/contracts-v1.md`

## Bounded provenance guardrail
No global graph default added. Existing bounded server-side extraction remains:
- focus-node centric
- `max_hops`
- `max_nodes`

## Validation (required)
```bash
python3 -m py_compile scripts/visualizer_export.py scripts/visualizer_api.py scripts/validate_visualizer_contract.py
python3 scripts/validate_visualizer_contract.py
go test ./...
go vet ./...
```
All pass locally.

Closes #104
