### PR TITLE
docs(audit): prep v0.3.5-rc1 auditor packet + roadmap refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- No unreleased entries yet.
+
+## [0.3.5-rc1] - 2026-02-20
+
 ### Added
-- Deterministic runtime connectivity smoke gate: `scripts/connectivity_smoke.sh` (import → extract → stats → search → list facts → optimize integrity).
-- One-command external audit preflight pack generator: `scripts/audit_preflight.sh --tag ...` (writes markdown summary + per-step logs under `docs/audits/`).
+- Deterministic runtime connectivity smoke gate: `scripts/connectivity_smoke.sh`.
+- One-command external audit preflight pack generator: `scripts/audit_preflight.sh --tag ...`.
+- v0.3.5-rc1 audit handoff docs (`go-no-go`, auditor command pack, release notes).
 
 ### Changed
-- CI now runs the connectivity smoke gate on every PR/push.
-- `scripts/release_checklist.sh` now requires the same connectivity smoke gate before release publish checks pass.
-- `scripts/audit_rc_smoke.sh` now includes the runtime connectivity smoke as part of its RC validation flow.
+- CI now executes runtime connectivity smoke on PR/push.
+- Release checklist now requires connectivity smoke before publish checks pass.
+- RC smoke now includes runtime connectivity validation.
+- Visualizer closure includes retrieval-debug deltas/reasons across bm25+semantic+hybrid and bounded provenance contract enforcement.
 
 ## [0.3.4] - 2026-02-20
 

--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ Core memory platform is shipped and stable:
 - RC + delta audit process codified with go/no-go docs
 - Release artifact verification and reproducible smoke paths
 
-### 🚀 Phase 4 — Ops Maturity *(Active, v0.3.5-dev lanes)*
+### 🚀 Phase 4 — Ops Maturity *(Complete for v0.3.5-rc1 prep)*
 Shipped on `main`:
 - **Lane 1:** `cortex optimize` maintenance command
 - **Lane 2:** `scripts/slo_snapshot.sh` report artifacts (JSON/markdown)
@@ -738,16 +738,19 @@ Shipped on `main`:
 - **Lane 6:** thresholded canary warn/fail bands (`PASS|WARN|FAIL`)
 - **Lane 7:** deterministic runtime connectivity smoke gate (`scripts/connectivity_smoke.sh`)
 - **Lane 8:** one-command external audit preflight artifact (`scripts/audit_preflight.sh`)
+- **Lane 9:** v0.3.5-rc1 audit packet docs (`docs/audits/v0.3.5-rc1-*.md`, `docs/releases/v0.3.5-rc1.md`)
 
 ### 🔭 Phase 5 — Next Priorities
+- Run external audit on immutable target `v0.3.5-rc1` and close findings
+- Codex real-work dogfooding loop (collect evidence, tune thresholds/prompting only when data justifies)
 - SLO trend comparison across canary history (relative regression detection)
-- Cost/latency budget policy overlays for canary and release checks
 - Dashboard-grade visibility for release gates + canary trend history
 
 ### Current State
 - Latest stable release: **`v0.3.4`**
 - Current source fallback version: **`0.3.5-dev`**
-- Open issues: **none at time of last roadmap refresh**
+- Audit prep docs ready for next RC: **`v0.3.5-rc1`**
+- Open issues: **none**
 
 See [docs/CORTEX_DEEP_DIVE.md](docs/CORTEX_DEEP_DIVE.md) for the full strategic deep dive and [docs/prd/](docs/prd/) for detailed implementation specs.
 
@@ -764,7 +767,7 @@ cd cortex
 go build ./cmd/cortex/
 go test ./...
 scripts/connectivity_smoke.sh   # end-to-end runtime gate (import→extract→search→optimize)
-scripts/audit_preflight.sh --tag v0.3.4   # generate audit-ready markdown + logs
+scripts/audit_preflight.sh --tag v0.3.5-rc1   # generate audit-ready markdown + logs
 ```
 
 - 📖 Read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines

--- a/docs/CORTEX_DEEP_DIVE.md
+++ b/docs/CORTEX_DEEP_DIVE.md
@@ -7,7 +7,7 @@
 ## Last Updated
 
 - **Updated:** 2026-02-20 (ET)
-- **Repo checked:** `hurttlocker/cortex` @ `9ab5d04` (main)
+- **Repo checked:** `hurttlocker/cortex` @ `25bae09` (main)
 - **Latest stable release:** `v0.3.4`
 - **Current dev fallback version in source:** `0.3.5-dev`
 
@@ -19,18 +19,17 @@ Cortex has moved from “feature buildout” into “operational hardening + rel
 
 ### What is true right now
 - Stable release is live: **v0.3.4**
-- RC and delta audits were completed before promotion
-- Post-release hardening lanes (v0.3.5-dev) are actively shipped on `main`
+- v0.3.5-rc1 audit packet scaffolding is prepared (`docs/audits/` + `docs/releases/`)
+- Visualizer v1 closure sequence is complete (#99 and #104 are closed)
+- Post-release hardening lanes (v0.3.5-dev) are fully shipped on `main`
 - Current open issue count: **0** (at time of refresh)
 
 ### Most recent merged wave (top commits)
-1. `9ab5d04` — SLO canary threshold warn/fail bands (lane 6)
-2. `5c6323d` — fix `--cortex-bin` handling in `slo_snapshot.sh`
-3. `2bcd23a` — scheduled SLO canary workflow + artifacts (lane 5)
-4. `0693413` — release checklist enforcement before GoReleaser (lane 4)
-5. `8a224f2` — CI doc/status drift guard for go/no-go docs (lane 3)
-6. `be52bba` — SLO snapshot script/report tooling (lane 2)
-7. `efd9314` — `cortex optimize` command (lane 1)
+1. `25bae09` — close #104: retrieval debug deltas + bounded provenance closure (#121)
+2. `8c8488e` — one-command external audit preflight script + docs (#120)
+3. `21a39fa` — deterministic connectivity smoke gate in CI/release flow (#118)
+4. `71977db` — memory quality engine composite + explainability (#116)
+5. `1f874a6` — reason run inspector filters + drill-down (#114)
 
 ---
 
@@ -42,17 +41,19 @@ Import, extraction, hybrid search, MCP, reasoning, and observability are deliver
 ## Layer 2 — Reliability + Release Readiness (DONE)
 The v0.3.4 cycle delivered audit fit, immutable target auditing, release artifact verification, and explicit go/no-go docs.
 
-## Layer 3 — Ops Maturity (IN PROGRESS, HEAVILY ADVANCED)
-Most high-impact ops controls are now in place:
+## Layer 3 — Ops Maturity (COMPLETE FOR RC PREP)
+High-impact ops controls are now in place:
 - `cortex optimize` maintenance path
 - SLO snapshot artifact generation
 - CI doc drift guardrails
 - Release checklist gating before publish
 - Scheduled canary + artifact history
 - Thresholded canary regression signaling
+- Deterministic connectivity smoke gate
+- One-command audit preflight evidence generation
 
 ## Layer 4 — Next Expansion (NEXT)
-Natural next targets are trend-aware regression comparisons, dashboarding, and higher-level memory-quality improvements.
+Natural next targets are external-audit execution on immutable RC, codex-in-production tuning based on telemetry, and trend-aware regression intelligence/dashboarding.
 
 ---
 
@@ -70,6 +71,8 @@ Natural next targets are trend-aware regression comparisons, dashboarding, and h
 - PR autofix gate
 - Release workflow gate: `scripts/release_checklist.sh`
 - Docs drift gate: `scripts/ci_release_guard.sh`
+- Runtime connectivity gate: `scripts/connectivity_smoke.sh`
+- Auditor evidence gate: `scripts/audit_preflight.sh`
 
 ---
 
@@ -98,13 +101,11 @@ The prior document anchored to `v0.3.3` / `968954e` and emphasized audit hardeni
 Now, beyond that baseline, Cortex added:
 
 1. **Stable promotion to v0.3.4** after audit loop
-2. **Null memory_class hardening closure** in search/migrations path
-3. **DB maintenance command** (`cortex optimize`)
-4. **SLO reporting script** (`scripts/slo_snapshot.sh`)
-5. **Scheduled SLO canary workflow** (`.github/workflows/slo-canary.yml`)
-6. **Thresholded canary gates** (PASS/WARN/FAIL, warn/fail ms bands)
-7. **CI guard against go/no-go doc drift**
-8. **Release workflow checklist enforcement** before publish
+2. **Reliability lane completion** (optimize, SLO snapshot/canary, checklist/doc drift guards)
+3. **Deterministic connectivity gate** for release/runtime path validation
+4. **One-command audit preflight** that emits markdown + per-step logs
+5. **Visualizer v1 closure** including retrieval-debug deltas and bounded provenance explorer
+6. **RC audit packet scaffolding** for `v0.3.5-rc1` (go/no-go + auditor command pack + release notes)
 
 ---
 
@@ -161,12 +162,12 @@ The platform is now strong on correctness and operations. The next strategic unl
 
 ---
 
-## Recommended Next Roadmap Slice (Post Lane 6)
+## Recommended Next Roadmap Slice (Post RC-prep lanes)
 
-1. **Lane 7:** SLO trend comparator (latest vs historical canary artifacts)
-2. **Lane 8:** Canary budget checks (cost/tokens where applicable)
-3. **Lane 9:** Readme roadmap refresh to reflect shipped lane sequence explicitly
-4. **Lane 10:** Dashboarding of canary + drift + release gate history
+1. **External audit execution:** run immutable-target audit on `v0.3.5-rc1`, collect findings, close deltas.
+2. **Codex real-work tuning loop:** continue production dogfooding and adjust thresholds/prompts only from measured regressions.
+3. **SLO trend intelligence:** compare latest canary against historical baseline for relative regressions, not only static thresholds.
+4. **Gate observability dashboard:** unify release checks, canary trends, and audit preflight history into one operator view.
 
 ---
 

--- a/docs/audits/v0.3.5-rc1-auditor-pack.md
+++ b/docs/audits/v0.3.5-rc1-auditor-pack.md
@@ -1,0 +1,90 @@
+# Cortex v0.3.5-rc1 Auditor Command Pack
+
+Audit target:
+- Repo: `hurttlocker/cortex`
+- Tag: `v0.3.5-rc1`
+- Focus: release reliability gates + visualizer v1 contract closure
+- Gate summary: see `docs/audits/v0.3.5-rc1-go-no-go.md`
+
+## 1) Environment / provenance
+
+```bash
+git clone https://github.com/hurttlocker/cortex.git
+cd cortex
+git checkout v0.3.5-rc1
+
+go version
+```
+
+## 2) Build + baseline tests
+
+```bash
+go test ./...
+go vet ./...
+go build -o ./bin/cortex ./cmd/cortex
+./bin/cortex version
+```
+
+Expected:
+- tests pass
+- vet pass
+- binary prints `cortex 0.3.5-rc1` (or release ldflags version)
+
+## 3) Release + runtime gate checks
+
+```bash
+scripts/release_checklist.sh --tag v0.3.5-rc1
+scripts/connectivity_smoke.sh --cortex-bin ./bin/cortex
+scripts/audit_rc_smoke.sh
+```
+
+Expected:
+- all commands pass
+- strict mode section in RC smoke still emits WARN lines and non-zero signaling when fixture forces guardrail warnings
+
+## 4) One-command preflight evidence pack
+
+```bash
+scripts/audit_preflight.sh --tag v0.3.5-rc1
+```
+
+Expected artifacts:
+- `docs/audits/v0.3.5-rc1-preflight.md`
+- `docs/audits/v0.3.5-rc1-preflight-logs/*.log`
+
+## 5) Visualizer contract closure checks
+
+```bash
+python3 -m py_compile scripts/visualizer_export.py scripts/visualizer_api.py scripts/validate_visualizer_contract.py
+python3 scripts/validate_visualizer_contract.py
+```
+
+Expected:
+- canonical contract includes retrieval lists for `bm25`, `semantic`, and `hybrid`
+- canonical contract includes `retrieval.deltas[]` with rank movement + reason
+- canonical graph contains bounded `max_hops` and `max_nodes`
+
+## 6) Manual spot checks (optional but recommended)
+
+```bash
+python3 scripts/visualizer_export.py \
+  --output docs/visualizer/data/latest.json \
+  --obsidian-output docs/visualizer/data/obsidian-graph.json \
+  --obsidian-vault-dir docs/visualizer/data/obsidian-vault
+
+python3 scripts/visualizer_api.py --bootstrap --port 8787
+# open http://127.0.0.1:8787/prototype-v1.html
+```
+
+Check:
+- Retrieval Debug panel shows BM25 + semantic + hybrid and delta reasons
+- Provenance graph remains bounded and focus-node oriented
+
+## 7) Audit notes template
+
+Capture:
+- tag + commit tested
+- full command transcript
+- pass/fail per section
+- deviations from expected output
+- recommendations for follow-up before stable promotion

--- a/docs/audits/v0.3.5-rc1-go-no-go.md
+++ b/docs/audits/v0.3.5-rc1-go-no-go.md
@@ -1,0 +1,51 @@
+# v0.3.5-rc1 Pre-Audit Go/No-Go Handoff
+
+Date: 2026-02-20
+Scope: v0.3.5-rc1 external audit readiness (release gates + visualizer v1 closure + ops maturity controls).
+
+## Gate Checklist
+
+### Release integrity
+- [ ] `v0.3.5-rc1` pre-release published
+- [ ] Assets present (darwin/linux/windows + checksums)
+- [ ] One checksum spot-check completed from release assets
+
+### Runtime behavior + reliability gates
+- [ ] `scripts/connectivity_smoke.sh` passes on RC target
+- [ ] `scripts/audit_rc_smoke.sh` passes on RC target
+- [ ] `scripts/release_checklist.sh --tag v0.3.5-rc1` passes
+- [ ] `scripts/audit_preflight.sh --tag v0.3.5-rc1` passes and emits report/logs
+
+### Visualizer contract gates (for #99/#104 closure proof)
+- [ ] `python3 scripts/validate_visualizer_contract.py` passes on RC target
+- [ ] Retrieval payload includes bm25/semantic/hybrid + deltas/reasons
+- [ ] Bounded graph contract includes `bounds.max_hops` + `bounds.max_nodes`
+
+### Code health gates
+- [ ] `go test ./...` passes
+- [ ] `go vet ./...` passes
+
+### Audit artifact package
+- [ ] Go/no-go decision doc finalized (this file)
+- [ ] Auditor command pack finalized (`docs/audits/v0.3.5-rc1-auditor-pack.md`)
+- [ ] RC release notes finalized (`docs/releases/v0.3.5-rc1.md`)
+
+## Current Decision
+
+## ⏳ HOLD (await RC tag + artifact run)
+
+Rationale:
+- Documentation and command paths are now prepared.
+- Final GO should only be declared after immutable RC tag is cut and all gate commands are run against that exact target.
+
+## Auditor Notes
+
+- Audit target must be immutable (`v0.3.5-rc1`) and command transcripts should reference this exact tag/commit.
+- Prefer `scripts/audit_preflight.sh --tag v0.3.5-rc1` to generate reproducible, timestamped evidence artifacts.
+
+## Owner Follow-ups
+
+1. Cut RC tag and publish prerelease artifacts.
+2. Run preflight and attach markdown + logs into audit packet.
+3. Send auditor packet with pinned tag, expected outputs, and any caveats.
+4. After auditor findings, apply fixes and rerun preflight before stable promotion.

--- a/docs/releases/v0.3.5-rc1.md
+++ b/docs/releases/v0.3.5-rc1.md
@@ -1,0 +1,56 @@
+# Cortex v0.3.5-rc1 Release Notes
+
+Date: 2026-02-20
+Tag: `v0.3.5-rc1`
+Status: **RC candidate (pre-audit)**
+
+## Highlights
+
+- **End-to-end reliability gates tightened for release quality**
+  - deterministic runtime connectivity smoke: `scripts/connectivity_smoke.sh`
+  - one-command auditor preflight pack: `scripts/audit_preflight.sh`
+  - release checklist now requires connectivity validation before publish checks pass
+
+- **Visualizer v1 closure (contract-first, bounded graph discipline)**
+  - retrieval debug now includes BM25 + semantic + hybrid + deltas/reasons
+  - bounded provenance explorer retained (`max_hops`, `max_nodes`), no global graph default
+  - issue closure sequence completed for #100 → #101 → #103 → #102 → #104 → #99
+
+- **Audit handoff readiness improved**
+  - reproducible command path for go/no-go + smoke + contract validation
+  - explicit evidence artifact generation for external auditor packet
+
+## Included scope (high-level)
+
+- Core release reliability lanes:
+  - connectivity gate in CI/release flow
+  - audit preflight script and evidence logs
+- Visualizer v1 completion:
+  - Retrieval Debug + Provenance Explorer closure
+  - Memory Quality Engine + Reason Run Inspector already integrated in same v1 stack
+
+## Validation commands
+
+```bash
+python3 -m py_compile scripts/visualizer_export.py scripts/visualizer_api.py scripts/validate_visualizer_contract.py
+python3 scripts/validate_visualizer_contract.py
+scripts/connectivity_smoke.sh
+scripts/audit_rc_smoke.sh
+scripts/audit_preflight.sh --tag v0.3.5-rc1
+go test ./...
+go vet ./...
+```
+
+## Auditor-facing notes
+
+- Audit target should be pinned to immutable tag: `v0.3.5-rc1`.
+- Use the generated preflight report/logs from:
+  - `docs/audits/v0.3.5-rc1-preflight.md`
+  - `docs/audits/v0.3.5-rc1-preflight-logs/`
+- Command pack: `docs/audits/v0.3.5-rc1-auditor-pack.md`
+
+## Post-audit promotion path (planned)
+
+1. Apply any auditor-requested fixes on top of RC branch/tag strategy.
+2. Re-run preflight and smoke with immutable target.
+3. Promote to stable `v0.3.5` only after GO decision and artifact revalidation.


### PR DESCRIPTION
## Summary
Prepares an auditor-ready v0.3.5-rc1 packet and refreshes roadmap docs so Q can hand off a clean external audit package immediately.

## What shipped
### 1) New v0.3.5-rc1 audit docs
- `docs/audits/v0.3.5-rc1-go-no-go.md`
- `docs/audits/v0.3.5-rc1-auditor-pack.md`
- `docs/releases/v0.3.5-rc1.md`

These files codify:
- immutable audit target discipline (`v0.3.5-rc1`)
- exact command path for reliability + visualizer contract gates
- auditor handoff expectations and evidence locations

### 2) Roadmap/doc refresh
- `README.md`
  - marks ops maturity lane completion for RC prep
  - adds lane 9 for audit packet docs
  - updates next priorities for audit execution + codex real-work dogfooding loop
- `docs/CORTEX_DEEP_DIVE.md`
  - updated repo checkpoint and merged-wave summary
  - updates abstraction-layer status and next roadmap slice

### 3) Changelog readiness
- `CHANGELOG.md`
  - adds `0.3.5-rc1` section so release checklist gate can pass for RC path
  - keeps Unreleased section clean

## Validation
- `python3 -m py_compile scripts/visualizer_export.py scripts/visualizer_api.py scripts/validate_visualizer_contract.py`
- `python3 scripts/validate_visualizer_contract.py`
- `scripts/ci_release_guard.sh --offline`
- `scripts/release_checklist.sh --tag v0.3.5-rc1`
- `scripts/audit_preflight.sh --tag v0.3.5-rc1 --out /tmp/v0.3.5-rc1-preflight.md`
- `go test ./...`
- `go vet ./...`

All pass locally.
