### PR TITLE
feat(audit): add adversarial break harness for fresh-user audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Deterministic runtime connectivity smoke gate: `scripts/connectivity_smoke.sh`.
 - One-command external audit preflight pack generator: `scripts/audit_preflight.sh --tag ...`.
+- Adversarial audit sanity harness: `scripts/audit_break_harness.sh`.
 - v0.3.5-rc1 audit handoff docs (`go-no-go`, auditor command pack, release notes).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ cd cortex
 go build ./cmd/cortex/
 go test ./...
 scripts/connectivity_smoke.sh   # end-to-end runtime gate (import→extract→search→optimize)
+scripts/audit_break_harness.sh  # adversarial sanity checks (missing paths + lock/concurrency regressions)
 scripts/audit_preflight.sh --tag v0.3.5-rc1   # generate audit-ready markdown + logs
 ```
 

--- a/docs/audits/v0.3.5-rc1-auditor-pack.md
+++ b/docs/audits/v0.3.5-rc1-auditor-pack.md
@@ -64,7 +64,18 @@ Expected:
 - canonical contract includes `retrieval.deltas[]` with rank movement + reason
 - canonical graph contains bounded `max_hops` and `max_nodes`
 
-## 6) Manual spot checks (optional but recommended)
+## 6) Adversarial break harness (recommended)
+
+```bash
+scripts/audit_break_harness.sh --cortex-bin ./bin/cortex
+```
+
+Expected:
+- missing telemetry path is handled gracefully (no crash)
+- missing import path fails cleanly (non-zero + clear error)
+- known concurrency/lock-recovery regression tests pass
+
+## 7) Manual spot checks (optional but recommended)
 
 ```bash
 python3 scripts/visualizer_export.py \
@@ -80,7 +91,7 @@ Check:
 - Retrieval Debug panel shows BM25 + semantic + hybrid and delta reasons
 - Provenance graph remains bounded and focus-node oriented
 
-## 7) Audit notes template
+## 8) Audit notes template
 
 Capture:
 - tag + commit tested

--- a/docs/audits/v0.3.5-rc1-go-no-go.md
+++ b/docs/audits/v0.3.5-rc1-go-no-go.md
@@ -15,6 +15,7 @@ Scope: v0.3.5-rc1 external audit readiness (release gates + visualizer v1 closur
 - [ ] `scripts/audit_rc_smoke.sh` passes on RC target
 - [ ] `scripts/release_checklist.sh --tag v0.3.5-rc1` passes
 - [ ] `scripts/audit_preflight.sh --tag v0.3.5-rc1` passes and emits report/logs
+- [ ] `scripts/audit_break_harness.sh` passes (adversarial sanity checks)
 
 ### Visualizer contract gates (for #99/#104 closure proof)
 - [ ] `python3 scripts/validate_visualizer_contract.py` passes on RC target

--- a/scripts/audit_break_harness.sh
+++ b/scripts/audit_break_harness.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+audit_break_harness.sh — adversarial sanity checks for external break-audit prep
+
+Usage:
+  scripts/audit_break_harness.sh [--cortex-bin /path/to/cortex]
+
+What it verifies (deterministic):
+1) Missing telemetry file path is handled gracefully (codex-rollout-report exits 0 with Runs parsed: 0)
+2) Missing import path fails cleanly (non-zero, no crash)
+3) Targeted concurrency/recovery regression tests pass:
+   - concurrent identical imports
+   - malformed/zero PID embed lock reclaim
+   - stale migration claim reclaim
+
+This script is intentionally conservative: it checks crash resistance + known reliability regressions.
+EOF
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CORTEX_BIN=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cortex-bin)
+      CORTEX_BIN="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+TMP_DIR="$(mktemp -d -t cortex-break-harness.XXXXXX)"
+BUILT_BIN=""
+cleanup() {
+  if [[ -n "$BUILT_BIN" && -f "$BUILT_BIN" ]]; then
+    rm -f "$BUILT_BIN"
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+if [[ -z "$CORTEX_BIN" ]]; then
+  BUILT_BIN="$(mktemp -t cortex-break-bin.XXXXXX)"
+  echo "==> [1/4] build runtime binary"
+  go build -o "$BUILT_BIN" ./cmd/cortex
+  CORTEX_BIN="$BUILT_BIN"
+else
+  if [[ ! -x "$CORTEX_BIN" ]]; then
+    echo "ERROR: --cortex-bin not executable: $CORTEX_BIN" >&2
+    exit 1
+  fi
+  echo "==> [1/4] use provided binary: $CORTEX_BIN"
+fi
+
+echo "==> [2/4] missing telemetry should not crash"
+MISSING_TELEMETRY="$TMP_DIR/does-not-exist.jsonl"
+ROLL_LOG="$TMP_DIR/rollout_missing.log"
+"$CORTEX_BIN" codex-rollout-report --file "$MISSING_TELEMETRY" >"$ROLL_LOG" 2>&1
+if ! rg -q "Runs parsed:\s*0" "$ROLL_LOG"; then
+  echo "ERROR: expected 'Runs parsed: 0' for missing telemetry file" >&2
+  cat "$ROLL_LOG" >&2
+  exit 1
+fi
+
+echo "==> [3/4] missing import path should fail cleanly"
+MISSING_IMPORT="$TMP_DIR/missing-input.md"
+IMPORT_LOG="$TMP_DIR/import_missing.log"
+set +e
+"$CORTEX_BIN" import "$MISSING_IMPORT" >"$IMPORT_LOG" 2>&1
+import_rc=$?
+set -e
+if [[ $import_rc -eq 0 ]]; then
+  echo "ERROR: expected non-zero exit for missing import path" >&2
+  cat "$IMPORT_LOG" >&2
+  exit 1
+fi
+if ! rg -qi "no such file|cannot|error" "$IMPORT_LOG"; then
+  echo "ERROR: missing import failure did not include expected error text" >&2
+  cat "$IMPORT_LOG" >&2
+  exit 1
+fi
+
+echo "==> [4/4] targeted regression tests"
+go test ./internal/ingest -run TestProcessMemory_ConcurrentIdenticalImports_NoUniqueErrors -v
+go test ./cmd/cortex -run 'TestAcquireEmbedRunLock_Reclaims(MalformedPIDLock|ZeroPIDLock)' -v
+go test ./internal/store -run 'Test(ClaimMetaMigration_ReclaimsDeadPID|MigrateFTSMultiColumn_RecoverStaleInProgressMarker)' -v
+
+echo "✅ audit break harness passed"


### PR DESCRIPTION
## Summary
Prepares Cortex for a true "new-user trying to break it" audit by adding a deterministic adversarial sanity harness and wiring it into the v0.3.5-rc1 auditor packet docs.

## What changed
### 1) New script: `scripts/audit_break_harness.sh`
Checks crash resistance + known reliability regressions:
1. Missing telemetry path in `codex-rollout-report` is handled gracefully (`Runs parsed: 0`, no crash)
2. Missing import path fails cleanly (non-zero + clear error text)
3. Targeted regression tests pass:
   - concurrent identical imports
   - malformed/zero PID embed lock reclaim
   - stale migration claim reclaim

### 2) Auditor packet updates
- `docs/audits/v0.3.5-rc1-auditor-pack.md`
  - adds dedicated adversarial break harness section
  - keeps sequence deterministic for external auditor
- `docs/audits/v0.3.5-rc1-go-no-go.md`
  - adds checklist item for break harness pass

### 3) Readme/changelog
- README contributing snippet includes break harness command
- Changelog `0.3.5-rc1` notes break harness addition

## Why
Q asked to prep for an external auditor behaving like a fresh user attempting to break software. This script gives a repeatable baseline adversarial pass before deeper manual break-testing.

## Validation
- `bash -n scripts/audit_break_harness.sh`
- `scripts/audit_break_harness.sh`
- `python3 scripts/validate_visualizer_contract.py`
- `scripts/release_checklist.sh --tag v0.3.5-rc1`
- `go test ./...`
- `go vet ./...`

All pass locally.
