### PR TITLE
fix(audit): close fresh-user break findings (F-01..F-05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to this project will be documented in this file.
 - RC smoke now includes runtime connectivity validation.
 - Visualizer closure includes retrieval-debug deltas/reasons across bm25+semantic+hybrid and bounded provenance contract enforcement.
 
+### Fixed
+- Importer now rejects symlinked directory recursion paths (prevents symlink-loop stack overflow crashes).
+- Recursive directory imports now surface unreadable walk paths as explicit import errors (no silent partial-success).
+- `codex-rollout-report --warn-only=false` now fails when zero valid telemetry runs are parsed.
+- `CORTEX_DB=~/...` and `--db ~/...` now expand `~` to user home before DB open.
+- `cortex search --limit` now validates bounds (`1..1000`) instead of silently coercing invalid values.
+
 ## [0.3.4] - 2026-02-20
 
 ### Added

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -202,10 +202,10 @@ func parseGlobalFlags(args []string) []string {
 // --db flag > CORTEX_DB env var > default path
 func getDBPath() string {
 	if globalDBPath != "" {
-		return globalDBPath
+		return expandUserPath(globalDBPath)
 	}
 	if envPath := os.Getenv("CORTEX_DB"); envPath != "" {
-		return envPath
+		return expandUserPath(envPath)
 	}
 	return "" // Let store.NewStore use its default
 }
@@ -594,6 +594,9 @@ func runSearch(args []string) error {
 	query := strings.Join(queryParts, " ")
 	if query == "" {
 		return fmt.Errorf("usage: cortex search <query> [--mode keyword|semantic|hybrid] [--limit N] [--embed <provider/model>] [--class rule,decision] [--no-class-boost] [--include-superseded] [--explain] [--json] [--agent <id>] [--channel <name>] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--show-metadata]")
+	}
+	if limit < 1 || limit > 1000 {
+		return fmt.Errorf("--limit must be between 1 and 1000")
 	}
 
 	searchMode, err := search.ParseMode(mode)

--- a/docs/audits/v0.3.5-rc1-auditor-pack.md
+++ b/docs/audits/v0.3.5-rc1-auditor-pack.md
@@ -71,8 +71,10 @@ scripts/audit_break_harness.sh --cortex-bin ./bin/cortex
 ```
 
 Expected:
-- missing telemetry path is handled gracefully (no crash)
+- missing telemetry path is handled gracefully (warn-only 0, strict non-zero)
 - missing import path fails cleanly (non-zero + clear error)
+- symlink-loop recursive import fails cleanly (no stack overflow)
+- unreadable recursive subtrees are surfaced as explicit import errors
 - known concurrency/lock-recovery regression tests pass
 
 ## 7) Manual spot checks (optional but recommended)

--- a/docs/releases/v0.3.5-rc1.md
+++ b/docs/releases/v0.3.5-rc1.md
@@ -19,6 +19,14 @@ Status: **RC candidate (pre-audit)**
 - **Audit handoff readiness improved**
   - reproducible command path for go/no-go + smoke + contract validation
   - explicit evidence artifact generation for external auditor packet
+  - adversarial break harness path for fresh-user destructive audit rehearsal
+
+- **External pre-audit findings remediated**
+  - symlink-loop recursive import no longer crashes (clean failure path)
+  - strict rollout guard now fails when telemetry has zero valid runs
+  - unreadable recursive subtree paths are surfaced as explicit import errors
+  - `CORTEX_DB=~/...` and `--db ~/...` now expand to home directory
+  - `cortex search --limit` now enforces safe bounds (`1..1000`)
 
 ## Included scope (high-level)
 

--- a/internal/codexrollout/report.go
+++ b/internal/codexrollout/report.go
@@ -108,6 +108,9 @@ func ExecuteWithOptions(opts Options) (*Result, error) {
 
 	r := BuildReport(events, skipped)
 	warnings := EvaluateGuardrails(r, opts.Guardrails)
+	if r.TotalRuns == 0 {
+		warnings = append(warnings, "no valid telemetry runs parsed")
+	}
 	output := RenderReport(opts.FilePath, r, warnings, opts.Guardrails)
 
 	exitCode := 0

--- a/scripts/audit_break_harness.sh
+++ b/scripts/audit_break_harness.sh
@@ -9,9 +9,13 @@ Usage:
   scripts/audit_break_harness.sh [--cortex-bin /path/to/cortex]
 
 What it verifies (deterministic):
-1) Missing telemetry file path is handled gracefully (codex-rollout-report exits 0 with Runs parsed: 0)
+1) Missing telemetry file path is handled gracefully:
+   - warn-only mode exits 0 with Runs parsed: 0
+   - strict mode exits non-zero (no valid runs should fail gate)
 2) Missing import path fails cleanly (non-zero, no crash)
-3) Targeted concurrency/recovery regression tests pass:
+3) Symlink-loop directory import fails cleanly (no stack overflow)
+4) Unreadable recursive subtree is surfaced as an explicit error (no silent partial success)
+5) Targeted concurrency/recovery regression tests pass:
    - concurrent identical imports
    - malformed/zero PID embed lock reclaim
    - stale migration claim reclaim
@@ -54,7 +58,7 @@ trap cleanup EXIT
 
 if [[ -z "$CORTEX_BIN" ]]; then
   BUILT_BIN="$(mktemp -t cortex-break-bin.XXXXXX)"
-  echo "==> [1/4] build runtime binary"
+  echo "==> [1/6] build runtime binary"
   go build -o "$BUILT_BIN" ./cmd/cortex
   CORTEX_BIN="$BUILT_BIN"
 else
@@ -62,10 +66,10 @@ else
     echo "ERROR: --cortex-bin not executable: $CORTEX_BIN" >&2
     exit 1
   fi
-  echo "==> [1/4] use provided binary: $CORTEX_BIN"
+  echo "==> [1/6] use provided binary: $CORTEX_BIN"
 fi
 
-echo "==> [2/4] missing telemetry should not crash"
+echo "==> [2/6] missing telemetry handling (warn-only + strict)"
 MISSING_TELEMETRY="$TMP_DIR/does-not-exist.jsonl"
 ROLL_LOG="$TMP_DIR/rollout_missing.log"
 "$CORTEX_BIN" codex-rollout-report --file "$MISSING_TELEMETRY" >"$ROLL_LOG" 2>&1
@@ -75,7 +79,23 @@ if ! rg -q "Runs parsed:\s*0" "$ROLL_LOG"; then
   exit 1
 fi
 
-echo "==> [3/4] missing import path should fail cleanly"
+STRICT_LOG="$TMP_DIR/rollout_missing_strict.log"
+set +e
+"$CORTEX_BIN" codex-rollout-report --file "$MISSING_TELEMETRY" --warn-only=false >"$STRICT_LOG" 2>&1
+strict_rc=$?
+set -e
+if [[ $strict_rc -eq 0 ]]; then
+  echo "ERROR: strict mode should fail when no telemetry runs are parsed" >&2
+  cat "$STRICT_LOG" >&2
+  exit 1
+fi
+if ! rg -qi "no valid telemetry runs" "$STRICT_LOG"; then
+  echo "ERROR: strict zero-run path missing expected warning text" >&2
+  cat "$STRICT_LOG" >&2
+  exit 1
+fi
+
+echo "==> [3/6] missing import path should fail cleanly"
 MISSING_IMPORT="$TMP_DIR/missing-input.md"
 IMPORT_LOG="$TMP_DIR/import_missing.log"
 set +e
@@ -93,7 +113,59 @@ if ! rg -qi "no such file|cannot|error" "$IMPORT_LOG"; then
   exit 1
 fi
 
-echo "==> [4/4] targeted regression tests"
+echo "==> [4/6] symlink-loop import should fail cleanly"
+LOOP_DIR="$TMP_DIR/loopdir"
+mkdir -p "$LOOP_DIR/sub"
+if ln -s "$LOOP_DIR" "$LOOP_DIR/sub/back" 2>/dev/null; then
+  LOOP_LOG="$TMP_DIR/import_loop.log"
+  set +e
+  "$CORTEX_BIN" --db "$TMP_DIR/loop.db" import "$LOOP_DIR" -r >"$LOOP_LOG" 2>&1
+  loop_rc=$?
+  set -e
+  if [[ $loop_rc -eq 0 ]]; then
+    echo "ERROR: expected non-zero exit for symlink-loop import" >&2
+    cat "$LOOP_LOG" >&2
+    exit 1
+  fi
+  if ! rg -qi "symlinked directory|cycle|error" "$LOOP_LOG"; then
+    echo "ERROR: symlink-loop import output missing expected cycle/symlink error text" >&2
+    cat "$LOOP_LOG" >&2
+    exit 1
+  fi
+else
+  echo "  (symlink creation unavailable in this environment; skipping symlink-loop check)"
+fi
+
+echo "==> [5/6] unreadable subtree should surface explicit import errors"
+PARTIAL_DIR="$TMP_DIR/partial"
+mkdir -p "$PARTIAL_DIR/secret"
+cat > "$PARTIAL_DIR/ok.md" <<'EOF'
+# Visible
+safe content
+EOF
+cat > "$PARTIAL_DIR/secret/hidden.md" <<'EOF'
+# Hidden
+should trigger walk error
+EOF
+chmod 000 "$PARTIAL_DIR/secret" || true
+PARTIAL_LOG="$TMP_DIR/import_partial.log"
+set +e
+"$CORTEX_BIN" --db "$TMP_DIR/partial.db" import "$PARTIAL_DIR" -r >"$PARTIAL_LOG" 2>&1
+partial_rc=$?
+set -e
+chmod 755 "$PARTIAL_DIR/secret" || true
+if [[ $partial_rc -eq 0 ]]; then
+  echo "ERROR: expected non-zero exit when recursive import hits unreadable subtree" >&2
+  cat "$PARTIAL_LOG" >&2
+  exit 1
+fi
+if ! rg -qi "walk error|permission denied|error" "$PARTIAL_LOG"; then
+  echo "ERROR: unreadable subtree path did not surface explicit walk/import error" >&2
+  cat "$PARTIAL_LOG" >&2
+  exit 1
+fi
+
+echo "==> [6/6] targeted regression tests"
 go test ./internal/ingest -run TestProcessMemory_ConcurrentIdenticalImports_NoUniqueErrors -v
 go test ./cmd/cortex -run 'TestAcquireEmbedRunLock_Reclaims(MalformedPIDLock|ZeroPIDLock)' -v
 go test ./internal/store -run 'Test(ClaimMetaMigration_ReclaimsDeadPID|MigrateFTSMultiColumn_RecoverStaleInProgressMarker)' -v


### PR DESCRIPTION
## Summary
Remediates the external fresh-user break-audit findings and hardens the audit harness so these regressions are now gate-covered.

## Findings addressed
### F-01 (High) — symlink-loop recursive import stack overflow
- `internal/ingest/ingest.go`
  - `ImportFile`: rejects symlinked directory imports early.
  - `ImportDir`: skips symlinked directories during walk and records explicit errors.

### F-02 (High) — strict telemetry false-green on zero valid runs
- `internal/codexrollout/report.go`
  - `ExecuteWithOptions`: adds warning `no valid telemetry runs parsed` when `TotalRuns == 0`.
  - strict mode now exits non-zero in this case.
- tests added in `internal/codexrollout/report_test.go`.

### F-03 (Medium) — unreadable recursive subtree silently skipped
- `internal/ingest/ingest.go`
  - walk errors are now accumulated into `ImportResult.Errors` instead of silently dropped.
  - directory walk errors use `SkipDir` to continue safely while preserving error visibility.
- tests added in `internal/ingest/ingest_test.go`.

### F-04 (Medium) — `CORTEX_DB=~/...` not expanded
- `cmd/cortex/main.go`
  - `getDBPath()` now expands `~` for both `--db` and `CORTEX_DB` values.
- tests added in `cmd/cortex/main_test.go`.

### F-05 (Low) — `search --limit` accepted invalid values silently
- `cmd/cortex/main.go`
  - `runSearch` now validates `--limit` in range `1..1000` and errors otherwise.
- tests added in `cmd/cortex/main_test.go`.

## Harness/docs hardening
- `scripts/audit_break_harness.sh`
  - now verifies strict zero-run telemetry failure behavior
  - now includes symlink-loop import failure check
  - now includes unreadable recursive subtree error-surfacing check
- updated:
  - `docs/audits/v0.3.5-rc1-auditor-pack.md`
  - `docs/releases/v0.3.5-rc1.md`
  - `CHANGELOG.md`

## Validation
- `go test ./...`
- `go vet ./...`
- `scripts/audit_break_harness.sh`
- `scripts/release_checklist.sh --tag v0.3.5-rc1`
- `scripts/audit_preflight.sh --tag v0.3.5-rc1`
- `python3 scripts/validate_visualizer_contract.py`

All passed locally.
