### PR TITLE
fix(visualizer): guard export output paths against traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - `codex-rollout-report --warn-only=false` now fails when zero valid telemetry runs are parsed.
 - `CORTEX_DB=~/...` and `--db ~/...` now expand `~` to user home before DB open.
 - `cortex search --limit` now validates bounds (`1..1000`) instead of silently coercing invalid values.
+- `visualizer_export.py` now rejects output paths outside workspace root by default (prevents traversal-style `../` writes unless explicitly overridden).
 
 ## [0.3.4] - 2026-02-20
 

--- a/docs/audits/v0.3.5-rc1-auditor-pack.md
+++ b/docs/audits/v0.3.5-rc1-auditor-pack.md
@@ -75,6 +75,7 @@ Expected:
 - missing import path fails cleanly (non-zero + clear error)
 - symlink-loop recursive import fails cleanly (no stack overflow)
 - unreadable recursive subtrees are surfaced as explicit import errors
+- traversal-style `visualizer_export.py --output ../...` is rejected by default
 - known concurrency/lock-recovery regression tests pass
 
 ## 7) Manual spot checks (optional but recommended)

--- a/docs/audits/v0.3.5-rc1-go-no-go.md
+++ b/docs/audits/v0.3.5-rc1-go-no-go.md
@@ -16,6 +16,7 @@ Scope: v0.3.5-rc1 external audit readiness (release gates + visualizer v1 closur
 - [ ] `scripts/release_checklist.sh --tag v0.3.5-rc1` passes
 - [ ] `scripts/audit_preflight.sh --tag v0.3.5-rc1` passes and emits report/logs
 - [ ] `scripts/audit_break_harness.sh` passes (adversarial sanity checks)
+- [ ] traversal-style visualizer export paths are rejected by default unless explicitly overridden
 
 ### Visualizer contract gates (for #99/#104 closure proof)
 - [ ] `python3 scripts/validate_visualizer_contract.py` passes on RC target

--- a/docs/releases/v0.3.5-rc1.md
+++ b/docs/releases/v0.3.5-rc1.md
@@ -27,6 +27,7 @@ Status: **RC candidate (pre-audit)**
   - unreadable recursive subtree paths are surfaced as explicit import errors
   - `CORTEX_DB=~/...` and `--db ~/...` now expand to home directory
   - `cortex search --limit` now enforces safe bounds (`1..1000`)
+  - `visualizer_export.py` output paths are workspace-bound by default (rejects traversal-style `../` paths)
 
 ## Included scope (high-level)
 

--- a/docs/visualizer/README.md
+++ b/docs/visualizer/README.md
@@ -25,6 +25,10 @@ python3 scripts/visualizer_export.py \
   --obsidian-vault-dir docs/visualizer/data/obsidian-vault
 ```
 
+Safety note:
+- Output paths are workspace-bound by default (prevents `../` traversal-style writes).
+- If you intentionally need output outside the repo, pass `--allow-outside-workdir`.
+
 Data sources currently used:
 - `cortex stats --json`
 - `~/.cortex/reason-telemetry.jsonl`


### PR DESCRIPTION
## Summary
Implements the post-audit hardening item from the delta destructive audit: prevent traversal-style writes from `visualizer_export.py` output flags.

## What changed
### 1) Path boundary guard in exporter
- `scripts/visualizer_export.py`
  - Adds workspace-root guard for:
    - `--output`
    - `--obsidian-output`
    - `--obsidian-vault-dir`
  - Default behavior now rejects paths outside repo root (e.g. `../escape.json`).
  - Adds explicit override flag:
    - `--allow-outside-workdir`

### 2) Break harness now tests this vector
- `scripts/audit_break_harness.sh`
  - Adds deterministic check that traversal-style `visualizer_export.py --output ../...` fails with explicit boundary error.

### 3) Docs updates
- `docs/visualizer/README.md` safety note for new default/override.
- `docs/audits/v0.3.5-rc1-auditor-pack.md` and `docs/audits/v0.3.5-rc1-go-no-go.md` include this check.
- `docs/releases/v0.3.5-rc1.md` + `CHANGELOG.md` updated with hardening note.

## Why
External delta destructive audit reported one remaining low-severity vector: traversal-style export output paths could escape repo tree. This closes that gap and folds it into repeatable gate coverage.

## Validation
- `python3 -m py_compile scripts/visualizer_export.py scripts/visualizer_api.py scripts/validate_visualizer_contract.py`
- `go test ./...`
- `go vet ./...`
- `scripts/audit_break_harness.sh`
- `scripts/release_checklist.sh --tag v0.3.5-rc1`
- `scripts/audit_preflight.sh --tag v0.3.5-rc1`
- `python3 scripts/validate_visualizer_contract.py`

All pass locally.
