### PR TITLE
docs(release): prep v0.3.5-rc2 auditor packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 - No unreleased entries yet.
 
+## [0.3.5-rc2] - 2026-02-20
+
+### Fixed
+- Release checklist guard no longer hard-depends on `rg`; now uses `grep` fallback when `rg` is unavailable (fixes release-runner portability).
+
+### Added
+- v0.3.5-rc2 audit handoff docs (`go-no-go`, auditor command pack, release notes).
+
 ## [0.3.5-rc1] - 2026-02-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ Core memory platform is shipped and stable:
 - RC + delta audit process codified with go/no-go docs
 - Release artifact verification and reproducible smoke paths
 
-### 🚀 Phase 4 — Ops Maturity *(Complete for v0.3.5-rc1 prep)*
+### 🚀 Phase 4 — Ops Maturity *(Complete for v0.3.5-rc2 prep)*
 Shipped on `main`:
 - **Lane 1:** `cortex optimize` maintenance command
 - **Lane 2:** `scripts/slo_snapshot.sh` report artifacts (JSON/markdown)
@@ -738,10 +738,10 @@ Shipped on `main`:
 - **Lane 6:** thresholded canary warn/fail bands (`PASS|WARN|FAIL`)
 - **Lane 7:** deterministic runtime connectivity smoke gate (`scripts/connectivity_smoke.sh`)
 - **Lane 8:** one-command external audit preflight artifact (`scripts/audit_preflight.sh`)
-- **Lane 9:** v0.3.5-rc1 audit packet docs (`docs/audits/v0.3.5-rc1-*.md`, `docs/releases/v0.3.5-rc1.md`)
+- **Lane 9:** v0.3.5-rc2 audit packet docs (`docs/audits/v0.3.5-rc2-*.md`, `docs/releases/v0.3.5-rc2.md`)
 
 ### 🔭 Phase 5 — Next Priorities
-- Run external audit on immutable target `v0.3.5-rc1` and close findings
+- Run external audit on immutable target `v0.3.5-rc2` and close findings
 - Codex real-work dogfooding loop (collect evidence, tune thresholds/prompting only when data justifies)
 - SLO trend comparison across canary history (relative regression detection)
 - Dashboard-grade visibility for release gates + canary trend history
@@ -749,7 +749,7 @@ Shipped on `main`:
 ### Current State
 - Latest stable release: **`v0.3.4`**
 - Current source fallback version: **`0.3.5-dev`**
-- Audit prep docs ready for next RC: **`v0.3.5-rc1`**
+- Audit prep docs ready for next RC: **`v0.3.5-rc2`**
 - Open issues: **none**
 
 See [docs/CORTEX_DEEP_DIVE.md](docs/CORTEX_DEEP_DIVE.md) for the full strategic deep dive and [docs/prd/](docs/prd/) for detailed implementation specs.
@@ -768,7 +768,7 @@ go build ./cmd/cortex/
 go test ./...
 scripts/connectivity_smoke.sh   # end-to-end runtime gate (import→extract→search→optimize)
 scripts/audit_break_harness.sh  # adversarial sanity checks (missing paths + lock/concurrency regressions)
-scripts/audit_preflight.sh --tag v0.3.5-rc1   # generate audit-ready markdown + logs
+scripts/audit_preflight.sh --tag v0.3.5-rc2   # generate audit-ready markdown + logs
 ```
 
 - 📖 Read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines

--- a/docs/CORTEX_DEEP_DIVE.md
+++ b/docs/CORTEX_DEEP_DIVE.md
@@ -19,7 +19,7 @@ Cortex has moved from “feature buildout” into “operational hardening + rel
 
 ### What is true right now
 - Stable release is live: **v0.3.4**
-- v0.3.5-rc1 audit packet scaffolding is prepared (`docs/audits/` + `docs/releases/`)
+- v0.3.5-rc2 audit packet scaffolding is prepared (`docs/audits/` + `docs/releases/`)
 - Visualizer v1 closure sequence is complete (#99 and #104 are closed)
 - Post-release hardening lanes (v0.3.5-dev) are fully shipped on `main`
 - Current open issue count: **0** (at time of refresh)
@@ -105,7 +105,7 @@ Now, beyond that baseline, Cortex added:
 3. **Deterministic connectivity gate** for release/runtime path validation
 4. **One-command audit preflight** that emits markdown + per-step logs
 5. **Visualizer v1 closure** including retrieval-debug deltas and bounded provenance explorer
-6. **RC audit packet scaffolding** for `v0.3.5-rc1` (go/no-go + auditor command pack + release notes)
+6. **RC audit packet scaffolding** for `v0.3.5-rc2` (go/no-go + auditor command pack + release notes)
 
 ---
 
@@ -164,7 +164,7 @@ The platform is now strong on correctness and operations. The next strategic unl
 
 ## Recommended Next Roadmap Slice (Post RC-prep lanes)
 
-1. **External audit execution:** run immutable-target audit on `v0.3.5-rc1`, collect findings, close deltas.
+1. **External audit execution:** run immutable-target audit on `v0.3.5-rc2`, collect findings, close deltas.
 2. **Codex real-work tuning loop:** continue production dogfooding and adjust thresholds/prompts only from measured regressions.
 3. **SLO trend intelligence:** compare latest canary against historical baseline for relative regressions, not only static thresholds.
 4. **Gate observability dashboard:** unify release checks, canary trends, and audit preflight history into one operator view.

--- a/docs/audits/v0.3.5-rc2-auditor-pack.md
+++ b/docs/audits/v0.3.5-rc2-auditor-pack.md
@@ -1,0 +1,104 @@
+# Cortex v0.3.5-rc2 Auditor Command Pack
+
+Audit target:
+- Repo: `hurttlocker/cortex`
+- Tag: `v0.3.5-rc2`
+- Focus: release reliability gates + visualizer v1 contract closure
+- Gate summary: see `docs/audits/v0.3.5-rc2-go-no-go.md`
+
+## 1) Environment / provenance
+
+```bash
+git clone https://github.com/hurttlocker/cortex.git
+cd cortex
+git checkout v0.3.5-rc2
+
+go version
+```
+
+## 2) Build + baseline tests
+
+```bash
+go test ./...
+go vet ./...
+go build -o ./bin/cortex ./cmd/cortex
+./bin/cortex version
+```
+
+Expected:
+- tests pass
+- vet pass
+- binary prints `cortex 0.3.5-rc1` (or release ldflags version)
+
+## 3) Release + runtime gate checks
+
+```bash
+scripts/release_checklist.sh --tag v0.3.5-rc2
+scripts/connectivity_smoke.sh --cortex-bin ./bin/cortex
+scripts/audit_rc_smoke.sh
+```
+
+Expected:
+- all commands pass
+- strict mode section in RC smoke still emits WARN lines and non-zero signaling when fixture forces guardrail warnings
+
+## 4) One-command preflight evidence pack
+
+```bash
+scripts/audit_preflight.sh --tag v0.3.5-rc2
+```
+
+Expected artifacts:
+- `docs/audits/v0.3.5-rc2-preflight.md`
+- `docs/audits/v0.3.5-rc2-preflight-logs/*.log`
+
+## 5) Visualizer contract closure checks
+
+```bash
+python3 -m py_compile scripts/visualizer_export.py scripts/visualizer_api.py scripts/validate_visualizer_contract.py
+python3 scripts/validate_visualizer_contract.py
+```
+
+Expected:
+- canonical contract includes retrieval lists for `bm25`, `semantic`, and `hybrid`
+- canonical contract includes `retrieval.deltas[]` with rank movement + reason
+- canonical graph contains bounded `max_hops` and `max_nodes`
+
+## 6) Adversarial break harness (recommended)
+
+```bash
+scripts/audit_break_harness.sh --cortex-bin ./bin/cortex
+```
+
+Expected:
+- missing telemetry path is handled gracefully (warn-only 0, strict non-zero)
+- missing import path fails cleanly (non-zero + clear error)
+- symlink-loop recursive import fails cleanly (no stack overflow)
+- unreadable recursive subtrees are surfaced as explicit import errors
+- traversal-style `visualizer_export.py --output ../...` is rejected by default
+- known concurrency/lock-recovery regression tests pass
+
+## 7) Manual spot checks (optional but recommended)
+
+```bash
+python3 scripts/visualizer_export.py \
+  --output docs/visualizer/data/latest.json \
+  --obsidian-output docs/visualizer/data/obsidian-graph.json \
+  --obsidian-vault-dir docs/visualizer/data/obsidian-vault
+
+python3 scripts/visualizer_api.py --bootstrap --port 8787
+# open http://127.0.0.1:8787/prototype-v1.html
+```
+
+Check:
+- Retrieval Debug panel shows BM25 + semantic + hybrid and delta reasons
+- Provenance graph remains bounded and focus-node oriented
+
+## 8) Audit notes template
+
+Capture:
+- tag + commit tested
+- full command transcript
+- pass/fail per section
+- deviations from expected output
+- recommendations for follow-up before stable promotion

--- a/docs/audits/v0.3.5-rc2-go-no-go.md
+++ b/docs/audits/v0.3.5-rc2-go-no-go.md
@@ -1,0 +1,53 @@
+# v0.3.5-rc2 Pre-Audit Go/No-Go Handoff
+
+Date: 2026-02-20
+Scope: v0.3.5-rc2 external audit readiness (release gates + visualizer v1 closure + ops maturity controls).
+
+## Gate Checklist
+
+### Release integrity
+- [ ] `v0.3.5-rc2` pre-release published
+- [ ] Assets present (darwin/linux/windows + checksums)
+- [ ] One checksum spot-check completed from release assets
+
+### Runtime behavior + reliability gates
+- [ ] `scripts/connectivity_smoke.sh` passes on RC target
+- [ ] `scripts/audit_rc_smoke.sh` passes on RC target
+- [ ] `scripts/release_checklist.sh --tag v0.3.5-rc2` passes
+- [ ] `scripts/audit_preflight.sh --tag v0.3.5-rc2` passes and emits report/logs
+- [ ] `scripts/audit_break_harness.sh` passes (adversarial sanity checks)
+- [ ] traversal-style visualizer export paths are rejected by default unless explicitly overridden
+
+### Visualizer contract gates (for #99/#104 closure proof)
+- [ ] `python3 scripts/validate_visualizer_contract.py` passes on RC target
+- [ ] Retrieval payload includes bm25/semantic/hybrid + deltas/reasons
+- [ ] Bounded graph contract includes `bounds.max_hops` + `bounds.max_nodes`
+
+### Code health gates
+- [ ] `go test ./...` passes
+- [ ] `go vet ./...` passes
+
+### Audit artifact package
+- [ ] Go/no-go decision doc finalized (this file)
+- [ ] Auditor command pack finalized (`docs/audits/v0.3.5-rc2-auditor-pack.md`)
+- [ ] RC release notes finalized (`docs/releases/v0.3.5-rc2.md`)
+
+## Current Decision
+
+## ⏳ HOLD (await RC tag + artifact run)
+
+Rationale:
+- Documentation and command paths are now prepared.
+- Final GO should only be declared after immutable RC tag is cut and all gate commands are run against that exact target.
+
+## Auditor Notes
+
+- Audit target must be immutable (`v0.3.5-rc2`) and command transcripts should reference this exact tag/commit.
+- Prefer `scripts/audit_preflight.sh --tag v0.3.5-rc2` to generate reproducible, timestamped evidence artifacts.
+
+## Owner Follow-ups
+
+1. Cut RC tag and publish prerelease artifacts.
+2. Run preflight and attach markdown + logs into audit packet.
+3. Send auditor packet with pinned tag, expected outputs, and any caveats.
+4. After auditor findings, apply fixes and rerun preflight before stable promotion.

--- a/docs/releases/v0.3.5-rc2.md
+++ b/docs/releases/v0.3.5-rc2.md
@@ -1,0 +1,65 @@
+# Cortex v0.3.5-rc2 Release Notes
+
+Date: 2026-02-20
+Tag: `v0.3.5-rc2`
+Status: **RC candidate (pre-audit)**
+
+## Highlights
+
+- **End-to-end reliability gates tightened for release quality**
+  - deterministic runtime connectivity smoke: `scripts/connectivity_smoke.sh`
+  - one-command auditor preflight pack: `scripts/audit_preflight.sh`
+  - release checklist now requires connectivity validation before publish checks pass
+
+- **Visualizer v1 closure (contract-first, bounded graph discipline)**
+  - retrieval debug now includes BM25 + semantic + hybrid + deltas/reasons
+  - bounded provenance explorer retained (`max_hops`, `max_nodes`), no global graph default
+  - issue closure sequence completed for #100 → #101 → #103 → #102 → #104 → #99
+
+- **Audit handoff readiness improved**
+  - reproducible command path for go/no-go + smoke + contract validation
+  - explicit evidence artifact generation for external auditor packet
+  - adversarial break harness path for fresh-user destructive audit rehearsal
+
+- **External pre-audit findings remediated**
+  - symlink-loop recursive import no longer crashes (clean failure path)
+  - strict rollout guard now fails when telemetry has zero valid runs
+  - unreadable recursive subtree paths are surfaced as explicit import errors
+  - `CORTEX_DB=~/...` and `--db ~/...` now expand to home directory
+  - `cortex search --limit` now enforces safe bounds (`1..1000`)
+  - `visualizer_export.py` output paths are workspace-bound by default (rejects traversal-style `../` paths)
+
+## Included scope (high-level)
+
+- Core release reliability lanes:
+  - connectivity gate in CI/release flow
+  - audit preflight script and evidence logs
+- Visualizer v1 completion:
+  - Retrieval Debug + Provenance Explorer closure
+  - Memory Quality Engine + Reason Run Inspector already integrated in same v1 stack
+
+## Validation commands
+
+```bash
+python3 -m py_compile scripts/visualizer_export.py scripts/visualizer_api.py scripts/validate_visualizer_contract.py
+python3 scripts/validate_visualizer_contract.py
+scripts/connectivity_smoke.sh
+scripts/audit_rc_smoke.sh
+scripts/audit_preflight.sh --tag v0.3.5-rc2
+go test ./...
+go vet ./...
+```
+
+## Auditor-facing notes
+
+- Audit target should be pinned to immutable tag: `v0.3.5-rc2`.
+- Use the generated preflight report/logs from:
+  - `docs/audits/v0.3.5-rc2-preflight.md`
+  - `docs/audits/v0.3.5-rc2-preflight-logs/`
+- Command pack: `docs/audits/v0.3.5-rc2-auditor-pack.md`
+
+## Post-audit promotion path (planned)
+
+1. Apply any auditor-requested fixes on top of RC branch/tag strategy.
+2. Re-run preflight and smoke with immutable target.
+3. Promote to stable `v0.3.5` only after GO decision and artifact revalidation.


### PR DESCRIPTION
## Summary
Prepares v0.3.5-rc2 release/audit docs after the rc1 release-runner portability fix.

## Why rc2
- `v0.3.5-rc1` tag release failed due to `rg` not found in release runner checklist step.
- PR #126 fixed the checklist script (`grep` fallback).
- This PR aligns docs/roadmap to immutable next target: `v0.3.5-rc2`.

## What changed
- Added:
  - `docs/releases/v0.3.5-rc2.md`
  - `docs/audits/v0.3.5-rc2-go-no-go.md`
  - `docs/audits/v0.3.5-rc2-auditor-pack.md`
- Updated:
  - `CHANGELOG.md` with `0.3.5-rc2` section
  - `README.md` roadmap/current-state references to rc2
  - `docs/CORTEX_DEEP_DIVE.md` references to rc2

## Validation
- `go test ./...`
- `go vet ./...`
- `scripts/audit_break_harness.sh`
- `scripts/release_checklist.sh --tag v0.3.5-rc2`
- `scripts/audit_preflight.sh --tag v0.3.5-rc2`
- `python3 scripts/validate_visualizer_contract.py`

All pass locally.
