### PR TITLE
release: prep v0.3.5 stable notes + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to this project will be documented in this file.
 
 - No unreleased entries yet.
 
+## [0.3.5] - 2026-02-20
+
+### Added
+- Stable promotion from externally validated RC target `v0.3.5-rc2`.
+- External hostile-audit evidence path (immutable artifact + fresh-clone + adversarial checks) documented for release continuity.
+
+### Changed
+- Release promotion path now depends on successful hostile audit gate outcomes before stable tag publication.
+
+### Fixed
+- Carry-forward of RC hardening into stable:
+  - traversal-safe visualizer export output path guards
+  - strict rollout no-valid-telemetry non-zero enforcement
+  - unreadable recursive import subtree explicit failures
+  - symlink-loop recursion rejection in importer
+  - release checklist portability when `rg` is unavailable
+
+### Validation
+- External hostile audit verdict for `v0.3.5-rc2`: **GO** (no reproducible product findings).
+- Required gates pass: `audit_break_harness`, `audit_preflight`, `release_checklist`.
+
 ## [0.3.5-rc2] - 2026-02-20
 
 ### Fixed

--- a/docs/releases/v0.3.5.md
+++ b/docs/releases/v0.3.5.md
@@ -1,0 +1,45 @@
+# Cortex v0.3.5 Release Notes
+
+Date: 2026-02-20
+Tag: `v0.3.5`
+
+## Summary
+
+`v0.3.5` promotes the externally audited `v0.3.5-rc2` candidate to stable.
+
+## Highlights
+
+- **External hostile-audit validated promotion path**
+  - Immutable artifact checks passed (download, checksum, runtime behavior).
+  - Fresh-clone-from-`main` destructive audit checks passed.
+  - No reproducible product findings in external audit report.
+
+- **Reliability + release gate hardening now in stable**
+  - deterministic runtime connectivity smoke (`scripts/connectivity_smoke.sh`)
+  - one-command audit preflight (`scripts/audit_preflight.sh`)
+  - adversarial break harness (`scripts/audit_break_harness.sh`)
+  - portable release checklist guard (works even when `rg` is unavailable)
+
+- **Security/reliability fixes carried from RC wave**
+  - recursive importer rejects symlink-loop recursion paths cleanly
+  - recursive importer surfaces unreadable subtree walk errors explicitly
+  - strict rollout report mode fails on zero valid telemetry runs
+  - `CORTEX_DB=~/...` and `--db ~/...` expand home paths correctly
+  - `search --limit` enforces safe bounds (`1..1000`)
+  - `visualizer_export.py` blocks traversal-style output paths by default
+
+## Audit Position
+
+- RC audit target: `v0.3.5-rc2`
+- External hostile audit verdict: **GO**
+- Required gate summary: **PASS**
+  - `scripts/audit_break_harness.sh`
+  - `scripts/audit_preflight.sh --tag v0.3.5-rc2`
+  - `scripts/release_checklist.sh --tag v0.3.5-rc2`
+
+## Quick Verify
+
+```bash
+cortex version
+cortex codex-rollout-report --help
+```


### PR DESCRIPTION
## Summary
Prepare stable promotion for `v0.3.5` by adding stable release notes and changelog entry, based on externally validated `v0.3.5-rc2`.

## Changes
- `CHANGELOG.md`
  - adds `## [0.3.5] - 2026-02-20`
  - records stable promotion scope + validation posture
- `docs/releases/v0.3.5.md`
  - stable release notes with highlights, audit position, and quick verify

## Validation
- `go test ./...`
- `go vet ./...`
- `scripts/release_checklist.sh --tag v0.3.5`
- `scripts/audit_break_harness.sh`
- `scripts/audit_preflight.sh --tag v0.3.5`
- `python3 scripts/validate_visualizer_contract.py`

All pass locally.
