### PR TITLE
docs: add brand assets guide and README navigation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   <a href="#-how-cortex-is-different">What's Different</a> •
   <a href="#-vs-alternatives">Comparison</a> •
   <a href="#-roadmap">Roadmap</a> •
+  <a href="docs/branding.md">Brand Assets</a> •
   <a href="#-contributing">Contributing</a>
 </p>
 

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,0 +1,39 @@
+# Cortex Brand Assets
+
+This document is the single source of truth for logo and icon files used across Cortex.
+
+## Primary Logo
+
+- **README logo (transparent):** `docs/assets/cortex-logo-redpink-transparent.png`
+
+## Quick Usage Guide
+
+| Use case | File |
+|---|---|
+| Browser favicon (ICO) | `docs/assets/icons/favicon.ico` |
+| Browser favicon (PNG) | `docs/assets/favicon-16.png`, `docs/assets/favicon-32.png` |
+| Apple touch icon | `docs/assets/apple-touch-icon.png` |
+| PWA / Android icon (recommended) | `docs/assets/icons/cortex-icon-192.png`, `docs/assets/icons/cortex-icon-512.png` |
+| High-res docs/marketing export | `docs/assets/icons/cortex-icon-1024.png` |
+
+## Full Icon Set
+
+All generated from the same approved transparent source mark:
+
+- `docs/assets/icons/cortex-icon-16.png`
+- `docs/assets/icons/cortex-icon-32.png`
+- `docs/assets/icons/cortex-icon-48.png`
+- `docs/assets/icons/cortex-icon-64.png`
+- `docs/assets/icons/cortex-icon-128.png`
+- `docs/assets/icons/cortex-icon-152.png`
+- `docs/assets/icons/cortex-icon-180.png`
+- `docs/assets/icons/cortex-icon-192.png`
+- `docs/assets/icons/cortex-icon-256.png`
+- `docs/assets/icons/cortex-icon-512.png`
+- `docs/assets/icons/cortex-icon-1024.png`
+
+## Notes
+
+- Keep all new icon exports in `docs/assets/icons/`.
+- If logo composition changes, regenerate the full icon set so all surfaces stay consistent.
+- Avoid mixing old/non-transparent logo variants in product surfaces.


### PR DESCRIPTION
## Summary
- add `docs/branding.md` as the central guide for Cortex logo/icon files
- include quick usage mapping (favicon, apple touch icon, PWA, high-res)
- add a `Brand Assets` link in README top navigation for discoverability

## Why
People need one obvious place to find the right icon asset quickly without guessing file names.
