### PR TITLE
feat(search): metadata-aware ranking boosts + recency scoring (#148)

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -496,6 +496,8 @@ func runSearch(args []string) error {
 	channelFlag := ""
 	afterFlag := ""
 	beforeFlag := ""
+	boostAgentFlag := ""
+	boostChannelFlag := ""
 	showMetadata := false
 	explain := false
 	includeSuperseded := false
@@ -536,6 +538,16 @@ func runSearch(args []string) error {
 			beforeFlag = strings.TrimPrefix(args[i], "--before=")
 		case args[i] == "--show-metadata":
 			showMetadata = true
+		case args[i] == "--boost-agent" && i+1 < len(args):
+			i++
+			boostAgentFlag = args[i]
+		case strings.HasPrefix(args[i], "--boost-agent="):
+			boostAgentFlag = strings.TrimPrefix(args[i], "--boost-agent=")
+		case args[i] == "--boost-channel" && i+1 < len(args):
+			i++
+			boostChannelFlag = args[i]
+		case strings.HasPrefix(args[i], "--boost-channel="):
+			boostChannelFlag = strings.TrimPrefix(args[i], "--boost-channel=")
 		case args[i] == "--explain":
 			explain = true
 		case args[i] == "--include-superseded":
@@ -664,6 +676,8 @@ func runSearch(args []string) error {
 		Before:            beforeFlag,
 		IncludeSuperseded: includeSuperseded,
 		Explain:           explain,
+		BoostAgent:        boostAgentFlag,
+		BoostChannel:      boostChannelFlag,
 	}
 
 	results, err := engine.Search(ctx, query, opts)


### PR DESCRIPTION
## Metadata-Aware Agent Retrieval

Context-aware ranking boosts for agent search precision.

### New Options
- `--boost-agent main` — 1.08x boost for results from same agent
- `--boost-channel discord` — 1.05x boost for results from same channel
- Recency: today 1.10x, this week 1.05x, this month 1.02x (always-on)

### Key Design
- Boosts are **ranking-only** — no results filtered out
- Stacks multiplicatively (agent + channel = 1.134x)
- Case-insensitive, nil-safe
- Wired into CLI, explain support via RankComponents

Tests: 8 new + all existing pass (425+). Closes #148