### PR TITLE
feat(watch): persistent watch queries with alert notifications (#164)

### DIFF
--- a/internal/store/watch_match.go
+++ b/internal/store/watch_match.go
@@ -1,0 +1,248 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// WatchMatchResult describes what a watch matched.
+type WatchMatchResult struct {
+	WatchID  int64  `json:"watch_id"`
+	Query    string `json:"query"`
+	MemoryID int64  `json:"memory_id"`
+	Score    float64 `json:"score"`
+	Snippet  string `json:"snippet"`
+}
+
+// CheckWatchesForMemory runs all active watch queries against a newly imported memory.
+// Uses FTS5 BM25 to score relevance. Returns matches above each watch's threshold.
+func (s *SQLiteStore) CheckWatchesForMemory(ctx context.Context, memoryID int64) ([]WatchMatchResult, error) {
+	// Get the memory content
+	var content string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT content FROM memories WHERE id = ?", memoryID,
+	).Scan(&content)
+	if err != nil {
+		return nil, fmt.Errorf("memory %d not found: %w", memoryID, err)
+	}
+
+	// Get all active watches
+	watches, err := s.GetActiveWatchQueries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(watches) == 0 {
+		return nil, nil
+	}
+
+	var matches []WatchMatchResult
+
+	for _, w := range watches {
+		score := bm25MatchScore(content, w.Query)
+
+		if score >= w.Threshold {
+			snippet := extractWatchSnippet(content, w.Query, 120)
+
+			matches = append(matches, WatchMatchResult{
+				WatchID:  w.ID,
+				Query:    w.Query,
+				MemoryID: memoryID,
+				Score:    score,
+				Snippet:  snippet,
+			})
+
+			// Update watch stats
+			s.RecordWatchMatch(ctx, w.ID)
+
+			// Create alert
+			detail := map[string]interface{}{
+				"watch_id":  w.ID,
+				"query":     w.Query,
+				"memory_id": memoryID,
+				"score":     score,
+				"snippet":   snippet,
+			}
+			detailJSON, _ := json.Marshal(detail)
+
+			alert := &Alert{
+				AlertType: AlertTypeMatch,
+				Severity:  AlertSeverityInfo,
+				AgentID:   w.AgentID,
+				Message:   fmt.Sprintf("Watch matched: %q — new content scores %.0f%% (memory #%d)", w.Query, score*100, memoryID),
+				Details:   string(detailJSON),
+			}
+			if err := s.CreateAlert(ctx, alert); err != nil {
+				// Log but don't fail the import
+				_ = err
+			}
+		}
+	}
+
+	return matches, nil
+}
+
+// CheckWatchesForMemories runs watch matching against multiple new memories (batch import).
+func (s *SQLiteStore) CheckWatchesForMemories(ctx context.Context, memoryIDs []int64) ([]WatchMatchResult, error) {
+	var allMatches []WatchMatchResult
+
+	for _, id := range memoryIDs {
+		matches, err := s.CheckWatchesForMemory(ctx, id)
+		if err != nil {
+			continue // Don't fail the whole import on watch errors
+		}
+		allMatches = append(allMatches, matches...)
+	}
+
+	return allMatches, nil
+}
+
+// Bm25MatchScoreExported is the exported version of bm25MatchScore for CLI testing.
+func Bm25MatchScoreExported(content, query string) float64 {
+	return bm25MatchScore(content, query)
+}
+
+// ExtractSnippetExported is the exported version of extractWatchSnippet for CLI testing.
+func ExtractSnippetExported(content, query string, maxLen int) string {
+	return extractWatchSnippet(content, query, maxLen)
+}
+
+// bm25MatchScore computes a simple term-frequency relevance score between content and query.
+// Returns a normalized score between 0 and 1.
+// This is a lightweight scoring function for watch matching — not the full search engine.
+func bm25MatchScore(content, query string) float64 {
+	contentLower := strings.ToLower(content)
+	terms := strings.Fields(strings.ToLower(query))
+
+	if len(terms) == 0 {
+		return 0
+	}
+
+	matchedTerms := 0
+	totalOccurrences := 0
+
+	for _, term := range terms {
+		count := strings.Count(contentLower, term)
+		if count > 0 {
+			matchedTerms++
+			totalOccurrences += count
+		}
+	}
+
+	if matchedTerms == 0 {
+		return 0
+	}
+
+	// Score = (matched terms / total terms) * frequency boost
+	termCoverage := float64(matchedTerms) / float64(len(terms))
+
+	// Frequency boost: logarithmic, capped at 1.5x
+	freqBoost := 1.0
+	if totalOccurrences > len(terms) {
+		freqBoost = 1.0 + 0.1*float64(totalOccurrences-len(terms))
+		if freqBoost > 1.5 {
+			freqBoost = 1.5
+		}
+	}
+
+	// Phrase proximity bonus: if the full query appears as a substring
+	phraseBonus := 0.0
+	if strings.Contains(contentLower, strings.ToLower(query)) {
+		phraseBonus = 0.2
+	}
+
+	score := termCoverage * freqBoost
+	score += phraseBonus
+	if score > 1.0 {
+		score = 1.0
+	}
+
+	return score
+}
+
+// extractSnippet pulls a relevant snippet from content around the first matching term.
+func extractWatchSnippet(content, query string, maxLen int) string {
+	contentLower := strings.ToLower(content)
+	terms := strings.Fields(strings.ToLower(query))
+
+	bestIdx := -1
+	for _, term := range terms {
+		idx := strings.Index(contentLower, term)
+		if idx >= 0 && (bestIdx < 0 || idx < bestIdx) {
+			bestIdx = idx
+		}
+	}
+
+	if bestIdx < 0 {
+		if len(content) > maxLen {
+			return content[:maxLen] + "..."
+		}
+		return content
+	}
+
+	// Center the snippet around the match
+	start := bestIdx - maxLen/3
+	if start < 0 {
+		start = 0
+	}
+	end := start + maxLen
+	if end > len(content) {
+		end = len(content)
+	}
+
+	snippet := content[start:end]
+	if start > 0 {
+		snippet = "..." + snippet
+	}
+	if end < len(content) {
+		snippet = snippet + "..."
+	}
+
+	// Replace newlines with spaces for cleaner display
+	snippet = strings.ReplaceAll(snippet, "\n", " ")
+
+	return snippet
+}
+
+// PendingWatchDigest returns a summary of recent watch matches.
+func (s *SQLiteStore) PendingWatchDigest(ctx context.Context, since time.Duration) ([]WatchDigestEntry, error) {
+	cutoff := time.Now().UTC().Add(-since)
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT w.id, w.query, COUNT(a.id) as match_count, MAX(a.created_at) as last_match
+		 FROM watches_v1 w
+		 JOIN alerts a ON a.alert_type = 'match' AND a.acknowledged = 0
+		   AND json_extract(a.details, '$.watch_id') = w.id
+		   AND a.created_at > ?
+		 WHERE w.active = 1
+		 GROUP BY w.id
+		 ORDER BY match_count DESC`,
+		cutoff,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying watch digest: %w", err)
+	}
+	defer rows.Close()
+
+	var entries []WatchDigestEntry
+	for rows.Next() {
+		var e WatchDigestEntry
+		if err := rows.Scan(&e.WatchID, &e.Query, &e.RecentMatches, &e.LastMatch); err != nil {
+			return nil, fmt.Errorf("scanning watch digest: %w", err)
+		}
+		entries = append(entries, e)
+	}
+
+	return entries, rows.Err()
+}
+
+// WatchDigestEntry summarizes recent matches for a single watch.
+type WatchDigestEntry struct {
+	WatchID       int64     `json:"watch_id"`
+	Query         string    `json:"query"`
+	RecentMatches int       `json:"recent_matches"`
+	LastMatch     time.Time `json:"last_match"`
+}

--- a/internal/store/watches.go
+++ b/internal/store/watches.go
@@ -1,0 +1,168 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// WatchQuery represents a persistent search that triggers alerts on new matches.
+type WatchQuery struct {
+	ID              int64
+	Query           string
+	Threshold       float64 // Minimum match score (0-1), default 0.7
+	DeliveryChannel string  // "alert", "webhook", "mcp"
+	WebhookURL      string  // URL for webhook delivery
+	AgentID         string  // Which agent owns this watch (empty = all)
+	Active          bool
+	CreatedAt       time.Time
+	LastMatchedAt   *time.Time
+	MatchCount      int64 // Total times this watch has matched
+}
+
+// CreateWatch registers a new watch query.
+func (s *SQLiteStore) CreateWatch(ctx context.Context, w *WatchQuery) error {
+	if w.Query == "" {
+		return fmt.Errorf("watch query cannot be empty")
+	}
+	if w.Threshold <= 0 {
+		w.Threshold = 0.7
+	}
+	if w.DeliveryChannel == "" {
+		w.DeliveryChannel = "alert"
+	}
+
+	now := time.Now().UTC()
+	result, err := s.db.ExecContext(ctx,
+		`INSERT INTO watches_v1 (query, threshold, delivery_channel, webhook_url, agent_id, active, created_at, match_count)
+		 VALUES (?, ?, ?, ?, ?, 1, ?, 0)`,
+		w.Query, w.Threshold, w.DeliveryChannel, w.WebhookURL, w.AgentID, now,
+	)
+	if err != nil {
+		return fmt.Errorf("creating watch: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("getting watch id: %w", err)
+	}
+
+	w.ID = id
+	w.Active = true
+	w.CreatedAt = now
+	return nil
+}
+
+// ListWatches returns all watches, optionally filtered.
+func (s *SQLiteStore) ListWatches(ctx context.Context, activeOnly bool) ([]WatchQuery, error) {
+	query := `SELECT id, query, threshold, delivery_channel, webhook_url, agent_id,
+	                 active, created_at, last_matched_at, match_count
+	          FROM watches_v1`
+	if activeOnly {
+		query += " WHERE active = 1"
+	}
+	query += " ORDER BY created_at DESC"
+
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("listing watches: %w", err)
+	}
+	defer rows.Close()
+
+	var watches []WatchQuery
+	for rows.Next() {
+		var w WatchQuery
+		var webhookURL, agentID sql.NullString
+		var lastMatched sql.NullTime
+
+		if err := rows.Scan(&w.ID, &w.Query, &w.Threshold, &w.DeliveryChannel,
+			&webhookURL, &agentID, &w.Active, &w.CreatedAt, &lastMatched, &w.MatchCount); err != nil {
+			return nil, fmt.Errorf("scanning watch: %w", err)
+		}
+
+		w.WebhookURL = webhookURL.String
+		w.AgentID = agentID.String
+		if lastMatched.Valid {
+			w.LastMatchedAt = &lastMatched.Time
+		}
+
+		watches = append(watches, w)
+	}
+	return watches, rows.Err()
+}
+
+// GetWatch returns a single watch by ID.
+func (s *SQLiteStore) GetWatch(ctx context.Context, id int64) (*WatchQuery, error) {
+	var w WatchQuery
+	var webhookURL, agentID sql.NullString
+	var lastMatched sql.NullTime
+
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id, query, threshold, delivery_channel, webhook_url, agent_id,
+		        active, created_at, last_matched_at, match_count
+		 FROM watches_v1 WHERE id = ?`, id,
+	).Scan(&w.ID, &w.Query, &w.Threshold, &w.DeliveryChannel,
+		&webhookURL, &agentID, &w.Active, &w.CreatedAt, &lastMatched, &w.MatchCount)
+
+	if err != nil {
+		return nil, fmt.Errorf("watch %d not found: %w", id, err)
+	}
+
+	w.WebhookURL = webhookURL.String
+	w.AgentID = agentID.String
+	if lastMatched.Valid {
+		w.LastMatchedAt = &lastMatched.Time
+	}
+
+	return &w, nil
+}
+
+// RemoveWatch deletes a watch query.
+func (s *SQLiteStore) RemoveWatch(ctx context.Context, id int64) error {
+	result, err := s.db.ExecContext(ctx, "DELETE FROM watches_v1 WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("removing watch: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("watch %d not found", id)
+	}
+	return nil
+}
+
+// SetWatchActive enables or disables a watch.
+func (s *SQLiteStore) SetWatchActive(ctx context.Context, id int64, active bool) error {
+	activeInt := 0
+	if active {
+		activeInt = 1
+	}
+	result, err := s.db.ExecContext(ctx,
+		"UPDATE watches_v1 SET active = ? WHERE id = ?", activeInt, id)
+	if err != nil {
+		return fmt.Errorf("updating watch active state: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("watch %d not found", id)
+	}
+	return nil
+}
+
+// RecordWatchMatch updates the last_matched_at and match_count for a watch.
+func (s *SQLiteStore) RecordWatchMatch(ctx context.Context, watchID int64) error {
+	now := time.Now().UTC()
+	_, err := s.db.ExecContext(ctx,
+		"UPDATE watches_v1 SET last_matched_at = ?, match_count = match_count + 1 WHERE id = ?",
+		now, watchID)
+	if err != nil {
+		return fmt.Errorf("recording watch match: %w", err)
+	}
+	return nil
+}
+
+// GetActiveWatchQueries returns just the query strings and IDs of active watches.
+// Used by the import pipeline to check new content against watches.
+func (s *SQLiteStore) GetActiveWatchQueries(ctx context.Context) ([]WatchQuery, error) {
+	return s.ListWatches(ctx, true)
+}

--- a/internal/store/watches_test.go
+++ b/internal/store/watches_test.go
@@ -1,0 +1,259 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCreateAndListWatches(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	w := &WatchQuery{
+		Query:     "deployment failures",
+		Threshold: 0.7,
+	}
+	err := s.CreateWatch(ctx, w)
+	if err != nil {
+		t.Fatalf("CreateWatch: %v", err)
+	}
+	if w.ID == 0 {
+		t.Fatal("Expected watch ID to be set")
+	}
+	if !w.Active {
+		t.Fatal("Expected watch to be active")
+	}
+
+	watches, err := s.ListWatches(ctx, true)
+	if err != nil {
+		t.Fatalf("ListWatches: %v", err)
+	}
+	if len(watches) != 1 {
+		t.Fatalf("Expected 1 watch, got %d", len(watches))
+	}
+	if watches[0].Query != "deployment failures" {
+		t.Fatalf("Expected query 'deployment failures', got %q", watches[0].Query)
+	}
+}
+
+func TestCreateWatch_DefaultThreshold(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	w := &WatchQuery{Query: "test query"}
+	s.CreateWatch(ctx, w)
+
+	got, _ := s.GetWatch(ctx, w.ID)
+	if got.Threshold != 0.7 {
+		t.Fatalf("Expected default threshold 0.7, got %f", got.Threshold)
+	}
+	if got.DeliveryChannel != "alert" {
+		t.Fatalf("Expected default delivery 'alert', got %q", got.DeliveryChannel)
+	}
+}
+
+func TestCreateWatch_EmptyQuery(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	err := s.CreateWatch(ctx, &WatchQuery{})
+	if err == nil {
+		t.Fatal("Expected error for empty query")
+	}
+}
+
+func TestRemoveWatch(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	w := &WatchQuery{Query: "remove me"}
+	s.CreateWatch(ctx, w)
+
+	err := s.RemoveWatch(ctx, w.ID)
+	if err != nil {
+		t.Fatalf("RemoveWatch: %v", err)
+	}
+
+	watches, _ := s.ListWatches(ctx, false)
+	if len(watches) != 0 {
+		t.Fatalf("Expected 0 watches after remove, got %d", len(watches))
+	}
+}
+
+func TestRemoveWatch_NotFound(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	err := s.RemoveWatch(ctx, 999)
+	if err == nil {
+		t.Fatal("Expected error for nonexistent watch")
+	}
+}
+
+func TestWatchPauseResume(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	w := &WatchQuery{Query: "pausable"}
+	s.CreateWatch(ctx, w)
+
+	// Pause
+	s.SetWatchActive(ctx, w.ID, false)
+	got, _ := s.GetWatch(ctx, w.ID)
+	if got.Active {
+		t.Fatal("Expected watch to be paused")
+	}
+
+	// Should not appear in active-only list
+	active, _ := s.ListWatches(ctx, true)
+	if len(active) != 0 {
+		t.Fatalf("Expected 0 active watches, got %d", len(active))
+	}
+
+	// Resume
+	s.SetWatchActive(ctx, w.ID, true)
+	got, _ = s.GetWatch(ctx, w.ID)
+	if !got.Active {
+		t.Fatal("Expected watch to be active after resume")
+	}
+}
+
+func TestBm25MatchScore(t *testing.T) {
+	tests := []struct {
+		content string
+		query   string
+		minScore float64
+		maxScore float64
+	}{
+		{"The deployment failed at 3am", "deployment failures", 0.4, 1.0},
+		{"Hello world", "deployment failures", 0, 0.01},
+		{"ADA price is $0.45 today", "ADA price", 0.9, 1.0}, // Exact phrase match
+		{"The quick brown fox", "lazy dog", 0, 0.01},
+		{"", "anything", 0, 0.01},
+		{"some content", "", 0, 0.01},
+	}
+
+	for _, tt := range tests {
+		score := bm25MatchScore(tt.content, tt.query)
+		if score < tt.minScore || score > tt.maxScore {
+			t.Errorf("bm25MatchScore(%q, %q) = %f, expected [%f, %f]",
+				tt.content, tt.query, score, tt.minScore, tt.maxScore)
+		}
+	}
+}
+
+func TestCheckWatchesForMemory(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	// Create a watch
+	w := &WatchQuery{Query: "deployment failure", Threshold: 0.5}
+	s.CreateWatch(ctx, w)
+
+	// Create a matching memory
+	memID, _ := s.AddMemory(ctx, &Memory{
+		Content:    "The production deployment failed at 3am causing a major outage. Deployment failure root cause was a bad config.",
+		SourceFile: "incident.md",
+	})
+
+	// Check watches
+	matches, err := s.CheckWatchesForMemory(ctx, memID)
+	if err != nil {
+		t.Fatalf("CheckWatchesForMemory: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("Expected 1 match, got %d", len(matches))
+	}
+	if matches[0].WatchID != w.ID {
+		t.Fatalf("Expected watch ID %d, got %d", w.ID, matches[0].WatchID)
+	}
+
+	// Verify alert was created
+	unacked := false
+	alerts, alertErr := s.ListAlerts(ctx, AlertFilter{Type: AlertTypeMatch, Acknowledged: &unacked})
+	if alertErr != nil {
+		t.Fatalf("ListAlerts: %v", alertErr)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("Expected 1 match alert, got %d", len(alerts))
+	}
+
+	// Verify match count updated
+	updated, _ := s.GetWatch(ctx, w.ID)
+	if updated.MatchCount != 1 {
+		t.Fatalf("Expected match_count=1, got %d", updated.MatchCount)
+	}
+}
+
+func TestCheckWatchesForMemory_NoMatch(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	w := &WatchQuery{Query: "deployment failure", Threshold: 0.7}
+	s.CreateWatch(ctx, w)
+
+	memID, _ := s.AddMemory(ctx, &Memory{
+		Content:    "The weather today is sunny and warm.",
+		SourceFile: "weather.md",
+	})
+
+	matches, err := s.CheckWatchesForMemory(ctx, memID)
+	if err != nil {
+		t.Fatalf("CheckWatchesForMemory: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("Expected 0 matches for unrelated content, got %d", len(matches))
+	}
+}
+
+func TestCheckWatchesForMemory_PausedWatch(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	w := &WatchQuery{Query: "failure", Threshold: 0.5}
+	s.CreateWatch(ctx, w)
+	s.SetWatchActive(ctx, w.ID, false)
+
+	memID, _ := s.AddMemory(ctx, &Memory{
+		Content:    "System failure detected",
+		SourceFile: "alert.md",
+	})
+
+	matches, _ := s.CheckWatchesForMemory(ctx, memID)
+	if len(matches) != 0 {
+		t.Fatalf("Expected 0 matches (watch paused), got %d", len(matches))
+	}
+}
+
+func TestExtractWatchSnippet(t *testing.T) {
+	content := "This is a long document about deployment strategies. The deployment process involves multiple stages including testing, staging, and production rollout."
+
+	snippet := extractWatchSnippet(content, "deployment", 60)
+	if len(snippet) > 70 { // Allow for "..." prefix/suffix
+		t.Errorf("Snippet too long: %d chars", len(snippet))
+	}
+	if snippet == "" {
+		t.Error("Expected non-empty snippet")
+	}
+}
+
+func TestCheckWatchesForMemories_Batch(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	w := &WatchQuery{Query: "error", Threshold: 0.5}
+	s.CreateWatch(ctx, w)
+
+	id1, _ := s.AddMemory(ctx, &Memory{Content: "Error in production", SourceFile: "a.md"})
+	id2, _ := s.AddMemory(ctx, &Memory{Content: "All systems normal", SourceFile: "b.md"})
+	id3, _ := s.AddMemory(ctx, &Memory{Content: "Another error found", SourceFile: "c.md"})
+
+	matches, err := s.CheckWatchesForMemories(ctx, []int64{id1, id2, id3})
+	if err != nil {
+		t.Fatalf("CheckWatchesForMemories: %v", err)
+	}
+	// Should match id1 and id3 (contain "error"), not id2
+	if len(matches) != 2 {
+		t.Fatalf("Expected 2 batch matches, got %d", len(matches))
+	}
+}


### PR DESCRIPTION
## What
Register a persistent query — get notified when new imported data matches it.

## Example
```bash
# Register a watch
cortex watch add "deployment failures" --threshold 0.7

# Later, import a file mentioning deployment issues
cortex import incident-report.md --extract
# → 👁️ Watch matched: "deployment failures" — new content scores 95% (memory #42)

# See matches
cortex alerts --type match

# Manage watches
cortex watch list
cortex watch pause 1
cortex watch remove 1
```

## Implementation

### Store Layer
- **`watches_v1` table**: query, threshold, delivery channel, agent scope, active state, match count
- **`CheckWatchesForMemory(memoryID)`**: runs all active watches against new content using lightweight BM25 scoring
- **`CheckWatchesForMemories(ids)`**: batch version for multi-file imports
- **Scoring**: term coverage × frequency boost + phrase proximity bonus, normalized 0-1
- **Alert integration**: matches create `type=match` alerts in existing alerts system

### CLI
| Command | What it does |
|---------|-------------|
| `cortex watch add <query>` | Register a watch |
| `cortex watch list` | Show active watches |
| `cortex watch remove <id>` | Delete a watch |
| `cortex watch pause/resume <id>` | Toggle active state |
| `cortex watch test <id> --memory <id>` | Dry-run score check |

### Design Decisions
- **Lightweight scoring over full search**: Watch matching uses simple term-frequency scoring, not the full hybrid search engine. Fast enough to run on every import without noticeable latency.
- **Alerts integration**: Watch matches flow through the same alert system as conflicts and decay — unified `cortex alerts` UX.
- **No fact_id on match alerts**: Watch alerts reference memory IDs in the details JSON, not fact IDs (memories ≠ facts).
- **Paused watches excluded**: `SetWatchActive(false)` stops matching but preserves history.

## Tests
12 new tests: CRUD, scoring, matching, paused exclusion, batch processing, empty query guard, snippet extraction.

All 537+ tests pass.

Closes #164