### PR TITLE
feat: Watch queries — MCP tools + import pipeline integration (#164)

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -424,6 +424,124 @@ func TestReinforceToolInvalidIDs(t *testing.T) {
 	}
 }
 
+func TestWatchAddTool(t *testing.T) {
+	s := setupTestStore(t)
+	defer s.Close()
+
+	mcpServer := NewServer(ServerConfig{
+		Store:   s,
+		DBPath:  ":memory:",
+		Version: "test",
+	})
+
+	result := callTool(t, mcpServer, "cortex_watch_add", map[string]interface{}{
+		"query":     "deployment failures",
+		"threshold": 0.6,
+	})
+
+	text := getTextContent(t, result)
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("parsing watch add response: %v", err)
+	}
+
+	if resp["id"] == nil || resp["id"].(float64) == 0 {
+		t.Error("expected non-zero watch ID")
+	}
+	if resp["query"] != "deployment failures" {
+		t.Errorf("expected query 'deployment failures', got %v", resp["query"])
+	}
+	if resp["active"] != true {
+		t.Error("expected watch to be active")
+	}
+}
+
+func TestWatchAddToolMissingQuery(t *testing.T) {
+	s := setupTestStore(t)
+	defer s.Close()
+
+	mcpServer := NewServer(ServerConfig{
+		Store:   s,
+		DBPath:  ":memory:",
+		Version: "test",
+	})
+
+	result := callTool(t, mcpServer, "cortex_watch_add", map[string]interface{}{})
+
+	// Should return error
+	if !result.IsError {
+		t.Error("expected error for missing query")
+	}
+}
+
+func TestWatchListTool(t *testing.T) {
+	s := setupTestStore(t)
+	defer s.Close()
+
+	mcpServer := NewServer(ServerConfig{
+		Store:   s,
+		DBPath:  ":memory:",
+		Version: "test",
+	})
+
+	// Empty list
+	result := callTool(t, mcpServer, "cortex_watch_list", map[string]interface{}{})
+	text := getTextContent(t, result)
+	if text == "" {
+		t.Error("expected non-empty response")
+	}
+
+	// Add a watch then list
+	callTool(t, mcpServer, "cortex_watch_add", map[string]interface{}{
+		"query": "test watch",
+	})
+
+	result = callTool(t, mcpServer, "cortex_watch_list", map[string]interface{}{})
+	text = getTextContent(t, result)
+	var watches []map[string]interface{}
+	if err := json.Unmarshal([]byte(text), &watches); err != nil {
+		t.Fatalf("parsing watch list: %v", err)
+	}
+	if len(watches) != 1 {
+		t.Errorf("expected 1 watch, got %d", len(watches))
+	}
+}
+
+func TestImportTriggersWatchMatch(t *testing.T) {
+	s := setupTestStore(t)
+	defer s.Close()
+
+	mcpServer := NewServer(ServerConfig{
+		Store:   s,
+		DBPath:  ":memory:",
+		Version: "test",
+	})
+
+	// Create a watch for "cortex memory"
+	callTool(t, mcpServer, "cortex_watch_add", map[string]interface{}{
+		"query":     "cortex memory layer",
+		"threshold": 0.5,
+	})
+
+	// Import content that matches
+	result := callTool(t, mcpServer, "cortex_import", map[string]interface{}{
+		"content": "Cortex is the best memory layer for AI agents. It handles memory storage and retrieval.",
+		"source":  "test-match",
+	})
+
+	text := getTextContent(t, result)
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("parsing import response: %v", err)
+	}
+
+	if resp["watches_triggered"] == nil {
+		t.Error("expected watches_triggered in import response")
+	} else if resp["watches_triggered"].(float64) < 1 {
+		t.Error("expected at least 1 watch triggered")
+	}
+}
+
 func TestReinforceToolEmptyIDs(t *testing.T) {
 	s := setupTestStore(t)
 	defer s.Close()


### PR DESCRIPTION
## Summary

Completes **#164 Watch Queries** — persistent search queries that notify when newly imported data matches.

### What was already on `main`
- Store layer: `watches.go`, `watch_match.go` (CRUD, BM25 matching, batch checks, alert creation, digest)
- Migration: `watches_v1` table
- CLI: `cortex watch add|list|remove|pause|resume|test`
- Tests: 11 store-level tests

### What this PR adds
- **`cortex_watch_add` MCP tool** — create persistent watches from any MCP client
- **`cortex_watch_list` MCP tool** — list active watches from MCP clients
- **MCP import integration** — `cortex_import` now checks all active watches against imported content and returns `watch_matches` + `watches_triggered` in the response
- **CLI import integration** — `cortex import` checks watches against recently imported memories and prints match summaries
- **4 new MCP tests**: watch add, missing query validation, list, import-triggers-match

### Test results
- **541 tests** across 16 packages, all passing
- Zero regressions

### Closes
- Closes #164
- Completes Phase 2 of Epic #158