### PR TITLE
feat: Agent namespaces — scoped facts + multi-agent views (#165)

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -1797,7 +1797,7 @@ func runExtract(args []string) error {
 func runList(args []string) error {
 	// Parse flags
 	var limit int = 20
-	var sourceFile, factType, classFlag string
+	var sourceFile, factType, classFlag, agentFlag string
 	var listFacts, jsonOutput, includeSuperseded bool
 
 	for i := 0; i < len(args); i++ {
@@ -1830,6 +1830,11 @@ func runList(args []string) error {
 			factType = args[i]
 		case strings.HasPrefix(args[i], "--type="):
 			factType = strings.TrimPrefix(args[i], "--type=")
+		case args[i] == "--agent" && i+1 < len(args):
+			i++
+			agentFlag = args[i]
+		case strings.HasPrefix(args[i], "--agent="):
+			agentFlag = strings.TrimPrefix(args[i], "--agent=")
 		case args[i] == "--json":
 			jsonOutput = true
 		case args[i] == "--include-superseded":
@@ -1864,6 +1869,7 @@ func runList(args []string) error {
 		FactType:          factType,
 		MemoryClasses:     classes,
 		IncludeSuperseded: includeSuperseded,
+		Agent:             agentFlag,
 	}
 
 	if listFacts {
@@ -3768,6 +3774,9 @@ func outputListFactsTTY(facts []*store.Fact, opts store.ListOpts) error {
 		fmt.Printf("  %d. [%s] %s\n", i+1, fact.FactType, factContent)
 		fmt.Printf("     Confidence: %.2f · Decay: %.3f/day\n",
 			fact.Confidence, fact.DecayRate)
+		if fact.AgentID != "" {
+			fmt.Printf("     Agent: %s\n", fact.AgentID)
+		}
 		if fact.SupersededBy != nil {
 			fmt.Printf("     Superseded by fact: %d\n", *fact.SupersededBy)
 		}

--- a/internal/store/alerts.go
+++ b/internal/store/alerts.go
@@ -314,7 +314,7 @@ func (s *SQLiteStore) CheckDecayAlerts(ctx context.Context, thresholds DecayThre
 	// Get all active facts with their decay parameters
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, memory_id, subject, predicate, object, fact_type,
-		        confidence, decay_rate, last_reinforced, source_quote, created_at
+		        confidence, decay_rate, last_reinforced, source_quote, created_at, agent_id
 		 FROM facts
 		 WHERE superseded_by IS NULL
 		   AND confidence > 0`)
@@ -340,7 +340,7 @@ func (s *SQLiteStore) CheckDecayAlerts(ctx context.Context, thresholds DecayThre
 		var f Fact
 		if err := rows.Scan(&f.ID, &f.MemoryID, &f.Subject, &f.Predicate, &f.Object,
 			&f.FactType, &f.Confidence, &f.DecayRate, &f.LastReinforced,
-			&f.SourceQuote, &f.CreatedAt); err != nil {
+			&f.SourceQuote, &f.CreatedAt, &f.AgentID); err != nil {
 			return nil, fmt.Errorf("scanning fact: %w", err)
 		}
 		result.FactsScanned++

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -419,7 +419,7 @@ func (s *SQLiteStore) GetAttributeConflictsLimitWithSuperseded(ctx context.Conte
 	var conflicts []Conflict
 	for _, p := range pairs {
 		factQuery := fmt.Sprintf(`SELECT f.id, f.memory_id, f.subject, f.predicate, f.object, f.fact_type,
-			        f.confidence, f.decay_rate, f.last_reinforced, f.source_quote, f.created_at, f.superseded_by
+			        f.confidence, f.decay_rate, f.last_reinforced, f.source_quote, f.created_at, f.superseded_by, f.agent_id
 			 FROM facts f
 			 JOIN memories m ON f.memory_id = m.id AND m.deleted_at IS NULL
 			 WHERE LOWER(f.subject) = ? AND LOWER(f.predicate) = ?
@@ -439,7 +439,7 @@ func (s *SQLiteStore) GetAttributeConflictsLimitWithSuperseded(ctx context.Conte
 			var supersededBy sql.NullInt64
 			if err := factRows.Scan(
 				&f.ID, &f.MemoryID, &f.Subject, &f.Predicate, &f.Object, &f.FactType,
-				&f.Confidence, &f.DecayRate, &f.LastReinforced, &f.SourceQuote, &f.CreatedAt, &supersededBy,
+				&f.Confidence, &f.DecayRate, &f.LastReinforced, &f.SourceQuote, &f.CreatedAt, &supersededBy, &f.AgentID,
 			); err != nil {
 				factRows.Close()
 				return nil, fmt.Errorf("scanning fact: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -77,6 +77,7 @@ type Fact struct {
 	SourceQuote    string
 	CreatedAt      time.Time
 	SupersededBy   *int64 // Fact ID that superseded this fact (nil = active)
+	AgentID        string // Which agent created this fact (empty = global, visible to all)
 }
 
 // MemoryEvent represents an entry in the append-only event log.


### PR DESCRIPTION
## Summary

Implements **#165 Agent namespaces + scoped views** — the foundation for multi-agent memory sharing.

### What this adds
- **`agent_id` column on facts table** — migration adds column + index, backward compatible (defaults to empty = global)
- **Agent-scoped fact queries** — `ListFacts(opts.Agent="mister")` returns mister's facts + global facts
- **CLI support** — `cortex list --facts --agent mister` shows agent-specific view
- **MCP agent context** — `cortex_search`, `cortex_import`, `cortex_facts` all accept `agent_id` parameter
  - Search with agent_id both **filters** (metadata) and **boosts** (BoostAgent) results
  - Import with agent_id tags both memories (metadata) and extracted facts
- **Fact display** — shows agent ownership when `agent_id` is set
- **Conflict + decay scan updates** — all fact scanning sites updated to read the new column

### Namespace model
| Scope | agent_id | Visibility |
|-------|----------|------------|
| **Global** | `""` (empty) | Visible to all agents |
| **Agent-scoped** | `"mister"` | Prioritized for that agent, still visible to others via global view |

### Files changed
- `internal/store/store.go` — `AgentID` field on Fact struct
- `internal/store/facts.go` — AddFact, GetFact, ListFacts, GetFactsByMemoryIDs, StaleFacts updated
- `internal/store/events.go` — Conflict detection query updated  
- `internal/store/alerts.go` — Decay check query updated
- `internal/store/migrations.go` — `migrateFactAgentID()` adds column + index
- `internal/mcp/server.go` — agent_id on search, import, facts MCP tools
- `cmd/cortex/main.go` — `--agent` flag on `cortex list`, agent display in fact output

### Test results
- **544 tests** across 16 packages, all passing
- 3 new tests: agent_id persistence, default empty, agent-scoped listing
- Zero regressions

### Closes
- Closes #165
- Enables #166 (shared reinforcement) and #167 (cross-agent conflicts)