### PR TITLE
feat: Shared reinforcement — implicit decay reset + cross-agent amplification (#166)

### DIFF
--- a/internal/store/fact_access.go
+++ b/internal/store/fact_access.go
@@ -1,0 +1,229 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+)
+
+// AccessType defines the type of fact access.
+type AccessType string
+
+const (
+	AccessTypeSearch    AccessType = "search"
+	AccessTypeReinforce AccessType = "reinforce"
+	AccessTypeImport    AccessType = "import"
+	AccessTypeReference AccessType = "reference"
+)
+
+// ReinforcementWeights defines how much each access type resets the decay timer.
+var ReinforcementWeights = map[AccessType]float64{
+	AccessTypeReinforce: 1.0, // Full reset
+	AccessTypeImport:    0.8, // Strong — new data confirms
+	AccessTypeReference: 0.5, // Cross-agent access
+	AccessTypeSearch:    0.3, // Light — appeared in results
+}
+
+// FactAccess represents a recorded access to a fact.
+type FactAccess struct {
+	ID         int64
+	FactID     int64
+	AgentID    string
+	AccessType AccessType
+	CreatedAt  time.Time
+}
+
+// FactAccessSummary provides an aggregate view of a fact's access patterns.
+type FactAccessSummary struct {
+	FactID       int64    `json:"fact_id"`
+	TotalAccess  int      `json:"total_accesses"`
+	UniqueAgents int      `json:"unique_agents"`
+	AgentIDs     []string `json:"agent_ids"`
+	LastAccess   time.Time `json:"last_access"`
+	SearchCount  int      `json:"search_count"`
+	CrossAgent   bool     `json:"cross_agent"` // 2+ distinct agents
+}
+
+// RecordFactAccess logs a fact access and applies implicit reinforcement.
+func (s *SQLiteStore) RecordFactAccess(ctx context.Context, factID int64, agentID string, accessType AccessType) error {
+	// Record the access
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO fact_accesses_v1 (fact_id, agent_id, access_type) VALUES (?, ?, ?)`,
+		factID, agentID, string(accessType),
+	)
+	if err != nil {
+		return fmt.Errorf("recording fact access: %w", err)
+	}
+
+	// Apply weighted reinforcement
+	weight, ok := ReinforcementWeights[accessType]
+	if !ok {
+		weight = 0.3 // Default to search weight
+	}
+
+	return s.applyWeightedReinforcement(ctx, factID, weight)
+}
+
+// RecordFactAccessBatch records accesses for multiple facts (e.g., search results).
+func (s *SQLiteStore) RecordFactAccessBatch(ctx context.Context, factIDs []int64, agentID string, accessType AccessType) error {
+	if len(factIDs) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin batch access: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO fact_accesses_v1 (fact_id, agent_id, access_type) VALUES (?, ?, ?)`,
+	)
+	if err != nil {
+		return fmt.Errorf("prepare batch access: %w", err)
+	}
+	defer stmt.Close()
+
+	weight, ok := ReinforcementWeights[accessType]
+	if !ok {
+		weight = 0.3
+	}
+
+	for _, factID := range factIDs {
+		if _, err := stmt.ExecContext(ctx, factID, agentID, string(accessType)); err != nil {
+			continue // Skip individual failures
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit batch access: %w", err)
+	}
+
+	// Apply weighted reinforcement to all facts
+	for _, factID := range factIDs {
+		_ = s.applyWeightedReinforcement(ctx, factID, weight)
+	}
+
+	return nil
+}
+
+// GetFactAccessSummary returns access patterns for a fact.
+func (s *SQLiteStore) GetFactAccessSummary(ctx context.Context, factID int64) (*FactAccessSummary, error) {
+	summary := &FactAccessSummary{FactID: factID}
+
+	// Total + search counts
+	var lastAccessStr *string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*), 
+		        SUM(CASE WHEN access_type = 'search' THEN 1 ELSE 0 END),
+		        MAX(created_at)
+		 FROM fact_accesses_v1 WHERE fact_id = ?`, factID,
+	).Scan(&summary.TotalAccess, &summary.SearchCount, &lastAccessStr)
+	if err != nil {
+		return nil, fmt.Errorf("getting access summary: %w", err)
+	}
+	if lastAccessStr != nil {
+		if t, err := time.Parse("2006-01-02 15:04:05", *lastAccessStr); err == nil {
+			summary.LastAccess = t
+		} else if t, err := time.Parse(time.RFC3339, *lastAccessStr); err == nil {
+			summary.LastAccess = t
+		}
+	}
+
+	// Unique agents
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT DISTINCT agent_id FROM fact_accesses_v1 WHERE fact_id = ? AND agent_id != ''`,
+		factID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting unique agents: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var agent string
+		if err := rows.Scan(&agent); err != nil {
+			continue
+		}
+		summary.AgentIDs = append(summary.AgentIDs, agent)
+	}
+	summary.UniqueAgents = len(summary.AgentIDs)
+	summary.CrossAgent = summary.UniqueAgents >= 2
+
+	return summary, nil
+}
+
+// CheckCrossAgentReinforcement checks if 2+ agents accessed a fact recently
+// and applies the cross-agent amplification bonus.
+func (s *SQLiteStore) CheckCrossAgentReinforcement(ctx context.Context, factID int64, windowDays int) (bool, error) {
+	if windowDays <= 0 {
+		windowDays = 30
+	}
+
+	cutoff := time.Now().UTC().AddDate(0, 0, -windowDays)
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(DISTINCT agent_id) FROM fact_accesses_v1 
+		 WHERE fact_id = ? AND agent_id != '' AND created_at > ?`,
+		factID, cutoff,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("checking cross-agent access: %w", err)
+	}
+
+	if count >= 2 {
+		// Apply cross-agent amplification
+		_ = s.applyWeightedReinforcement(ctx, factID, ReinforcementWeights[AccessTypeReference])
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// applyWeightedReinforcement partially resets the decay timer based on weight.
+// weight=1.0 is a full reset to now, weight=0.3 moves last_reinforced 30% toward now.
+func (s *SQLiteStore) applyWeightedReinforcement(ctx context.Context, factID int64, weight float64) error {
+	if weight <= 0 {
+		return nil
+	}
+
+	// Get current last_reinforced
+	var lastReinforced time.Time
+	err := s.db.QueryRowContext(ctx,
+		`SELECT last_reinforced FROM facts WHERE id = ? AND superseded_by IS NULL`,
+		factID,
+	).Scan(&lastReinforced)
+	if err != nil {
+		return nil // Fact not found or superseded — no-op
+	}
+
+	now := time.Now().UTC()
+
+	if weight >= 1.0 {
+		// Full reset
+		_, err = s.db.ExecContext(ctx,
+			`UPDATE facts SET last_reinforced = ? WHERE id = ?`, now, factID)
+		return err
+	}
+
+	// Partial reset: move last_reinforced toward now by weight fraction
+	elapsed := now.Sub(lastReinforced)
+	adjustment := time.Duration(float64(elapsed) * weight)
+	newTime := lastReinforced.Add(adjustment)
+
+	// Don't go past now
+	if newTime.After(now) {
+		newTime = now
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE facts SET last_reinforced = ? WHERE id = ?`, newTime, factID)
+	return err
+}
+
+// EffectiveConfidence calculates the current confidence with Ebbinghaus decay.
+func EffectiveConfidence(confidence, decayRate float64, lastReinforced time.Time) float64 {
+	daysSince := time.Since(lastReinforced).Hours() / 24
+	return confidence * math.Exp(-decayRate*daysSince)
+}

--- a/internal/store/fact_access_test.go
+++ b/internal/store/fact_access_test.go
@@ -1,0 +1,185 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRecordFactAccess(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	factID, _ := s.AddFact(ctx, &Fact{
+		MemoryID: memID, Subject: "test", Predicate: "value",
+		Object: "hello", FactType: "kv",
+	})
+
+	err := s.RecordFactAccess(ctx, factID, "mister", AccessTypeSearch)
+	if err != nil {
+		t.Fatalf("RecordFactAccess: %v", err)
+	}
+
+	summary, err := s.GetFactAccessSummary(ctx, factID)
+	if err != nil {
+		t.Fatalf("GetFactAccessSummary: %v", err)
+	}
+	if summary.TotalAccess != 1 {
+		t.Fatalf("Expected 1 access, got %d", summary.TotalAccess)
+	}
+	if summary.SearchCount != 1 {
+		t.Fatalf("Expected 1 search access, got %d", summary.SearchCount)
+	}
+}
+
+func TestRecordFactAccessBatch(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	id1, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "a", Predicate: "p", Object: "o1", FactType: "kv"})
+	id2, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "b", Predicate: "p", Object: "o2", FactType: "kv"})
+
+	err := s.RecordFactAccessBatch(ctx, []int64{id1, id2}, "hawk", AccessTypeSearch)
+	if err != nil {
+		t.Fatalf("RecordFactAccessBatch: %v", err)
+	}
+
+	s1, _ := s.GetFactAccessSummary(ctx, id1)
+	s2, _ := s.GetFactAccessSummary(ctx, id2)
+	if s1.TotalAccess != 1 || s2.TotalAccess != 1 {
+		t.Fatalf("Expected 1 access each, got %d and %d", s1.TotalAccess, s2.TotalAccess)
+	}
+}
+
+func TestSearchImplicitReinforcement(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+
+	// Create fact with last_reinforced set 30 days ago
+	factID, _ := s.AddFact(ctx, &Fact{
+		MemoryID: memID, Subject: "old", Predicate: "fact",
+		Object: "value", FactType: "kv",
+	})
+
+	// Manually backdate last_reinforced
+	thirtyDaysAgo := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	s.db.ExecContext(ctx, "UPDATE facts SET last_reinforced = ? WHERE id = ?", thirtyDaysAgo, factID)
+
+	// Record search access (weight 0.3)
+	s.RecordFactAccess(ctx, factID, "mister", AccessTypeSearch)
+
+	// Verify last_reinforced moved forward (but not to now)
+	fact, _ := s.GetFact(ctx, factID)
+	if !fact.LastReinforced.After(thirtyDaysAgo) {
+		t.Fatal("Expected last_reinforced to move forward after search access")
+	}
+	if fact.LastReinforced.After(time.Now().UTC().Add(-1 * time.Hour)) {
+		t.Fatal("Search access should not fully reset last_reinforced (weight=0.3)")
+	}
+}
+
+func TestCrossAgentReinforcement(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "shared", SourceFile: "t.md"})
+	factID, _ := s.AddFact(ctx, &Fact{
+		MemoryID: memID, Subject: "shared", Predicate: "fact",
+		Object: "value", FactType: "kv",
+	})
+
+	// Only one agent
+	s.RecordFactAccess(ctx, factID, "mister", AccessTypeSearch)
+	amplified, _ := s.CheckCrossAgentReinforcement(ctx, factID, 30)
+	if amplified {
+		t.Fatal("Should not amplify with only 1 agent")
+	}
+
+	// Second agent
+	s.RecordFactAccess(ctx, factID, "hawk", AccessTypeSearch)
+	amplified, _ = s.CheckCrossAgentReinforcement(ctx, factID, 30)
+	if !amplified {
+		t.Fatal("Should amplify with 2 agents accessing same fact")
+	}
+}
+
+func TestCrossAgentSummary(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	factID, _ := s.AddFact(ctx, &Fact{
+		MemoryID: memID, Subject: "test", Predicate: "v",
+		Object: "val", FactType: "kv",
+	})
+
+	s.RecordFactAccess(ctx, factID, "mister", AccessTypeSearch)
+	s.RecordFactAccess(ctx, factID, "hawk", AccessTypeReinforce)
+	s.RecordFactAccess(ctx, factID, "mister", AccessTypeSearch)
+
+	summary, _ := s.GetFactAccessSummary(ctx, factID)
+	if summary.UniqueAgents != 2 {
+		t.Fatalf("Expected 2 unique agents, got %d", summary.UniqueAgents)
+	}
+	if !summary.CrossAgent {
+		t.Fatal("Expected cross_agent=true")
+	}
+	if summary.TotalAccess != 3 {
+		t.Fatalf("Expected 3 accesses, got %d", summary.TotalAccess)
+	}
+	if summary.SearchCount != 2 {
+		t.Fatalf("Expected 2 search accesses, got %d", summary.SearchCount)
+	}
+}
+
+func TestExplicitReinforceFullReset(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	factID, _ := s.AddFact(ctx, &Fact{
+		MemoryID: memID, Subject: "test", Predicate: "v",
+		Object: "val", FactType: "kv",
+	})
+
+	// Backdate
+	oldTime := time.Now().UTC().Add(-90 * 24 * time.Hour)
+	s.db.ExecContext(ctx, "UPDATE facts SET last_reinforced = ? WHERE id = ?", oldTime, factID)
+
+	// Explicit reinforce (weight=1.0 = full reset)
+	s.RecordFactAccess(ctx, factID, "mister", AccessTypeReinforce)
+
+	fact, _ := s.GetFact(ctx, factID)
+	// Should be within the last minute
+	if time.Since(fact.LastReinforced) > time.Minute {
+		t.Fatalf("Expected full reset to ~now, got last_reinforced=%v", fact.LastReinforced)
+	}
+}
+
+func TestEffectiveConfidence(t *testing.T) {
+	now := time.Now().UTC()
+
+	// Fresh fact
+	eff := EffectiveConfidence(0.9, 0.01, now)
+	if eff < 0.89 || eff > 0.91 {
+		t.Fatalf("Expected ~0.9 for fresh fact, got %f", eff)
+	}
+
+	// 30-day-old fact with low decay
+	thirtyDaysAgo := now.Add(-30 * 24 * time.Hour)
+	eff = EffectiveConfidence(0.9, 0.01, thirtyDaysAgo)
+	if eff > 0.75 {
+		t.Fatalf("Expected significant decay after 30 days, got %f", eff)
+	}
+
+	// Very old fact
+	yearAgo := now.Add(-365 * 24 * time.Hour)
+	eff = EffectiveConfidence(0.9, 0.01, yearAgo)
+	if eff > 0.05 {
+		t.Fatalf("Expected near-zero after a year, got %f", eff)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **#166 Shared reinforcement across agents** — searching or accessing a fact now extends its life, and multi-agent access amplifies the effect.

### How it works
Every fact access is logged to `fact_accesses_v1` and applies weighted reinforcement to the fact's `last_reinforced` timestamp:

| Action | Weight | Effect |
|--------|--------|--------|
| Explicit reinforce | 1.0 | Full reset to now |
| Import/update | 0.8 | Near-full reset |
| Cross-agent reference | 0.5 | Half-life extension |
| Search hit | 0.3 | Light extension |

**Partial reset math:** For weight=0.3 on a fact last reinforced 30 days ago, `last_reinforced` moves forward by 9 days (30 × 0.3). The fact still decays, but slower.

**Cross-agent amplification:** When 2+ distinct agents access the same fact within a configurable window, an additional 0.5 weight reinforcement fires. Facts that multiple agents rely on naturally survive longer.

### What's added
- `fact_accesses_v1` table (migration + 3 indexes)
- `RecordFactAccess` + `RecordFactAccessBatch` — log accesses with weighted reinforcement
- `GetFactAccessSummary` — per-fact analytics (total, search, unique agents, cross-agent flag)
- `CheckCrossAgentReinforcement` — detects multi-agent access patterns
- `EffectiveConfidence` helper — Ebbinghaus decay calculation
- CLI: `cortex fact-history <id>` — shows fact details + access patterns

### Test results
- **551 tests** across 16 packages, all passing
- 7 new tests covering all reinforcement scenarios

### Closes
- Closes #166