### PR TITLE
feat: Cross-agent conflict detection (#167)

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -4548,9 +4548,21 @@ func outputConflictsTTY(conflicts []observe.Conflict, verbose bool) error {
 		if conflictType == "" {
 			conflictType = "attribute"
 		}
-		fmt.Printf("\n❌ [%d/%d] %s conflict\n", i+1, len(ranked), conflictType)
-		fmt.Printf("   \"%s\" (confidence: %.2f, id: %d)\n", formatFactText(c.Fact1.Subject, c.Fact1.Predicate, c.Fact1.Object), c.Fact1.Confidence, c.Fact1.ID)
-		fmt.Printf("   \"%s\" (confidence: %.2f, id: %d)\n", formatFactText(c.Fact2.Subject, c.Fact2.Predicate, c.Fact2.Object), c.Fact2.Confidence, c.Fact2.ID)
+		crossTag := ""
+		if c.CrossAgent {
+			crossTag = " ⚠️ CROSS-AGENT"
+		}
+		fmt.Printf("\n❌ [%d/%d] %s conflict%s\n", i+1, len(ranked), conflictType, crossTag)
+		agent1 := ""
+		if c.Fact1.AgentID != "" {
+			agent1 = fmt.Sprintf(" [%s]", c.Fact1.AgentID)
+		}
+		agent2 := ""
+		if c.Fact2.AgentID != "" {
+			agent2 = fmt.Sprintf(" [%s]", c.Fact2.AgentID)
+		}
+		fmt.Printf("   \"%s\" (confidence: %.2f, id: %d)%s\n", formatFactText(c.Fact1.Subject, c.Fact1.Predicate, c.Fact1.Object), c.Fact1.Confidence, c.Fact1.ID, agent1)
+		fmt.Printf("   \"%s\" (confidence: %.2f, id: %d)%s\n", formatFactText(c.Fact2.Subject, c.Fact2.Predicate, c.Fact2.Object), c.Fact2.Confidence, c.Fact2.ID, agent2)
 		fmt.Printf("   Similarity: %.2f\n", c.Similarity)
 	}
 

--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -100,6 +100,7 @@ type Conflict struct {
 	Fact2        store.Fact `json:"fact2"`
 	ConflictType string     `json:"conflict_type"` // "attribute"
 	Similarity   float64    `json:"similarity"`
+	CrossAgent   bool       `json:"cross_agent,omitempty"`
 }
 
 // Engine provides memory observability capabilities.
@@ -549,6 +550,7 @@ func (e *Engine) GetConflictsLimitWithSuperseded(ctx context.Context, limit int,
 			Fact2:        sc.Fact2,
 			ConflictType: sc.ConflictType,
 			Similarity:   sc.Similarity,
+			CrossAgent:   sc.CrossAgent,
 		}
 	}
 

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -455,11 +455,14 @@ func (s *SQLiteStore) GetAttributeConflictsLimitWithSuperseded(ctx context.Conte
 		for i := 0; i < len(facts); i++ {
 			for j := i + 1; j < len(facts); j++ {
 				if facts[i].Object != facts[j].Object {
+					crossAgent := facts[i].AgentID != facts[j].AgentID &&
+						(facts[i].AgentID != "" || facts[j].AgentID != "")
 					conflicts = append(conflicts, Conflict{
 						Fact1:        facts[i],
 						Fact2:        facts[j],
 						ConflictType: "attribute",
 						Similarity:   1.0,
+						CrossAgent:   crossAgent,
 					})
 				}
 			}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -145,6 +145,7 @@ type Conflict struct {
 	Fact2        Fact    `json:"fact2"`
 	ConflictType string  `json:"conflict_type"` // "attribute"
 	Similarity   float64 `json:"similarity"`
+	CrossAgent   bool    `json:"cross_agent,omitempty"` // true if facts from different agents
 }
 
 // ProjectInfo holds metadata about a project tag.


### PR DESCRIPTION
## Summary

Implements **#167 Cross-agent conflict detection** — "Niot stored X but Hawk stored not-X" is now detected and surfaced with elevated severity.

### How it works
When a fact contradicts another fact from a different agent, the conflict is:
1. **Tagged** with `cross_agent: true`
2. **Elevated** in severity (info→warning, warning→critical)
3. **Labeled** with both agent IDs in the alert message

### Changes
- `CheckConflictsForFact` + `GetAttributeConflicts`: detect cross-agent conflicts via `agent_id` comparison
- `CheckAndAlertConflicts`: cross-agent conflicts get elevated severity + ⚠️ prefix
- `ConflictAlertDetails`: includes `fact1_agent`, `fact2_agent`, `cross_agent` fields
- CLI: conflict display shows `[agent]` tags and `⚠️ CROSS-AGENT` badge
- `store.Conflict` + `observe.Conflict`: `CrossAgent` field propagated through layers

### Test results
- **554 tests** across 16 packages, all passing
- 3 new tests: cross-agent detection, same-agent negative, bulk conflicts

### Closes
- Closes #167
- Completes **Phase 3 (Shared Cognition)** of Epic #158