### PR TITLE
feat: Fact relationship edges — knowledge graph foundation (#168)

### DIFF
--- a/internal/observe/alerts.go
+++ b/internal/observe/alerts.go
@@ -105,6 +105,16 @@ func CheckAndAlertConflicts(ctx context.Context, s *store.SQLiteStore, fact *sto
 		if err := s.CreateAlert(ctx, alert); err != nil {
 			return created, fmt.Errorf("creating conflict alert: %w", err)
 		}
+
+		// Auto-create 'contradicts' edge in knowledge graph
+		_ = s.AddEdge(ctx, &store.FactEdge{
+			SourceFactID: c.Fact1.ID,
+			TargetFactID: c.Fact2.ID,
+			EdgeType:     store.EdgeTypeContradicts,
+			Confidence:   1.0,
+			Source:       store.EdgeSourceDetected,
+		})
+
 		created++
 	}
 

--- a/internal/store/fact_edges.go
+++ b/internal/store/fact_edges.go
@@ -1,0 +1,257 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// EdgeType defines the type of relationship between facts.
+type EdgeType string
+
+const (
+	EdgeTypeSupports    EdgeType = "supports"
+	EdgeTypeContradicts EdgeType = "contradicts"
+	EdgeTypeRelatesTo   EdgeType = "relates_to"
+	EdgeTypeSupersedes  EdgeType = "supersedes"
+	EdgeTypeDerivedFrom EdgeType = "derived_from"
+)
+
+// EdgeSource defines how an edge was created.
+type EdgeSource string
+
+const (
+	EdgeSourceExplicit EdgeSource = "explicit"
+	EdgeSourceDetected EdgeSource = "detected"
+	EdgeSourceInferred EdgeSource = "inferred"
+)
+
+// FactEdge represents a typed relationship between two facts.
+type FactEdge struct {
+	ID           int64      `json:"id"`
+	SourceFactID int64      `json:"source_fact_id"`
+	TargetFactID int64      `json:"target_fact_id"`
+	EdgeType     EdgeType   `json:"edge_type"`
+	Confidence   float64    `json:"confidence"`
+	Source       EdgeSource `json:"source"`
+	AgentID      string     `json:"agent_id,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+}
+
+// GraphNode represents a fact in a graph traversal result.
+type GraphNode struct {
+	Fact  *Fact       `json:"fact"`
+	Edges []FactEdge  `json:"edges"`
+	Depth int         `json:"depth"`
+}
+
+// AddEdge creates a relationship between two facts.
+func (s *SQLiteStore) AddEdge(ctx context.Context, edge *FactEdge) error {
+	if edge.SourceFactID == edge.TargetFactID {
+		return fmt.Errorf("cannot create edge from a fact to itself")
+	}
+	if edge.Confidence <= 0 {
+		edge.Confidence = 1.0
+	}
+	if edge.Source == "" {
+		edge.Source = EdgeSourceExplicit
+	}
+
+	result, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO fact_edges_v1 (source_fact_id, target_fact_id, edge_type, confidence, source, agent_id)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		edge.SourceFactID, edge.TargetFactID, string(edge.EdgeType),
+		edge.Confidence, string(edge.Source), edge.AgentID,
+	)
+	if err != nil {
+		return fmt.Errorf("adding edge: %w", err)
+	}
+
+	id, _ := result.LastInsertId()
+	edge.ID = id
+	edge.CreatedAt = time.Now().UTC()
+	return nil
+}
+
+// GetEdgesForFact returns all edges where the given fact is source or target.
+func (s *SQLiteStore) GetEdgesForFact(ctx context.Context, factID int64) ([]FactEdge, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, source_fact_id, target_fact_id, edge_type, confidence, source, agent_id, created_at
+		 FROM fact_edges_v1
+		 WHERE source_fact_id = ? OR target_fact_id = ?
+		 ORDER BY created_at DESC`,
+		factID, factID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting edges for fact %d: %w", factID, err)
+	}
+	defer rows.Close()
+
+	return scanEdges(rows)
+}
+
+// GetEdgesByType returns all edges of a specific type.
+func (s *SQLiteStore) GetEdgesByType(ctx context.Context, edgeType EdgeType, limit int) ([]FactEdge, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, source_fact_id, target_fact_id, edge_type, confidence, source, agent_id, created_at
+		 FROM fact_edges_v1 WHERE edge_type = ? ORDER BY created_at DESC LIMIT ?`,
+		string(edgeType), limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting edges by type: %w", err)
+	}
+	defer rows.Close()
+
+	return scanEdges(rows)
+}
+
+// RemoveEdge deletes an edge by ID.
+func (s *SQLiteStore) RemoveEdge(ctx context.Context, edgeID int64) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM fact_edges_v1 WHERE id = ?`, edgeID)
+	if err != nil {
+		return fmt.Errorf("removing edge: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("edge %d not found", edgeID)
+	}
+	return nil
+}
+
+// TraverseGraph performs a breadth-first traversal from a starting fact,
+// following edges up to maxDepth hops. Returns all reachable facts with their edges.
+func (s *SQLiteStore) TraverseGraph(ctx context.Context, startFactID int64, maxDepth int, minConfidence float64) ([]GraphNode, error) {
+	if maxDepth <= 0 {
+		maxDepth = 2
+	}
+	if minConfidence <= 0 {
+		minConfidence = 0.0
+	}
+
+	visited := map[int64]bool{}
+	var result []GraphNode
+
+	// BFS queue
+	type queueItem struct {
+		factID int64
+		depth  int
+	}
+	queue := []queueItem{{startFactID, 0}}
+	visited[startFactID] = true
+
+	for len(queue) > 0 {
+		item := queue[0]
+		queue = queue[1:]
+
+		// Get the fact
+		fact, err := s.GetFact(ctx, item.factID)
+		if err != nil || fact == nil {
+			continue
+		}
+
+		// Get edges
+		edges, err := s.GetEdgesForFact(ctx, item.factID)
+		if err != nil {
+			continue
+		}
+
+		// Filter by confidence
+		var filteredEdges []FactEdge
+		for _, e := range edges {
+			if e.Confidence >= minConfidence {
+				filteredEdges = append(filteredEdges, e)
+			}
+		}
+
+		result = append(result, GraphNode{
+			Fact:  fact,
+			Edges: filteredEdges,
+			Depth: item.depth,
+		})
+
+		// Enqueue neighbors if not at max depth
+		if item.depth < maxDepth {
+			for _, e := range filteredEdges {
+				neighborID := e.TargetFactID
+				if neighborID == item.factID {
+					neighborID = e.SourceFactID
+				}
+				if !visited[neighborID] {
+					visited[neighborID] = true
+					queue = append(queue, queueItem{neighborID, item.depth + 1})
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// CountEdges returns the total number of edges in the graph.
+func (s *SQLiteStore) CountEdges(ctx context.Context) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM fact_edges_v1`).Scan(&count)
+	return count, err
+}
+
+// DecayInferredEdges removes inferred edges that haven't been reinforced
+// (no co-occurrence or access) within the given number of days.
+func (s *SQLiteStore) DecayInferredEdges(ctx context.Context, maxAgeDays int) (int, error) {
+	if maxAgeDays <= 0 {
+		maxAgeDays = 90
+	}
+	cutoff := time.Now().UTC().AddDate(0, 0, -maxAgeDays)
+
+	result, err := s.db.ExecContext(ctx,
+		`DELETE FROM fact_edges_v1 WHERE source = 'inferred' AND created_at < ?`,
+		cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("decaying inferred edges: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	return int(rows), nil
+}
+
+func scanEdges(rows *sql.Rows) ([]FactEdge, error) {
+	var edges []FactEdge
+	for rows.Next() {
+		var e FactEdge
+		var createdStr string
+		if err := rows.Scan(&e.ID, &e.SourceFactID, &e.TargetFactID,
+			&e.EdgeType, &e.Confidence, &e.Source, &e.AgentID, &createdStr); err != nil {
+			return nil, fmt.Errorf("scanning edge: %w", err)
+		}
+		if t, err := time.Parse("2006-01-02 15:04:05", createdStr); err == nil {
+			e.CreatedAt = t
+		} else if t, err := time.Parse(time.RFC3339, createdStr); err == nil {
+			e.CreatedAt = t
+		}
+		edges = append(edges, e)
+	}
+	return edges, rows.Err()
+}
+
+// ValidEdgeTypes returns the valid edge type strings.
+func ValidEdgeTypes() []string {
+	return []string{
+		string(EdgeTypeSupports), string(EdgeTypeContradicts),
+		string(EdgeTypeRelatesTo), string(EdgeTypeSupersedes),
+		string(EdgeTypeDerivedFrom),
+	}
+}
+
+// ParseEdgeType validates and returns an EdgeType.
+func ParseEdgeType(s string) (EdgeType, error) {
+	switch EdgeType(strings.ToLower(s)) {
+	case EdgeTypeSupports, EdgeTypeContradicts, EdgeTypeRelatesTo, EdgeTypeSupersedes, EdgeTypeDerivedFrom:
+		return EdgeType(strings.ToLower(s)), nil
+	default:
+		return "", fmt.Errorf("invalid edge type %q (valid: %s)", s, strings.Join(ValidEdgeTypes(), ", "))
+	}
+}

--- a/internal/store/fact_edges_test.go
+++ b/internal/store/fact_edges_test.go
@@ -1,0 +1,205 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAddEdge(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	f1, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "a", Predicate: "p", Object: "o1", FactType: "kv"})
+	f2, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "b", Predicate: "p", Object: "o2", FactType: "kv"})
+
+	edge := &FactEdge{
+		SourceFactID: f1, TargetFactID: f2,
+		EdgeType: EdgeTypeSupports, Source: EdgeSourceExplicit,
+	}
+	if err := s.AddEdge(ctx, edge); err != nil {
+		t.Fatalf("AddEdge: %v", err)
+	}
+	if edge.ID == 0 {
+		t.Fatal("Expected non-zero edge ID")
+	}
+}
+
+func TestAddEdgeSelfLoop(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	err := s.AddEdge(ctx, &FactEdge{
+		SourceFactID: 1, TargetFactID: 1, EdgeType: EdgeTypeSupports,
+	})
+	if err == nil {
+		t.Fatal("Expected error for self-loop edge")
+	}
+}
+
+func TestAddEdgeDuplicate(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	f1, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "a", Predicate: "p", Object: "o1", FactType: "kv"})
+	f2, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "b", Predicate: "p", Object: "o2", FactType: "kv"})
+
+	edge := &FactEdge{SourceFactID: f1, TargetFactID: f2, EdgeType: EdgeTypeSupports}
+	s.AddEdge(ctx, edge)
+
+	// Duplicate should be ignored (OR IGNORE)
+	err := s.AddEdge(ctx, &FactEdge{SourceFactID: f1, TargetFactID: f2, EdgeType: EdgeTypeSupports})
+	if err != nil {
+		t.Fatalf("Expected duplicate to be silently ignored, got: %v", err)
+	}
+}
+
+func TestGetEdgesForFact(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	f1, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "a", Predicate: "p", Object: "o1", FactType: "kv"})
+	f2, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "b", Predicate: "p", Object: "o2", FactType: "kv"})
+	f3, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "c", Predicate: "p", Object: "o3", FactType: "kv"})
+
+	s.AddEdge(ctx, &FactEdge{SourceFactID: f1, TargetFactID: f2, EdgeType: EdgeTypeSupports})
+	s.AddEdge(ctx, &FactEdge{SourceFactID: f3, TargetFactID: f1, EdgeType: EdgeTypeContradicts})
+
+	edges, err := s.GetEdgesForFact(ctx, f1)
+	if err != nil {
+		t.Fatalf("GetEdgesForFact: %v", err)
+	}
+	if len(edges) != 2 {
+		t.Fatalf("Expected 2 edges for f1 (as source and target), got %d", len(edges))
+	}
+}
+
+func TestRemoveEdge(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	f1, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "a", Predicate: "p", Object: "o1", FactType: "kv"})
+	f2, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "b", Predicate: "p", Object: "o2", FactType: "kv"})
+
+	edge := &FactEdge{SourceFactID: f1, TargetFactID: f2, EdgeType: EdgeTypeRelatesTo}
+	s.AddEdge(ctx, edge)
+
+	if err := s.RemoveEdge(ctx, edge.ID); err != nil {
+		t.Fatalf("RemoveEdge: %v", err)
+	}
+
+	edges, _ := s.GetEdgesForFact(ctx, f1)
+	if len(edges) != 0 {
+		t.Fatal("Expected 0 edges after removal")
+	}
+}
+
+func TestTraverseGraph(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "graph test", SourceFile: "t.md"})
+	f1, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "root", Predicate: "p", Object: "o1", FactType: "kv"})
+	f2, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "child", Predicate: "p", Object: "o2", FactType: "kv"})
+	f3, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "grandchild", Predicate: "p", Object: "o3", FactType: "kv"})
+	f4, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "unrelated", Predicate: "p", Object: "o4", FactType: "kv"})
+	_ = f4
+
+	s.AddEdge(ctx, &FactEdge{SourceFactID: f1, TargetFactID: f2, EdgeType: EdgeTypeSupports})
+	s.AddEdge(ctx, &FactEdge{SourceFactID: f2, TargetFactID: f3, EdgeType: EdgeTypeDerivedFrom})
+
+	// Depth 2 should find f1, f2, f3 but not f4
+	nodes, err := s.TraverseGraph(ctx, f1, 2, 0)
+	if err != nil {
+		t.Fatalf("TraverseGraph: %v", err)
+	}
+	if len(nodes) != 3 {
+		t.Fatalf("Expected 3 nodes (root + child + grandchild), got %d", len(nodes))
+	}
+
+	// Depth 1 should only find f1, f2
+	nodes1, _ := s.TraverseGraph(ctx, f1, 1, 0)
+	if len(nodes1) != 2 {
+		t.Fatalf("Expected 2 nodes at depth 1, got %d", len(nodes1))
+	}
+}
+
+func TestTraverseGraphConfidenceFilter(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	f1, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "a", Predicate: "p", Object: "o1", FactType: "kv"})
+	f2, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "b", Predicate: "p", Object: "o2", FactType: "kv"})
+	f3, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "c", Predicate: "p", Object: "o3", FactType: "kv"})
+
+	s.AddEdge(ctx, &FactEdge{SourceFactID: f1, TargetFactID: f2, EdgeType: EdgeTypeRelatesTo, Confidence: 0.9})
+	s.AddEdge(ctx, &FactEdge{SourceFactID: f1, TargetFactID: f3, EdgeType: EdgeTypeRelatesTo, Confidence: 0.3})
+
+	// High confidence filter should only follow the strong edge
+	nodes, _ := s.TraverseGraph(ctx, f1, 2, 0.5)
+	if len(nodes) != 2 {
+		t.Fatalf("Expected 2 nodes with minConf=0.5 (root + f2), got %d", len(nodes))
+	}
+}
+
+func TestSupersedeCreatesEdge(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	f1, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "config", Predicate: "value", Object: "old", FactType: "kv"})
+	f2, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "config", Predicate: "value", Object: "new", FactType: "kv"})
+
+	s.SupersedeFact(ctx, f1, f2, "updated")
+
+	// Should have a supersedes edge
+	edges, _ := s.GetEdgesForFact(ctx, f2)
+	found := false
+	for _, e := range edges {
+		if e.EdgeType == EdgeTypeSupersedes && e.SourceFactID == f2 && e.TargetFactID == f1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Expected 'supersedes' edge from new fact to old fact")
+	}
+}
+
+func TestDecayInferredEdges(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	f1, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "a", Predicate: "p", Object: "o1", FactType: "kv"})
+	f2, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "b", Predicate: "p", Object: "o2", FactType: "kv"})
+
+	// Add inferred edge
+	s.AddEdge(ctx, &FactEdge{SourceFactID: f1, TargetFactID: f2, EdgeType: EdgeTypeRelatesTo, Source: EdgeSourceInferred})
+
+	// Backdate it
+	s.db.ExecContext(ctx, `UPDATE fact_edges_v1 SET created_at = datetime('now', '-100 days')`)
+
+	removed, err := s.DecayInferredEdges(ctx, 90)
+	if err != nil {
+		t.Fatalf("DecayInferredEdges: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("Expected 1 removed, got %d", removed)
+	}
+}
+
+func TestParseEdgeType(t *testing.T) {
+	for _, valid := range ValidEdgeTypes() {
+		if _, err := ParseEdgeType(valid); err != nil {
+			t.Errorf("Expected %q to be valid: %v", valid, err)
+		}
+	}
+
+	if _, err := ParseEdgeType("invalid_type"); err == nil {
+		t.Error("Expected error for invalid edge type")
+	}
+}

--- a/internal/store/facts.go
+++ b/internal/store/facts.go
@@ -216,6 +216,15 @@ func (s *SQLiteStore) SupersedeFact(ctx context.Context, oldFactID, newFactID in
 		Source:    "supersede",
 	})
 
+	// Auto-create 'supersedes' edge in knowledge graph
+	_ = s.AddEdge(ctx, &FactEdge{
+		SourceFactID: newFactID,
+		TargetFactID: oldFactID,
+		EdgeType:     EdgeTypeSupersedes,
+		Confidence:   1.0,
+		Source:       EdgeSourceDetected,
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Implements **#168 Fact relationship edges** — typed edges between facts, the foundation of the emergent knowledge graph.

### Edge types
| Type | Meaning | Auto-created by |
|------|---------|----------------|
| `supports` | A provides evidence for B | explicit |
| `contradicts` | A conflicts with B | conflict detection |
| `relates_to` | A is topically related to B | co-occurrence (TBD) |
| `supersedes` | A replaces B (newer) | SupersedeFact() |
| `derived_from` | A was extracted from B | explicit |

### What's included
- **Store:** AddEdge, GetEdgesForFact, GetEdgesByType, RemoveEdge, TraverseGraph, CountEdges, DecayInferredEdges
- **CLI:** `cortex edge add|list|remove`, `cortex graph <id> --depth --min-confidence`
- **MCP:** `cortex_edge_add`, `cortex_graph`
- **Auto-edges:** Conflict detection auto-creates contradicts edges; supersede auto-creates supersedes edges
- **Inferred edge decay:** Unused inferred edges are cleaned up after 90 days (consistent with Cortex philosophy)
- **Graph traversal:** BFS with configurable depth + minimum confidence filtering

### Tests: 564 total, all passing. 10 new tests.

Closes #168