### PR TITLE
feat: Relationship inference engine — emergent knowledge graph (#170)

### DIFF
--- a/internal/store/inference.go
+++ b/internal/store/inference.go
@@ -1,0 +1,337 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// InferenceResult holds the outcome of running the inference engine.
+type InferenceResult struct {
+	EdgesCreated    int              `json:"edges_created"`
+	EdgesSkipped    int              `json:"edges_skipped"` // Already existed
+	RulesApplied    map[string]int   `json:"rules_applied"`
+	Proposals       []EdgeProposal   `json:"proposals,omitempty"` // For dry-run
+}
+
+// EdgeProposal represents a proposed edge from inference.
+type EdgeProposal struct {
+	SourceFactID int64    `json:"source_fact_id"`
+	TargetFactID int64    `json:"target_fact_id"`
+	EdgeType     EdgeType `json:"edge_type"`
+	Confidence   float64  `json:"confidence"`
+	Rule         string   `json:"rule"`
+	Reason       string   `json:"reason"`
+}
+
+// InferenceOpts controls inference behavior.
+type InferenceOpts struct {
+	DryRun        bool    // Preview only, don't create edges
+	MinConfidence float64 // Minimum confidence for inferred edges (default: 0.3)
+	MaxEdges      int     // Maximum edges to create per run (default: 100)
+}
+
+// DefaultInferenceOpts returns sensible defaults.
+func DefaultInferenceOpts() InferenceOpts {
+	return InferenceOpts{
+		MinConfidence: 0.3,
+		MaxEdges:      100,
+	}
+}
+
+// RunInference applies all inference rules and creates (or proposes) edges.
+func (s *SQLiteStore) RunInference(ctx context.Context, opts InferenceOpts) (*InferenceResult, error) {
+	if opts.MinConfidence <= 0 {
+		opts.MinConfidence = 0.3
+	}
+	if opts.MaxEdges <= 0 {
+		opts.MaxEdges = 100
+	}
+
+	result := &InferenceResult{
+		RulesApplied: make(map[string]int),
+	}
+
+	rules := []struct {
+		name string
+		fn   func(context.Context, InferenceOpts, *InferenceResult) error
+	}{
+		{"cooccurrence", s.inferFromCooccurrence},
+		{"subject_clustering", s.inferFromSubjectClustering},
+		{"supersession", s.inferFromSupersession},
+	}
+
+	for _, rule := range rules {
+		if result.EdgesCreated >= opts.MaxEdges && !opts.DryRun {
+			break
+		}
+		if err := rule.fn(ctx, opts, result); err != nil {
+			return result, fmt.Errorf("rule %s: %w", rule.name, err)
+		}
+	}
+
+	return result, nil
+}
+
+// Rule 1: Co-occurrence → relates_to
+// Facts that co-occur >= 5 times get a relates_to edge.
+func (s *SQLiteStore) inferFromCooccurrence(ctx context.Context, opts InferenceOpts, result *InferenceResult) error {
+	suggestions, err := s.SuggestEdgesFromCooccurrence(ctx, 5)
+	if err != nil {
+		return err
+	}
+
+	for _, pair := range suggestions {
+		// Confidence based on co-occurrence count (5=0.5, 10=0.7, 20+=0.9)
+		conf := 0.5 + float64(pair.Count-5)*0.02
+		if conf > 0.9 {
+			conf = 0.9
+		}
+		if conf < opts.MinConfidence {
+			continue
+		}
+
+		proposal := EdgeProposal{
+			SourceFactID: pair.FactIDA,
+			TargetFactID: pair.FactIDB,
+			EdgeType:     EdgeTypeRelatesTo,
+			Confidence:   conf,
+			Rule:         "cooccurrence",
+			Reason:       fmt.Sprintf("Co-occurred %d times", pair.Count),
+		}
+
+		if opts.DryRun {
+			result.Proposals = append(result.Proposals, proposal)
+			result.RulesApplied["cooccurrence"]++
+			continue
+		}
+
+		err := s.AddEdge(ctx, &FactEdge{
+			SourceFactID: pair.FactIDA,
+			TargetFactID: pair.FactIDB,
+			EdgeType:     EdgeTypeRelatesTo,
+			Confidence:   conf,
+			Source:       EdgeSourceInferred,
+		})
+		if err != nil {
+			result.EdgesSkipped++
+		} else {
+			result.EdgesCreated++
+			result.RulesApplied["cooccurrence"]++
+		}
+
+		if result.EdgesCreated >= opts.MaxEdges {
+			break
+		}
+	}
+
+	return nil
+}
+
+// Rule 2: Subject clustering → relates_to
+// Facts with the same subject but different predicates are structurally related.
+func (s *SQLiteStore) inferFromSubjectClustering(ctx context.Context, opts InferenceOpts, result *InferenceResult) error {
+	// Find subjects with multiple distinct predicates
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT LOWER(subject), COUNT(DISTINCT predicate) as pred_count
+		 FROM facts
+		 WHERE superseded_by IS NULL AND confidence > 0 AND subject != ''
+		 GROUP BY LOWER(subject)
+		 HAVING COUNT(DISTINCT predicate) >= 2
+		 ORDER BY pred_count DESC
+		 LIMIT 50`,
+	)
+	if err != nil {
+		return fmt.Errorf("querying subject clusters: %w", err)
+	}
+	defer rows.Close()
+
+	var subjects []string
+	for rows.Next() {
+		var subject string
+		var count int
+		if err := rows.Scan(&subject, &count); err != nil {
+			continue
+		}
+		subjects = append(subjects, subject)
+	}
+
+	for _, subject := range subjects {
+		if result.EdgesCreated >= opts.MaxEdges && !opts.DryRun {
+			break
+		}
+
+		// Get facts for this subject
+		factRows, err := s.db.QueryContext(ctx,
+			`SELECT id FROM facts
+			 WHERE LOWER(subject) = ? AND superseded_by IS NULL AND confidence > 0
+			 ORDER BY created_at DESC LIMIT 10`,
+			subject,
+		)
+		if err != nil {
+			continue
+		}
+
+		var factIDs []int64
+		for factRows.Next() {
+			var id int64
+			factRows.Scan(&id)
+			factIDs = append(factIDs, id)
+		}
+		factRows.Close()
+
+		// Create relates_to edges between facts with same subject
+		for i := 0; i < len(factIDs); i++ {
+			for j := i + 1; j < len(factIDs); j++ {
+				conf := 0.4 // Lower confidence for subject clustering
+				if conf < opts.MinConfidence {
+					continue
+				}
+
+				proposal := EdgeProposal{
+					SourceFactID: factIDs[i],
+					TargetFactID: factIDs[j],
+					EdgeType:     EdgeTypeRelatesTo,
+					Confidence:   conf,
+					Rule:         "subject_clustering",
+					Reason:       fmt.Sprintf("Same subject: %q", subject),
+				}
+
+				if opts.DryRun {
+					result.Proposals = append(result.Proposals, proposal)
+					result.RulesApplied["subject_clustering"]++
+					continue
+				}
+
+				err := s.AddEdge(ctx, &FactEdge{
+					SourceFactID: factIDs[i],
+					TargetFactID: factIDs[j],
+					EdgeType:     EdgeTypeRelatesTo,
+					Confidence:   conf,
+					Source:       EdgeSourceInferred,
+				})
+				if err != nil {
+					result.EdgesSkipped++
+				} else {
+					result.EdgesCreated++
+					result.RulesApplied["subject_clustering"]++
+				}
+
+				if result.EdgesCreated >= opts.MaxEdges {
+					return nil
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// Rule 3: Supersession patterns → supersedes
+// Facts with same subject+predicate but different objects where one is newer.
+func (s *SQLiteStore) inferFromSupersession(ctx context.Context, opts InferenceOpts, result *InferenceResult) error {
+	// Find subject+predicate pairs with multiple active facts
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT LOWER(subject), LOWER(predicate), COUNT(*) as cnt
+		 FROM facts
+		 WHERE superseded_by IS NULL AND confidence > 0 AND subject != ''
+		 GROUP BY LOWER(subject), LOWER(predicate)
+		 HAVING COUNT(DISTINCT object) > 1
+		 ORDER BY cnt DESC
+		 LIMIT 50`,
+	)
+	if err != nil {
+		return fmt.Errorf("querying supersession candidates: %w", err)
+	}
+	defer rows.Close()
+
+	type spPair struct{ subject, predicate string }
+	var pairs []spPair
+	for rows.Next() {
+		var p spPair
+		var cnt int
+		rows.Scan(&p.subject, &p.predicate, &cnt)
+		pairs = append(pairs, p)
+	}
+
+	for _, p := range pairs {
+		if result.EdgesCreated >= opts.MaxEdges && !opts.DryRun {
+			break
+		}
+
+		factRows, err := s.db.QueryContext(ctx,
+			`SELECT id, object, created_at FROM facts
+			 WHERE LOWER(subject) = ? AND LOWER(predicate) = ?
+			   AND superseded_by IS NULL AND confidence > 0
+			 ORDER BY created_at DESC LIMIT 5`,
+			p.subject, p.predicate,
+		)
+		if err != nil {
+			continue
+		}
+
+		type factInfo struct {
+			id        int64
+			object    string
+			createdAt time.Time
+		}
+		var facts []factInfo
+		for factRows.Next() {
+			var f factInfo
+			var createdStr string
+			factRows.Scan(&f.id, &f.object, &createdStr)
+			if t, err := time.Parse("2006-01-02 15:04:05", createdStr); err == nil {
+				f.createdAt = t
+			}
+			facts = append(facts, f)
+		}
+		factRows.Close()
+
+		// Newest fact supersedes older ones with different objects
+		if len(facts) >= 2 {
+			newest := facts[0]
+			for _, older := range facts[1:] {
+				if strings.EqualFold(newest.object, older.object) {
+					continue
+				}
+
+				conf := 0.6
+				if conf < opts.MinConfidence {
+					continue
+				}
+
+				proposal := EdgeProposal{
+					SourceFactID: newest.id,
+					TargetFactID: older.id,
+					EdgeType:     EdgeTypeSupersedes,
+					Confidence:   conf,
+					Rule:         "supersession",
+					Reason:       fmt.Sprintf("%s %s: %q → %q", p.subject, p.predicate, older.object, newest.object),
+				}
+
+				if opts.DryRun {
+					result.Proposals = append(result.Proposals, proposal)
+					result.RulesApplied["supersession"]++
+					continue
+				}
+
+				err := s.AddEdge(ctx, &FactEdge{
+					SourceFactID: newest.id,
+					TargetFactID: older.id,
+					EdgeType:     EdgeTypeSupersedes,
+					Confidence:   conf,
+					Source:       EdgeSourceInferred,
+				})
+				if err != nil {
+					result.EdgesSkipped++
+				} else {
+					result.EdgesCreated++
+					result.RulesApplied["supersession"]++
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/store/inference_test.go
+++ b/internal/store/inference_test.go
@@ -1,0 +1,161 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestInferenceDryRun(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+
+	// Create facts with same subject, different predicates
+	s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "cortex", Predicate: "language", Object: "Go", FactType: "kv"})
+	s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "cortex", Predicate: "database", Object: "SQLite", FactType: "kv"})
+
+	opts := DefaultInferenceOpts()
+	opts.DryRun = true
+
+	result, err := s.RunInference(ctx, opts)
+	if err != nil {
+		t.Fatalf("RunInference dry-run: %v", err)
+	}
+
+	if result.EdgesCreated != 0 {
+		t.Fatal("Dry-run should not create edges")
+	}
+	if len(result.Proposals) == 0 {
+		t.Fatal("Expected proposals from subject clustering")
+	}
+}
+
+func TestInferenceApply(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+
+	s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "cortex", Predicate: "language", Object: "Go", FactType: "kv"})
+	s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "cortex", Predicate: "database", Object: "SQLite", FactType: "kv"})
+
+	opts := DefaultInferenceOpts()
+	opts.DryRun = false
+
+	result, err := s.RunInference(ctx, opts)
+	if err != nil {
+		t.Fatalf("RunInference apply: %v", err)
+	}
+
+	if result.EdgesCreated == 0 {
+		t.Fatal("Expected at least 1 edge created")
+	}
+
+	// Verify edge exists
+	edgeCount, _ := s.CountEdges(ctx)
+	if edgeCount == 0 {
+		t.Fatal("Expected edges in database after inference")
+	}
+}
+
+func TestInferenceCooccurrence(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+	f1, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "a", Predicate: "p", Object: "o1", FactType: "kv"})
+	f2, _ := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "b", Predicate: "p", Object: "o2", FactType: "kv"})
+
+	// Create co-occurrence above threshold
+	for i := 0; i < 7; i++ {
+		s.RecordCooccurrence(ctx, f1, f2)
+	}
+
+	opts := DefaultInferenceOpts()
+	opts.DryRun = true
+
+	result, _ := s.RunInference(ctx, opts)
+
+	found := false
+	for _, p := range result.Proposals {
+		if p.Rule == "cooccurrence" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Expected co-occurrence rule to propose an edge")
+	}
+}
+
+func TestInferenceSupersession(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+
+	// Same subject+predicate, different objects
+	s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "config", Predicate: "value", Object: "old_val", FactType: "kv"})
+	s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "config", Predicate: "value", Object: "new_val", FactType: "kv"})
+
+	opts := DefaultInferenceOpts()
+	opts.DryRun = true
+
+	result, _ := s.RunInference(ctx, opts)
+
+	found := false
+	for _, p := range result.Proposals {
+		if p.Rule == "supersession" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Expected supersession rule to propose an edge")
+	}
+}
+
+func TestInferenceMaxEdges(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+
+	// Create many facts with same subject to generate many proposals
+	for i := 0; i < 10; i++ {
+		s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "project", Predicate: fmt.Sprintf("attr%d", i), Object: fmt.Sprintf("val%d", i), FactType: "kv"})
+	}
+
+	opts := DefaultInferenceOpts()
+	opts.DryRun = false
+	opts.MaxEdges = 3
+
+	result, _ := s.RunInference(ctx, opts)
+
+	if result.EdgesCreated > 3 {
+		t.Fatalf("Expected max 3 edges, got %d", result.EdgesCreated)
+	}
+}
+
+func TestInferenceMinConfidence(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	memID, _ := s.AddMemory(ctx, &Memory{Content: "test", SourceFile: "t.md"})
+
+	s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "x", Predicate: "a", Object: "v1", FactType: "kv"})
+	s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "x", Predicate: "b", Object: "v2", FactType: "kv"})
+
+	// High confidence threshold should filter out low-confidence subject clustering (0.4)
+	opts := DefaultInferenceOpts()
+	opts.DryRun = true
+	opts.MinConfidence = 0.8
+
+	result, _ := s.RunInference(ctx, opts)
+
+	for _, p := range result.Proposals {
+		if p.Rule == "subject_clustering" {
+			t.Fatal("Subject clustering (conf=0.4) should be filtered at minConf=0.8")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements **#170 Relationship inference from usage patterns** — the final piece of the Cortex knowledge graph. Facts now connect themselves based on how they're actually used.

### 3 Inference Rules
| Rule | Edge Type | Signal | Confidence |
|------|----------|--------|------------|
| Co-occurrence | `relates_to` | Facts appear together 5+ times | 0.5-0.9 (scales with count) |
| Subject clustering | `relates_to` | Same subject, different predicates | 0.4 |
| Supersession | `supersedes` | Same subject+predicate, different objects | 0.6 |

### Philosophy
- **Dry-run first**: `cortex infer --dry-run` previews proposals without creating
- **Low initial confidence**: Inferred edges start weak, must be reinforced to survive
- **Decay on inferred edges**: Unused inferred edges fade away (via `DecayInferredEdges`)
- **Configurable**: `--min-confidence` filters weak proposals, `--max-edges` caps per run

### Tests: 576 total, all passing. 6 new.

### 🎉 This closes Epic #158 — Cortex v1.0: From Tool to Platform

All 12 issues across 4 phases are complete:
- Phase 1 (Zero-Friction Install): #159, #160, #161
- Phase 2 (Proactive Intelligence): #162, #163, #164
- Phase 3 (Shared Cognition): #165, #166, #167
- Phase 4 (Emergent Knowledge Graph): #168, #169, #170

Closes #170