### PR TITLE
feat: add cleanup --dedup-facts for near-duplicate supersession

### DIFF
--- a/internal/store/facts_dedup.go
+++ b/internal/store/facts_dedup.go
@@ -1,0 +1,256 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+type dedupFactRow struct {
+	ID             int64
+	Subject        string
+	Predicate      string
+	Object         string
+	Confidence     float64
+	LastReinforced string
+}
+
+// DedupFacts finds near-duplicate facts (same subject+predicate with similar objects)
+// and supersedes lower-quality duplicates. In dry-run mode it only reports candidates.
+func (s *SQLiteStore) DedupFacts(ctx context.Context, opts DedupFactOptions) (*DedupFactReport, error) {
+	if opts.Threshold <= 0 {
+		opts.Threshold = 0.90
+	}
+	if opts.Threshold > 1 {
+		opts.Threshold = 1
+	}
+	if opts.MaxPreview <= 0 {
+		opts.MaxPreview = 25
+	}
+
+	query := `
+		SELECT id, subject, predicate, object, confidence, COALESCE(last_reinforced, '')
+		FROM facts
+		WHERE superseded_by IS NULL
+	`
+	args := []interface{}{}
+	if strings.TrimSpace(opts.Agent) != "" {
+		query += ` AND agent_id = ?`
+		args = append(args, strings.TrimSpace(opts.Agent))
+	}
+	query += `
+		ORDER BY LOWER(TRIM(subject)), LOWER(TRIM(predicate)), confidence DESC, last_reinforced DESC, id ASC
+	`
+
+	rows, err := s.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying facts for dedup: %w", err)
+	}
+	defer rows.Close()
+
+	groups := map[string][]dedupFactRow{}
+	groupOrder := []string{}
+	for rows.Next() {
+		var r dedupFactRow
+		if err := rows.Scan(&r.ID, &r.Subject, &r.Predicate, &r.Object, &r.Confidence, &r.LastReinforced); err != nil {
+			return nil, fmt.Errorf("scanning fact row: %w", err)
+		}
+		key := normalizeFactKey(r.Subject, r.Predicate)
+		if _, ok := groups[key]; !ok {
+			groupOrder = append(groupOrder, key)
+		}
+		groups[key] = append(groups[key], r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating fact rows: %w", err)
+	}
+
+	report := &DedupFactReport{GroupsScanned: len(groupOrder)}
+	merges := make([]DedupFactMerge, 0)
+
+	for _, key := range groupOrder {
+		facts := groups[key]
+		if len(facts) < 2 {
+			continue
+		}
+
+		// ensure deterministic winner precedence
+		sort.SliceStable(facts, func(i, j int) bool {
+			if facts[i].Confidence != facts[j].Confidence {
+				return facts[i].Confidence > facts[j].Confidence
+			}
+			if facts[i].LastReinforced != facts[j].LastReinforced {
+				return facts[i].LastReinforced > facts[j].LastReinforced
+			}
+			return facts[i].ID < facts[j].ID
+		})
+
+		winners := []dedupFactRow{facts[0]}
+		for _, candidate := range facts[1:] {
+			bestWinnerIdx := -1
+			bestSimilarity := 0.0
+			for idx, w := range winners {
+				sim := factObjectSimilarity(w.Object, candidate.Object)
+				report.PairsCompared++
+				if sim >= opts.Threshold && sim > bestSimilarity {
+					bestSimilarity = sim
+					bestWinnerIdx = idx
+				}
+			}
+			if bestWinnerIdx == -1 {
+				winners = append(winners, candidate)
+				continue
+			}
+
+			winner := winners[bestWinnerIdx]
+			merges = append(merges, DedupFactMerge{
+				Subject:          winner.Subject,
+				Predicate:        winner.Predicate,
+				WinnerID:         winner.ID,
+				WinnerObject:     winner.Object,
+				WinnerConfidence: winner.Confidence,
+				LoserID:          candidate.ID,
+				LoserObject:      candidate.Object,
+				LoserConfidence:  candidate.Confidence,
+				Similarity:       bestSimilarity,
+			})
+		}
+	}
+
+	report.Merges = len(merges)
+	if len(merges) > opts.MaxPreview {
+		report.Preview = append(report.Preview, merges[:opts.MaxPreview]...)
+	} else {
+		report.Preview = append(report.Preview, merges...)
+	}
+
+	if opts.DryRun {
+		return report, nil
+	}
+
+	for _, m := range merges {
+		reason := fmt.Sprintf("dedup-facts similarity=%.3f", m.Similarity)
+		if err := s.SupersedeFact(ctx, m.LoserID, m.WinnerID, reason); err != nil {
+			return nil, fmt.Errorf("superseding loser fact %d with winner %d: %w", m.LoserID, m.WinnerID, err)
+		}
+	}
+
+	return report, nil
+}
+
+func normalizeFactKey(subject, predicate string) string {
+	return normalizeFactObject(subject) + "\x00" + normalizeFactObject(predicate)
+}
+
+func normalizeFactObject(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	if v == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(v))
+	lastSpace := false
+	for _, r := range v {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			b.WriteRune(r)
+			lastSpace = false
+		case unicode.IsSpace(r), r == '-', r == '_', r == '/':
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func factObjectSimilarity(a, b string) float64 {
+	aNorm := normalizeFactObject(a)
+	bNorm := normalizeFactObject(b)
+	if aNorm == "" || bNorm == "" {
+		return 0
+	}
+	if aNorm == bNorm {
+		return 1
+	}
+	j := tokenJaccard(aNorm, bNorm)
+	l := normalizedLevenshtein(aNorm, bNorm)
+	if j > l {
+		return j
+	}
+	return l
+}
+
+func tokenJaccard(a, b string) float64 {
+	aSet := map[string]struct{}{}
+	for _, t := range strings.Fields(a) {
+		aSet[t] = struct{}{}
+	}
+	bSet := map[string]struct{}{}
+	for _, t := range strings.Fields(b) {
+		bSet[t] = struct{}{}
+	}
+	if len(aSet) == 0 && len(bSet) == 0 {
+		return 1
+	}
+	inter := 0
+	for t := range aSet {
+		if _, ok := bSet[t]; ok {
+			inter++
+		}
+	}
+	union := len(aSet) + len(bSet) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+func normalizedLevenshtein(a, b string) float64 {
+	ar := []rune(a)
+	br := []rune(b)
+	if len(ar) == 0 && len(br) == 0 {
+		return 1
+	}
+	maxLen := len(ar)
+	if len(br) > maxLen {
+		maxLen = len(br)
+	}
+	if maxLen == 0 {
+		return 0
+	}
+	d := make([][]int, len(ar)+1)
+	for i := range d {
+		d[i] = make([]int, len(br)+1)
+	}
+	for i := 0; i <= len(ar); i++ {
+		d[i][0] = i
+	}
+	for j := 0; j <= len(br); j++ {
+		d[0][j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		for j := 1; j <= len(br); j++ {
+			cost := 0
+			if ar[i-1] != br[j-1] {
+				cost = 1
+			}
+			del := d[i-1][j] + 1
+			ins := d[i][j-1] + 1
+			sub := d[i-1][j-1] + cost
+			d[i][j] = minInt(del, minInt(ins, sub))
+		}
+	}
+	dist := d[len(ar)][len(br)]
+	return 1 - float64(dist)/float64(maxLen)
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/store/facts_dedup_test.go
+++ b/internal/store/facts_dedup_test.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestDedupFacts_DryRunPreview(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "cortex.db")
+
+	si, err := NewStore(StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer si.Close()
+	s := si.(*SQLiteStore)
+	ctx := context.Background()
+
+	memID, err := s.AddMemory(ctx, &Memory{Content: "fact dedup dry run", SourceFile: "dry.md"})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+
+	if _, err := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "ETH", Predicate: "is", Object: "Ethereum is layer 1", Confidence: 0.95, FactType: "state"}); err != nil {
+		t.Fatalf("AddFact winner: %v", err)
+	}
+	if _, err := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "ETH", Predicate: "is", Object: "Ethereum is layer-1", Confidence: 0.80, FactType: "state"}); err != nil {
+		t.Fatalf("AddFact loser: %v", err)
+	}
+	if _, err := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "ETH", Predicate: "is", Object: "Ethereum has proof of stake", Confidence: 0.70, FactType: "state"}); err != nil {
+		t.Fatalf("AddFact unrelated: %v", err)
+	}
+
+	report, err := s.DedupFacts(ctx, DedupFactOptions{DryRun: true, Threshold: 0.90, MaxPreview: 10})
+	if err != nil {
+		t.Fatalf("DedupFacts dry run: %v", err)
+	}
+	if report.Merges != 1 {
+		t.Fatalf("expected 1 merge candidate, got %d", report.Merges)
+	}
+	if len(report.Preview) != 1 {
+		t.Fatalf("expected 1 preview merge, got %d", len(report.Preview))
+	}
+	m := report.Preview[0]
+	if m.Subject != "ETH" || m.Predicate != "is" {
+		t.Fatalf("unexpected preview subject/predicate: %+v", m)
+	}
+	if m.WinnerObject != "Ethereum is layer 1" {
+		t.Fatalf("unexpected winner object: %q", m.WinnerObject)
+	}
+	if m.LoserObject != "Ethereum is layer-1" {
+		t.Fatalf("unexpected loser object: %q", m.LoserObject)
+	}
+	if m.Similarity < 0.90 {
+		t.Fatalf("expected similarity >= 0.90, got %.3f", m.Similarity)
+	}
+}
+
+func TestDedupFacts_ExecutesSupersede(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "cortex.db")
+
+	si, err := NewStore(StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer si.Close()
+	s := si.(*SQLiteStore)
+	ctx := context.Background()
+
+	memID, err := s.AddMemory(ctx, &Memory{Content: "fact dedup apply", SourceFile: "apply.md"})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+
+	winnerID, err := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "BTC", Predicate: "is", Object: "Bitcoin is digital gold", Confidence: 0.92, FactType: "state"})
+	if err != nil {
+		t.Fatalf("AddFact winner: %v", err)
+	}
+	loserID, err := s.AddFact(ctx, &Fact{MemoryID: memID, Subject: "BTC", Predicate: "is", Object: "Bitcoin is digital-gold", Confidence: 0.81, FactType: "state"})
+	if err != nil {
+		t.Fatalf("AddFact loser: %v", err)
+	}
+
+	report, err := s.DedupFacts(ctx, DedupFactOptions{DryRun: false, Threshold: 0.90, MaxPreview: 10})
+	if err != nil {
+		t.Fatalf("DedupFacts execute: %v", err)
+	}
+	if report.Merges != 1 {
+		t.Fatalf("expected 1 merge executed, got %d", report.Merges)
+	}
+
+	winner, err := s.GetFact(ctx, winnerID)
+	if err != nil {
+		t.Fatalf("GetFact winner: %v", err)
+	}
+	if winner.SupersededBy != nil {
+		t.Fatalf("winner should remain active, superseded_by=%v", winner.SupersededBy)
+	}
+
+	loser, err := s.GetFact(ctx, loserID)
+	if err != nil {
+		t.Fatalf("GetFact loser: %v", err)
+	}
+	if loser.SupersededBy == nil || *loser.SupersededBy != winnerID {
+		t.Fatalf("expected loser superseded by %d, got %+v", winnerID, loser.SupersededBy)
+	}
+	if loser.Confidence != 0.0 {
+		t.Fatalf("expected loser confidence tombstoned to 0.0, got %f", loser.Confidence)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -148,6 +148,35 @@ type Conflict struct {
 	CrossAgent   bool    `json:"cross_agent,omitempty"` // true if facts from different agents
 }
 
+// DedupFactOptions controls near-duplicate fact deduplication.
+type DedupFactOptions struct {
+	Agent      string  `json:"agent,omitempty"`
+	Threshold  float64 `json:"threshold"` // 0..1 similarity threshold
+	DryRun     bool    `json:"dry_run"`
+	MaxPreview int     `json:"max_preview"`
+}
+
+// DedupFactMerge describes one loser->winner supersession candidate.
+type DedupFactMerge struct {
+	Subject          string  `json:"subject"`
+	Predicate        string  `json:"predicate"`
+	WinnerID         int64   `json:"winner_id"`
+	WinnerObject     string  `json:"winner_object"`
+	WinnerConfidence float64 `json:"winner_confidence"`
+	LoserID          int64   `json:"loser_id"`
+	LoserObject      string  `json:"loser_object"`
+	LoserConfidence  float64 `json:"loser_confidence"`
+	Similarity       float64 `json:"similarity"`
+}
+
+// DedupFactReport summarizes dedup analysis/execution.
+type DedupFactReport struct {
+	GroupsScanned int              `json:"groups_scanned"`
+	PairsCompared int              `json:"pairs_compared"`
+	Merges        int              `json:"merges"`
+	Preview       []DedupFactMerge `json:"preview,omitempty"`
+}
+
 // ProjectInfo holds metadata about a project tag.
 type ProjectInfo struct {
 	Name        string `json:"name"`
@@ -185,6 +214,7 @@ type Store interface {
 	UpdateFactType(ctx context.Context, id int64, factType string) error
 	ReinforceFact(ctx context.Context, id int64) error
 	SupersedeFact(ctx context.Context, oldFactID, newFactID int64, reason string) error
+	DedupFacts(ctx context.Context, opts DedupFactOptions) (*DedupFactReport, error)
 	ReinforceFactsByMemoryIDs(ctx context.Context, memoryIDs []int64) (int, error)
 	GetFactsByMemoryIDs(ctx context.Context, memoryIDs []int64) ([]*Fact, error)
 	GetFactsByMemoryIDsIncludingSuperseded(ctx context.Context, memoryIDs []int64) ([]*Fact, error)


### PR DESCRIPTION
Implements #245.

## What changed
- Added near-duplicate fact dedup support in the store layer:
  - `SQLiteStore.DedupFacts(ctx, DedupFactOptions)`
  - New reporting types: `DedupFactReport`, `DedupFactMerge`
- Added cleanup CLI flags:
  - `--dedup-facts`
  - `--dedup-threshold <float>` (default 0.90)
- Dedup behavior:
  - Scopes to active facts (`superseded_by IS NULL`), optional agent filter
  - Groups by normalized `(subject, predicate)`
  - Compares object similarity; merges to highest-confidence winner
  - Uses `SupersedeFact` tombstones (no hard delete)
- Dry-run output now prints actual candidate pairs with:
  - subject, predicate
  - winner object + confidence
  - loser object + confidence
  - similarity score

## Tests
- Added `internal/store/facts_dedup_test.go` covering:
  - dry-run preview pair reporting
  - live supersede behavior
- Full suite passes.

## Validation
- `go test ./...` ✅
