### PR TITLE
feat: add search --intent pre-filter buckets

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -664,6 +664,7 @@ func runSearch(args []string) error {
 	boostAgentFlag := ""
 	boostChannelFlag := ""
 	sourceFlag := ""
+	intentFlag := "all"
 	sourceBoostFlags := []string{}
 	showMetadata := false
 	explain := false
@@ -710,6 +711,11 @@ func runSearch(args []string) error {
 			sourceFlag = args[i]
 		case strings.HasPrefix(args[i], "--source="):
 			sourceFlag = strings.TrimPrefix(args[i], "--source=")
+		case args[i] == "--intent" && i+1 < len(args):
+			i++
+			intentFlag = args[i]
+		case strings.HasPrefix(args[i], "--intent="):
+			intentFlag = strings.TrimPrefix(args[i], "--intent=")
 		case args[i] == "--source-boost" && i+1 < len(args):
 			i++
 			sourceBoostFlags = append(sourceBoostFlags, args[i])
@@ -791,7 +797,7 @@ func runSearch(args []string) error {
 
 	query := strings.Join(queryParts, " ")
 	if query == "" {
-		return fmt.Errorf("usage: cortex search <query> [--mode keyword|semantic|hybrid|rrf] [--limit N] [--embed <provider/model>] [--expand] [--llm <provider/model>] [--class rule,decision] [--no-class-boost] [--include-superseded] [--explain] [--json] [--agent <id>] [--channel <name>] [--source <provider>] [--source-boost <prefix[:weight]>] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--show-metadata]")
+		return fmt.Errorf("usage: cortex search <query> [--mode keyword|semantic|hybrid|rrf] [--limit N] [--embed <provider/model>] [--expand] [--llm <provider/model>] [--class rule,decision] [--no-class-boost] [--include-superseded] [--explain] [--json] [--agent <id>] [--channel <name>] [--source <provider>] [--intent memory|import|connector|all] [--source-boost <prefix[:weight]>] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--show-metadata]")
 	}
 	if limit < 1 || limit > 1000 {
 		return fmt.Errorf("--limit must be between 1 and 1000")
@@ -870,6 +876,7 @@ func runSearch(args []string) error {
 		After:             afterFlag,
 		Before:            beforeFlag,
 		Source:            sourceFlag,
+		Intent:            intentFlag,
 		SourceBoosts:      parsedSourceBoosts,
 		IncludeSuperseded: includeSuperseded,
 		Explain:           explain,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -133,6 +133,10 @@ func registerSearchTool(s *server.MCPServer, engine *search.Engine, defaultAgent
 		mcp.WithString("source",
 			mcp.Description("Filter results by source prefix (e.g., 'github', 'gmail'). Matches connector-imported records by provider name."),
 		),
+		mcp.WithString("intent",
+			mcp.Description("Intent bucket filter before scoring: memory, import, connector, all (default all)."),
+			mcp.Enum("memory", "import", "connector", "all"),
+		),
 		mcp.WithArray("source_boosts",
 			mcp.Description("Optional source-specific score boosts. Array of {prefix, weight}. Weight defaults to 1.15 and is clamped to 1.0-2.0."),
 			mcp.Items(map[string]any{
@@ -190,6 +194,9 @@ func registerSearchTool(s *server.MCPServer, engine *search.Engine, defaultAgent
 
 		if source, err := req.RequireString("source"); err == nil && source != "" {
 			opts.Source = source
+		}
+		if intent, err := req.RequireString("intent"); err == nil && intent != "" {
+			opts.Intent = intent
 		}
 		if boosts, err := parseMCPSourceBoosts(req); err == nil {
 			opts.SourceBoosts = boosts

--- a/internal/search/intent_test.go
+++ b/internal/search/intent_test.go
@@ -1,0 +1,58 @@
+package search
+
+import "testing"
+
+func TestNormalizeIntent(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", IntentAll, false},
+		{"all", IntentAll, false},
+		{"memory", IntentMemory, false},
+		{"import", IntentImport, false},
+		{"connector", IntentConnector, false},
+		{"weird", "", true},
+	}
+
+	for _, tc := range cases {
+		got, err := normalizeIntent(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("normalizeIntent(%q): expected error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("normalizeIntent(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("normalizeIntent(%q)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFilterByIntent(t *testing.T) {
+	results := []Result{
+		{SourceFile: "memory/2026-02-27.md", Content: "daily note"},
+		{SourceFile: "MEMORY.md", Content: "long-term memory"},
+		{SourceFile: "github:issues/123", Content: "connector item"},
+		{SourceFile: "knowledge/product/cortex.md", Content: "imported doc"},
+	}
+
+	mem := filterByIntent(results, IntentMemory)
+	if len(mem) != 2 {
+		t.Fatalf("memory intent expected 2, got %d", len(mem))
+	}
+
+	conn := filterByIntent(results, IntentConnector)
+	if len(conn) != 1 || conn[0].SourceFile != "github:issues/123" {
+		t.Fatalf("connector intent mismatch: %+v", conn)
+	}
+
+	imp := filterByIntent(results, IntentImport)
+	if len(imp) != 1 || imp[0].SourceFile != "knowledge/product/cortex.md" {
+		t.Fatalf("import intent mismatch: %+v", imp)
+	}
+}


### PR DESCRIPTION
Implements #251.

## What shipped
- Added new search intent bucket option in core search engine:
  - `intent=memory|import|connector|all`
  - validation via `normalizeIntent(...)`
- Added intent pre-filtering before metadata/class/ranking stages in `Engine.Search`.
- Added source classification helper for memory sources.
- CLI support:
  - `cortex search "query" --intent <memory|import|connector|all>`
  - defaults to `all`.
- MCP support:
  - Added `intent` enum parameter to `cortex_search` and wires to search options.
- Added tests:
  - `internal/search/intent_test.go` for intent normalization and filtering behavior.

## Notes
- This is a convenience wrapper that filters source buckets before scoring.
- Existing `--source` and `--source-boost` behavior remains intact.

## Validation
- `go test ./...` ✅
