### PR TITLE
feat: add fact lifecycle state model (active/core/retired)

### DIFF
--- a/internal/store/alerts.go
+++ b/internal/store/alerts.go
@@ -230,7 +230,7 @@ func (s *SQLiteStore) CheckConflictsForFact(ctx context.Context, fact *Fact) ([]
 
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, memory_id, subject, predicate, object, fact_type,
-		        confidence, decay_rate, last_reinforced, source_quote, created_at, superseded_by, agent_id
+		        confidence, decay_rate, last_reinforced, source_quote, created_at, state, superseded_by, agent_id
 		 FROM facts
 		 WHERE LOWER(subject) = LOWER(?)
 		   AND LOWER(predicate) = LOWER(?)
@@ -252,7 +252,7 @@ func (s *SQLiteStore) CheckConflictsForFact(ctx context.Context, fact *Fact) ([]
 		if err := rows.Scan(
 			&existing.ID, &existing.MemoryID, &existing.Subject, &existing.Predicate,
 			&existing.Object, &existing.FactType, &existing.Confidence, &existing.DecayRate,
-			&existing.LastReinforced, &existing.SourceQuote, &existing.CreatedAt, &supersededBy,
+			&existing.LastReinforced, &existing.SourceQuote, &existing.CreatedAt, &existing.State, &supersededBy,
 			&existing.AgentID,
 		); err != nil {
 			return nil, fmt.Errorf("scanning existing fact: %w", err)
@@ -325,7 +325,7 @@ func (s *SQLiteStore) CheckDecayAlerts(ctx context.Context, thresholds DecayThre
 	// Get all active facts with their decay parameters
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id, memory_id, subject, predicate, object, fact_type,
-		        confidence, decay_rate, last_reinforced, source_quote, created_at, agent_id
+		        confidence, decay_rate, last_reinforced, source_quote, created_at, state, agent_id
 		 FROM facts
 		 WHERE superseded_by IS NULL
 		   AND confidence > 0`)
@@ -351,7 +351,7 @@ func (s *SQLiteStore) CheckDecayAlerts(ctx context.Context, thresholds DecayThre
 		var f Fact
 		if err := rows.Scan(&f.ID, &f.MemoryID, &f.Subject, &f.Predicate, &f.Object,
 			&f.FactType, &f.Confidence, &f.DecayRate, &f.LastReinforced,
-			&f.SourceQuote, &f.CreatedAt, &f.AgentID); err != nil {
+			&f.SourceQuote, &f.CreatedAt, &f.State, &f.AgentID); err != nil {
 			return nil, fmt.Errorf("scanning fact: %w", err)
 		}
 		result.FactsScanned++

--- a/internal/store/cluster_store.go
+++ b/internal/store/cluster_store.go
@@ -335,7 +335,7 @@ func (s *SQLiteStore) ListClusterFacts(ctx context.Context, clusterID int64, lim
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT f.id, f.memory_id, f.subject, f.predicate, f.object, f.fact_type,
 		        f.confidence, f.decay_rate, f.last_reinforced, f.source_quote,
-		        f.created_at, f.superseded_by, COALESCE(f.agent_id, '')
+		        f.created_at, f.state, f.superseded_by, COALESCE(f.agent_id, '')
 		 FROM facts f
 		 JOIN fact_clusters fc ON fc.fact_id = f.id
 		 WHERE fc.cluster_id = ?
@@ -365,6 +365,7 @@ func (s *SQLiteStore) ListClusterFacts(ctx context.Context, clusterID int64, lim
 			&f.LastReinforced,
 			&f.SourceQuote,
 			&f.CreatedAt,
+			&f.State,
 			&supersededBy,
 			&f.AgentID,
 		); err != nil {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -419,7 +419,7 @@ func (s *SQLiteStore) GetAttributeConflictsLimitWithSuperseded(ctx context.Conte
 	var conflicts []Conflict
 	for _, p := range pairs {
 		factQuery := fmt.Sprintf(`SELECT f.id, f.memory_id, f.subject, f.predicate, f.object, f.fact_type,
-			        f.confidence, f.decay_rate, f.last_reinforced, f.source_quote, f.created_at, f.superseded_by, f.agent_id
+			        f.confidence, f.decay_rate, f.last_reinforced, f.source_quote, f.created_at, f.state, f.superseded_by, f.agent_id
 			 FROM facts f
 			 JOIN memories m ON f.memory_id = m.id AND m.deleted_at IS NULL
 			 WHERE LOWER(f.subject) = ? AND LOWER(f.predicate) = ?
@@ -439,7 +439,7 @@ func (s *SQLiteStore) GetAttributeConflictsLimitWithSuperseded(ctx context.Conte
 			var supersededBy sql.NullInt64
 			if err := factRows.Scan(
 				&f.ID, &f.MemoryID, &f.Subject, &f.Predicate, &f.Object, &f.FactType,
-				&f.Confidence, &f.DecayRate, &f.LastReinforced, &f.SourceQuote, &f.CreatedAt, &supersededBy, &f.AgentID,
+				&f.Confidence, &f.DecayRate, &f.LastReinforced, &f.SourceQuote, &f.CreatedAt, &f.State, &supersededBy, &f.AgentID,
 			); err != nil {
 				factRows.Close()
 				return nil, fmt.Errorf("scanning fact: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -63,6 +63,13 @@ type Metadata struct {
 	TimestampEnd   string `json:"timestamp_end,omitempty"`
 }
 
+const (
+	FactStateActive     = "active"
+	FactStateCore       = "core"
+	FactStateRetired    = "retired"
+	FactStateSuperseded = "superseded"
+)
+
 // Fact represents an extracted fact from a memory.
 type Fact struct {
 	ID             int64
@@ -76,6 +83,7 @@ type Fact struct {
 	LastReinforced time.Time
 	SourceQuote    string
 	CreatedAt      time.Time
+	State          string // active|core|retired|superseded
 	SupersededBy   *int64 // Fact ID that superseded this fact (nil = active)
 	AgentID        string // Which agent created this fact (empty = global, visible to all)
 }
@@ -97,6 +105,7 @@ type ListOpts struct {
 	Offset            int
 	SortBy            string   // "date", "confidence", "recalls"
 	FactType          string   // filter by fact type
+	State             string   // filter by fact lifecycle state (active|core|retired|superseded)
 	SourceFile        string   // filter by source file
 	Project           string   // filter by project tag
 	MemoryClasses     []string // filter by memory class
@@ -212,6 +221,7 @@ type Store interface {
 	ListFactsByMemoryIDs(ctx context.Context, memoryIDs []int64, factType string, limit int) ([]*Fact, error)
 	UpdateFactConfidence(ctx context.Context, id int64, confidence float64) error
 	UpdateFactType(ctx context.Context, id int64, factType string) error
+	UpdateFactState(ctx context.Context, id int64, state string) error
 	ReinforceFact(ctx context.Context, id int64) error
 	SupersedeFact(ctx context.Context, oldFactID, newFactID int64, reason string) error
 	DedupFacts(ctx context.Context, opts DedupFactOptions) (*DedupFactReport, error)


### PR DESCRIPTION
Implements #255.
Parent epic: #253

## What shipped
- Added fact lifecycle state model:
  - `active` (default)
  - `core`
  - `retired`
  - `superseded` (system-managed)
- Added `state` column to facts with migration + backfill behavior:
  - legacy rows default/backfill to `active`
  - rows with `superseded_by` backfill to `superseded`
- Added state index: `idx_facts_state`.
- Updated store read/write paths to include state in fact scans/queries.
- Added state filter support to `ListFacts` (`ListOpts.State`).
- Added `UpdateFactState(...)` store helper with guardrails:
  - allows `active|core|retired`
  - rejects direct `superseded` assignment.
- Updated `SupersedeFact(...)` to set `state='superseded'` atomically.

## Tests
- Added/updated tests for:
  - state column existence
  - state transitions
  - supersede interaction forcing `superseded`
  - migration backfill for legacy DBs

## Validation
- `go test ./...` ✅ (16/16 packages green)
