### PR TITLE
feat: add lifecycle policy runner command

### DIFF
--- a/cmd/cortex/lifecycle_test.go
+++ b/cmd/cortex/lifecycle_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+func TestRunLifecycle_DryRunJSON(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "cortex.db")
+	si, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	ctx := context.Background()
+	memID, _ := si.AddMemory(ctx, &store.Memory{Content: "lifecycle test", SourceFile: "memory/2026-02-27.md"})
+	factID, _ := si.AddFact(ctx, &store.Fact{MemoryID: memID, Subject: "test", Predicate: "status", Object: "active", FactType: "state", Confidence: 0.9})
+	if err := si.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	oldDBPath := globalDBPath
+	globalDBPath = dbPath
+	t.Cleanup(func() { globalDBPath = oldDBPath })
+	t.Setenv("HOME", t.TempDir())
+
+	var runErr error
+	out := captureStdout(func() {
+		runErr = runLifecycle([]string{"run", "--dry-run", "--json"})
+	})
+	if runErr != nil {
+		t.Fatalf("runLifecycle dry-run: %v\nout=%s", runErr, out)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("decode lifecycle json: %v\nout=%s", err, out)
+	}
+	if v, ok := payload["dry_run"].(bool); !ok || !v {
+		t.Fatalf("expected dry_run=true payload, got %v", payload["dry_run"])
+	}
+
+	s2, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("re-open store: %v", err)
+	}
+	defer s2.Close()
+	f, err := s2.GetFact(context.Background(), factID)
+	if err != nil {
+		t.Fatalf("GetFact: %v", err)
+	}
+	if f.State != store.FactStateActive {
+		t.Fatalf("dry-run should not mutate fact state, got %s", f.State)
+	}
+}

--- a/internal/lifecycle/runner.go
+++ b/internal/lifecycle/runner.go
@@ -1,0 +1,310 @@
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	cfgresolver "github.com/hurttlocker/cortex/internal/config"
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+type Action struct {
+	Policy    string `json:"policy"`
+	Action    string `json:"action"`
+	FactID    int64  `json:"fact_id,omitempty"`
+	WinnerID  int64  `json:"winner_id,omitempty"`
+	LoserID   int64  `json:"loser_id,omitempty"`
+	FromState string `json:"from_state,omitempty"`
+	ToState   string `json:"to_state,omitempty"`
+	Reason    string `json:"reason"`
+	Applied   bool   `json:"applied"`
+}
+
+type Report struct {
+	DryRun     bool     `json:"dry_run"`
+	Scanned    int      `json:"scanned"`
+	Applied    int      `json:"applied"`
+	Actions    []Action `json:"actions"`
+	PolicyRuns struct {
+		ReinforcePromote  int `json:"reinforce_promote"`
+		DecayRetire       int `json:"decay_retire"`
+		ConflictSupersede int `json:"conflict_supersede"`
+	} `json:"policy_runs"`
+}
+
+type Runner struct {
+	st       store.Store
+	sqlite   *store.SQLiteStore
+	policies cfgresolver.PolicyConfig
+	now      time.Time
+}
+
+func NewRunner(st store.Store, policies cfgresolver.PolicyConfig) (*Runner, error) {
+	sqlite, ok := st.(*store.SQLiteStore)
+	if !ok {
+		return nil, fmt.Errorf("lifecycle runner requires sqlite store")
+	}
+	return &Runner{st: st, sqlite: sqlite, policies: policies, now: time.Now().UTC()}, nil
+}
+
+func (r *Runner) Run(ctx context.Context, dryRun bool) (*Report, error) {
+	report := &Report{DryRun: dryRun, Actions: make([]Action, 0, 64)}
+
+	if err := ValidatePolicyTargets(r.policies); err != nil {
+		return nil, err
+	}
+
+	if r.policies.ReinforcePromote.Enabled {
+		actions, scanned, err := r.applyReinforcePromote(ctx, dryRun)
+		if err != nil {
+			return nil, err
+		}
+		report.Scanned += scanned
+		report.PolicyRuns.ReinforcePromote = len(actions)
+		report.Actions = append(report.Actions, actions...)
+	}
+
+	if r.policies.DecayRetire.Enabled {
+		actions, scanned, err := r.applyDecayRetire(ctx, dryRun)
+		if err != nil {
+			return nil, err
+		}
+		report.Scanned += scanned
+		report.PolicyRuns.DecayRetire = len(actions)
+		report.Actions = append(report.Actions, actions...)
+	}
+
+	if r.policies.ConflictSupersede.Enabled {
+		actions, scanned, err := r.applyConflictSupersede(ctx, dryRun)
+		if err != nil {
+			return nil, err
+		}
+		report.Scanned += scanned
+		report.PolicyRuns.ConflictSupersede = len(actions)
+		report.Actions = append(report.Actions, actions...)
+	}
+
+	for _, a := range report.Actions {
+		if a.Applied {
+			report.Applied++
+		}
+	}
+	return report, nil
+}
+
+func (r *Runner) applyReinforcePromote(ctx context.Context, dryRun bool) ([]Action, int, error) {
+	cfg := r.policies.ReinforcePromote
+	actions := []Action{}
+	rows, err := r.sqlite.GetDB().QueryContext(ctx, `
+		SELECT f.id, f.state,
+		       COALESCE((SELECT COUNT(*) FROM fact_accesses_v1 a
+		                 WHERE a.fact_id = f.id AND a.access_type IN ('reinforce','reference','import')), 0) AS reinforcement_count,
+		       COALESCE((SELECT COUNT(DISTINCT f2.memory_id) FROM facts f2
+		                 WHERE f2.superseded_by IS NULL
+		                   AND LOWER(f2.subject) = LOWER(f.subject)
+		                   AND LOWER(f2.predicate) = LOWER(f.predicate)
+		                   AND LOWER(f2.object) = LOWER(f.object)), 0) AS source_count
+		FROM facts f
+		WHERE f.superseded_by IS NULL AND LOWER(f.state) = 'active'`)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query reinforce-promote candidates: %w", err)
+	}
+	scanned := 0
+	for rows.Next() {
+		var factID int64
+		var state string
+		var reinforcementCount, sourceCount int
+		if err := rows.Scan(&factID, &state, &reinforcementCount, &sourceCount); err != nil {
+			return nil, scanned, fmt.Errorf("scan reinforce-promote row: %w", err)
+		}
+		scanned++
+		if reinforcementCount < cfg.MinReinforcements || sourceCount < cfg.MinSources {
+			continue
+		}
+		act := Action{
+			Policy:    "reinforce-promote",
+			Action:    "state_transition",
+			FactID:    factID,
+			FromState: state,
+			ToState:   cfg.TargetState,
+			Reason:    fmt.Sprintf("reinforcements=%d >= %d and sources=%d >= %d", reinforcementCount, cfg.MinReinforcements, sourceCount, cfg.MinSources),
+			Applied:   false,
+		}
+		actions = append(actions, act)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, scanned, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, scanned, fmt.Errorf("close reinforce-promote rows: %w", err)
+	}
+	if !dryRun {
+		for i := range actions {
+			if err := r.st.UpdateFactState(ctx, actions[i].FactID, cfg.TargetState); err != nil {
+				actions[i].Reason += "; apply_error: " + err.Error()
+			} else {
+				actions[i].Applied = true
+			}
+		}
+	}
+	return actions, scanned, nil
+}
+
+func (r *Runner) applyDecayRetire(ctx context.Context, dryRun bool) ([]Action, int, error) {
+	cfg := r.policies.DecayRetire
+	actions := []Action{}
+	rows, err := r.sqlite.GetDB().QueryContext(ctx, `
+		SELECT f.id, f.state, f.confidence,
+		       COALESCE(MAX(a.created_at), f.last_reinforced) AS last_access
+		FROM facts f
+		LEFT JOIN fact_accesses_v1 a ON a.fact_id = f.id
+		WHERE f.superseded_by IS NULL
+		  AND LOWER(f.state) IN ('active','core')
+		GROUP BY f.id, f.state, f.confidence, f.last_reinforced`)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query decay-retire candidates: %w", err)
+	}
+	scanned := 0
+	for rows.Next() {
+		var factID int64
+		var state string
+		var confidence float64
+		var lastAccessRaw string
+		if err := rows.Scan(&factID, &state, &confidence, &lastAccessRaw); err != nil {
+			return nil, scanned, fmt.Errorf("scan decay-retire row: %w", err)
+		}
+		lastAccess, err := parseSQLiteTime(lastAccessRaw)
+		if err != nil {
+			return nil, scanned, fmt.Errorf("parse decay-retire last_access %q: %w", lastAccessRaw, err)
+		}
+		scanned++
+		days := int(r.now.Sub(lastAccess).Hours() / 24)
+		if days < cfg.InactiveDays || confidence >= cfg.ConfidenceBelow {
+			continue
+		}
+		act := Action{
+			Policy:    "decay-retire",
+			Action:    "state_transition",
+			FactID:    factID,
+			FromState: state,
+			ToState:   cfg.TargetState,
+			Reason:    fmt.Sprintf("inactive_days=%d >= %d and confidence=%.3f < %.3f", days, cfg.InactiveDays, confidence, cfg.ConfidenceBelow),
+			Applied:   false,
+		}
+		actions = append(actions, act)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, scanned, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, scanned, fmt.Errorf("close decay-retire rows: %w", err)
+	}
+	if !dryRun {
+		for i := range actions {
+			if err := r.st.UpdateFactState(ctx, actions[i].FactID, cfg.TargetState); err != nil {
+				actions[i].Reason += "; apply_error: " + err.Error()
+			} else {
+				actions[i].Applied = true
+			}
+		}
+	}
+	return actions, scanned, nil
+}
+
+func (r *Runner) applyConflictSupersede(ctx context.Context, dryRun bool) ([]Action, int, error) {
+	cfg := r.policies.ConflictSupersede
+	conflicts, err := r.st.GetAttributeConflictsLimitWithSuperseded(ctx, 1000, false)
+	if err != nil {
+		return nil, 0, fmt.Errorf("get attribute conflicts: %w", err)
+	}
+
+	actions := make([]Action, 0)
+	supersededLosers := map[int64]struct{}{}
+	for _, c := range conflicts {
+		f1 := c.Fact1
+		f2 := c.Fact2
+		confDelta := f1.Confidence - f2.Confidence
+		if confDelta < 0 {
+			confDelta = -confDelta
+		}
+		if confDelta < cfg.MinConfidenceDelta {
+			continue
+		}
+
+		winner := f1
+		loser := f2
+		if f2.Confidence > f1.Confidence {
+			winner = f2
+			loser = f1
+		}
+		if cfg.RequireStrictlyNewer && !winner.CreatedAt.After(loser.CreatedAt) {
+			continue
+		}
+		if _, exists := supersededLosers[loser.ID]; exists {
+			continue
+		}
+
+		act := Action{
+			Policy:   "conflict-supersede",
+			Action:   "supersede",
+			WinnerID: winner.ID,
+			LoserID:  loser.ID,
+			Reason:   fmt.Sprintf("winner confidence %.3f > %.3f by %.3f%s", winner.Confidence, loser.Confidence, confDelta, newerSuffix(cfg.RequireStrictlyNewer)),
+			Applied:  false,
+		}
+		if !dryRun {
+			if err := r.st.SupersedeFact(ctx, loser.ID, winner.ID, "lifecycle conflict-supersede"); err != nil {
+				act.Reason += "; apply_error: " + err.Error()
+			} else {
+				act.Applied = true
+				supersededLosers[loser.ID] = struct{}{}
+			}
+		}
+		actions = append(actions, act)
+	}
+	return actions, len(conflicts), nil
+}
+
+func newerSuffix(required bool) string {
+	if required {
+		return " and newer timestamp"
+	}
+	return ""
+}
+
+func ValidatePolicyTargets(p cfgresolver.PolicyConfig) error {
+	for _, target := range []string{p.ReinforcePromote.TargetState, p.DecayRetire.TargetState} {
+		s := strings.ToLower(strings.TrimSpace(target))
+		if s == "" {
+			continue
+		}
+		if s != store.FactStateActive && s != store.FactStateCore && s != store.FactStateRetired {
+			return fmt.Errorf("invalid policy target_state %q (valid: active, core, retired)", target)
+		}
+	}
+	return nil
+}
+
+func parseSQLiteTime(raw string) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, fmt.Errorf("empty timestamp")
+	}
+	layouts := []string{
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		time.RFC3339,
+		time.RFC3339Nano,
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unsupported timestamp format")
+}

--- a/internal/lifecycle/runner_test.go
+++ b/internal/lifecycle/runner_test.go
@@ -1,0 +1,138 @@
+package lifecycle
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cfgresolver "github.com/hurttlocker/cortex/internal/config"
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+func seedLifecycleData(t *testing.T, s *store.SQLiteStore) (promoteID, decayID, conflictWinnerID, conflictLoserID int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	m1, _ := s.AddMemory(ctx, &store.Memory{Content: "promote primary", SourceFile: "memory/2026-01-01.md"})
+	m2, _ := s.AddMemory(ctx, &store.Memory{Content: "promote corroboration", SourceFile: "knowledge/corroboration.md"})
+	promoteID, _ = s.AddFact(ctx, &store.Fact{MemoryID: m1, Subject: "cortex", Predicate: "mode", Object: "agent cognition", FactType: "state", Confidence: 0.82})
+	_, _ = s.AddFact(ctx, &store.Fact{MemoryID: m2, Subject: "cortex", Predicate: "mode", Object: "agent cognition", FactType: "state", Confidence: 0.70})
+	for i := 0; i < 3; i++ {
+		_ = s.RecordFactAccess(ctx, promoteID, "xmate", store.AccessTypeReinforce)
+	}
+
+	m3, _ := s.AddMemory(ctx, &store.Memory{Content: "old fading", SourceFile: "memory/2025-10-01.md"})
+	decayID, _ = s.AddFact(ctx, &store.Fact{MemoryID: m3, Subject: "legacy", Predicate: "status", Object: "old", FactType: "state", Confidence: 0.20})
+	old := time.Now().UTC().AddDate(0, 0, -120)
+	if _, err := s.ExecContext(ctx, `UPDATE facts SET last_reinforced=? WHERE id=?`, old, decayID); err != nil {
+		t.Fatalf("update decay last_reinforced: %v", err)
+	}
+
+	m4, _ := s.AddMemory(ctx, &store.Memory{Content: "conflict old", SourceFile: "github:issues/1"})
+	m5, _ := s.AddMemory(ctx, &store.Memory{Content: "conflict new", SourceFile: "github:issues/2"})
+	conflictLoserID, _ = s.AddFact(ctx, &store.Fact{MemoryID: m4, Subject: "user", Predicate: "email", Object: "old@example.com", FactType: "identity", Confidence: 0.60})
+	conflictWinnerID, _ = s.AddFact(ctx, &store.Fact{MemoryID: m5, Subject: "user", Predicate: "email", Object: "new@example.com", FactType: "identity", Confidence: 0.90})
+	older := time.Now().UTC().AddDate(0, 0, -20)
+	newer := time.Now().UTC().AddDate(0, 0, -5)
+	if _, err := s.ExecContext(ctx, `UPDATE facts SET created_at=?, last_reinforced=? WHERE id=?`, older, older, conflictLoserID); err != nil {
+		t.Fatalf("update conflict loser time: %v", err)
+	}
+	if _, err := s.ExecContext(ctx, `UPDATE facts SET created_at=?, last_reinforced=? WHERE id=?`, newer, newer, conflictWinnerID); err != nil {
+		t.Fatalf("update conflict winner time: %v", err)
+	}
+
+	return
+}
+
+func testPolicies() cfgresolver.PolicyConfig {
+	p := cfgresolver.DefaultPolicyConfig()
+	p.ReinforcePromote.MinReinforcements = 3
+	p.ReinforcePromote.MinSources = 2
+	p.DecayRetire.InactiveDays = 30
+	p.DecayRetire.ConfidenceBelow = 0.30
+	p.ConflictSupersede.MinConfidenceDelta = 0.15
+	p.ConflictSupersede.RequireStrictlyNewer = true
+	return p
+}
+
+func TestRunner_DryRun_NoWrites(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "cortex.db")
+	si, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer si.Close()
+	s := si.(*store.SQLiteStore)
+	promoteID, decayID, winnerID, loserID := seedLifecycleData(t, s)
+
+	r, err := NewRunner(s, testPolicies())
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	report, err := r.Run(context.Background(), true)
+	if err != nil {
+		t.Fatalf("Run dry-run: %v", err)
+	}
+	if len(report.Actions) == 0 {
+		t.Fatalf("expected planned actions, got none")
+	}
+	if report.Applied != 0 {
+		t.Fatalf("expected 0 applied in dry-run, got %d", report.Applied)
+	}
+
+	fPromote, _ := s.GetFact(context.Background(), promoteID)
+	fDecay, _ := s.GetFact(context.Background(), decayID)
+	fWinner, _ := s.GetFact(context.Background(), winnerID)
+	fLoser, _ := s.GetFact(context.Background(), loserID)
+	if fPromote.State != store.FactStateActive || fDecay.State != store.FactStateActive {
+		t.Fatalf("dry-run should not change states: promote=%s decay=%s", fPromote.State, fDecay.State)
+	}
+	if fLoser.SupersededBy != nil || fLoser.State == store.FactStateSuperseded {
+		t.Fatalf("dry-run should not supersede loser; state=%s superseded=%v", fLoser.State, fLoser.SupersededBy)
+	}
+	if fWinner.State == store.FactStateSuperseded {
+		t.Fatalf("winner should remain non-superseded")
+	}
+}
+
+func TestRunner_Apply_Writes(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "cortex.db")
+	si, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer si.Close()
+	s := si.(*store.SQLiteStore)
+	promoteID, decayID, winnerID, loserID := seedLifecycleData(t, s)
+
+	r, err := NewRunner(s, testPolicies())
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	report, err := r.Run(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Run apply: %v", err)
+	}
+	if report.Applied == 0 {
+		t.Fatalf("expected applied actions, got %+v", report)
+	}
+
+	fPromote, _ := s.GetFact(context.Background(), promoteID)
+	fDecay, _ := s.GetFact(context.Background(), decayID)
+	fWinner, _ := s.GetFact(context.Background(), winnerID)
+	fLoser, _ := s.GetFact(context.Background(), loserID)
+
+	if fPromote.State != store.FactStateCore {
+		t.Fatalf("expected promote fact -> core, got %s", fPromote.State)
+	}
+	if fDecay.State != store.FactStateRetired {
+		t.Fatalf("expected decay fact -> retired, got %s", fDecay.State)
+	}
+	if fLoser.SupersededBy == nil || *fLoser.SupersededBy != fWinner.ID {
+		t.Fatalf("expected loser superseded by winner; loser=%+v winner=%d", fLoser, fWinner.ID)
+	}
+	if fLoser.State != store.FactStateSuperseded {
+		t.Fatalf("expected loser state superseded, got %s", fLoser.State)
+	}
+}


### PR DESCRIPTION
Implements #256 (parent epic: #253)

## What shipped
- Added `cortex lifecycle run [--dry-run] [--json]` CLI command.
- Added lifecycle runner service in `internal/lifecycle` that applies built-in policies:
  - `reinforce-promote` (active -> configured target)
  - `decay-retire` (active/core -> configured target)
  - `conflict-supersede` (deterministic supersede on conflicts)
- Runner emits auditable action-level report with policy, action type, ids, reason, and applied flag.
- Dry-run mode performs **no writes** and returns plan-only results.
- Apply mode performs `UpdateFactState` and `SupersedeFact` writes.
- Added target-state validation to enforce policy outputs to `active|core|retired` only.

## Notes
- Fixed SQLite lock/hang in apply mode by collecting candidate actions from query rows first, then applying writes after rows are closed.
- Added robust SQLite timestamp parsing for mixed formats in lifecycle decay evaluation.

## Tests
- `internal/lifecycle/runner_test.go`
  - `TestRunner_DryRun_NoWrites`
  - `TestRunner_Apply_Writes`
- `cmd/cortex/lifecycle_test.go`
  - `TestRunLifecycle_DryRunJSON`

## Validation
- `go test ./internal/lifecycle -run TestRunner -v` ✅
- `go test ./cmd/cortex -run Lifecycle -v` ✅
- `go test ./...` ✅
