### PR TITLE
feat: add hard source-prefix filtering to search query path

### DIFF
--- a/internal/search/metadata_boost_test.go
+++ b/internal/search/metadata_boost_test.go
@@ -193,6 +193,7 @@ func TestIsConnectorSource(t *testing.T) {
 		{"discord:messages/456", true},
 		{"telegram:chats/789", true},
 		{"notion:pages/abc", true},
+		{"obsidian:notes/cortex.md", true},
 		{"memory/2026-02-23.md", false},
 		{"MEMORY.md", false},
 		{"/Users/q/notes.md", false},

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -234,6 +234,7 @@ type Store interface {
 	// Search
 	SearchFTS(ctx context.Context, query string, limit int) ([]*SearchResult, error)
 	SearchFTSWithProject(ctx context.Context, query string, limit int, project string) ([]*SearchResult, error)
+	SearchFTSWithFilters(ctx context.Context, query string, limit int, project string, sourcePrefix string) ([]*SearchResult, error)
 	SearchEmbedding(ctx context.Context, vector []float32, limit int, minSimilarity float64) ([]*SearchResult, error)
 	SearchEmbeddingWithProject(ctx context.Context, vector []float32, limit int, minSimilarity float64, project string) ([]*SearchResult, error)
 


### PR DESCRIPTION
Implements #291.

## What changed
- Added `SearchFTSWithFilters(...)` in store layer to support project + source prefix filters directly in SQL query path.
- Updated `searchBM25` to call filtered FTS/LIKE search with `opts.Source`.
- Kept existing post-search source filter as a safety net, but now filtering is done against the source column earlier.
- Improved source-filter behavior for connector prefix detection by including `obsidian:` in connector source classification.
- Added/updated tests:
  - `TestSearchFTSWithFilters_SourcePrefix`
  - `TestSearchFTSWithFilters_SourceAndProjectTogether`
  - `TestIsConnectorSource` includes obsidian

## Why
Previously source filtering happened after top-N retrieval, which could miss matching source results under tight limits and contradicted the issue requirement to filter on source in the search query path.

## Validation
- `go test ./internal/store ./internal/search -run 'SearchFTSWithFilters|FilterBySource|IsConnectorSource' -v` ✅
- `go test ./...` ✅
