### PR TITLE
feat: add cortex demo first-win command

### DIFF
--- a/cmd/cortex/demo.go
+++ b/cmd/cortex/demo.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func runDemo(args []string) error {
+	fs := flag.NewFlagSet("demo", flag.ContinueOnError)
+	dbPathFlag := fs.String("db", "", "Path to demo SQLite DB (default: temp file)")
+	demoDirFlag := fs.String("dir", "", "Directory for demo markdown files (default: temp dir)")
+	cleanup := fs.Bool("cleanup", false, "Delete demo files/DB after completion")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if len(fs.Args()) > 0 {
+		return fmt.Errorf("usage: cortex demo [--db <path>] [--dir <path>] [--cleanup]")
+	}
+
+	var err error
+	demoDir := strings.TrimSpace(*demoDirFlag)
+	if demoDir == "" {
+		demoDir, err = os.MkdirTemp("", "cortex-demo-")
+		if err != nil {
+			return fmt.Errorf("creating temp demo directory: %w", err)
+		}
+	} else {
+		demoDir = expandUserPath(demoDir)
+		if err := os.MkdirAll(demoDir, 0o755); err != nil {
+			return fmt.Errorf("creating demo directory: %w", err)
+		}
+	}
+
+	dbPath := strings.TrimSpace(*dbPathFlag)
+	if dbPath == "" {
+		dbPath = filepath.Join(os.TempDir(), fmt.Sprintf("cortex-demo-%d.db", time.Now().UnixNano()))
+	} else {
+		dbPath = expandUserPath(dbPath)
+	}
+
+	files, err := createDemoMarkdownFiles(demoDir)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("🧪 Cortex demo")
+	fmt.Printf("Demo files: %d markdown files in %s\n", len(files), demoDir)
+	fmt.Printf("Demo DB:    %s\n\n", dbPath)
+
+	oldDBPath := globalDBPath
+	globalDBPath = dbPath
+	defer func() { globalDBPath = oldDBPath }()
+
+	fmt.Println("Step 1/3: Import + extract sample knowledge")
+	if err := runImport([]string{demoDir, "--recursive", "--extract", "--no-enrich", "--no-classify"}); err != nil {
+		if *cleanup {
+			_ = cleanupDemoArtifacts(demoDir, dbPath)
+		}
+		return fmt.Errorf("demo import failed: %w", err)
+	}
+
+	fmt.Println("\nStep 2/3: Run demo searches")
+	fmt.Println("\nQuery: who is leading trading strategy?")
+	if err := runSearch([]string{"who", "is", "leading", "trading", "strategy", "--limit", "5"}); err != nil {
+		return fmt.Errorf("demo search failed: %w", err)
+	}
+
+	fmt.Println("\nQuery: what changed in onboarding?")
+	if err := runSearch([]string{"what", "changed", "in", "onboarding", "--limit", "5"}); err != nil {
+		return fmt.Errorf("demo search failed: %w", err)
+	}
+
+	fmt.Println("\nStep 3/3: Doctor check on demo DB")
+	if err := runDoctor([]string{}); err != nil {
+		return fmt.Errorf("demo doctor failed: %w", err)
+	}
+
+	fmt.Println("\n✅ Demo complete.")
+	fmt.Println("Your turn:")
+	fmt.Printf("  cortex --db %s search \"your question\"\n", dbPath)
+	fmt.Printf("  cortex --db %s list --facts --limit 10\n", dbPath)
+	fmt.Printf("  cortex --db %s stats\n", dbPath)
+	if !*cleanup {
+		fmt.Println("\nInspection paths (kept):")
+		fmt.Printf("  files: %s\n", demoDir)
+		fmt.Printf("  db:    %s\n", dbPath)
+		fmt.Println("Use --cleanup to auto-delete these next run.")
+	} else {
+		if err := cleanupDemoArtifacts(demoDir, dbPath); err != nil {
+			return fmt.Errorf("demo cleanup failed: %w", err)
+		}
+		fmt.Println("\nTemporary demo files cleaned up.")
+	}
+
+	return nil
+}
+
+func createDemoMarkdownFiles(dir string) ([]string, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating demo dir: %w", err)
+	}
+
+	type fileDef struct {
+		name    string
+		content string
+	}
+
+	defs := []fileDef{
+		{
+			name: "team.md",
+			content: `# Team
+
+- Q leads product direction and strategy.
+- Mister coordinates architecture and merges.
+- x7 implements core features in Go and runs test sweeps.
+`,
+		},
+		{
+			name: "trading.md",
+			content: `# Trading Ops
+
+- ORB strategy is active on QQQ and SPY.
+- Risk note: position size increases only after 30+ validated trades.
+- Next review window: Monday pre-market checklist.
+`,
+		},
+		{
+			name: "cortex.md",
+			content: `# Cortex
+
+- v1.2.1 adoption sprint delivered init wizard, error UX, and version checks.
+- Obsidian export supports dashboard, topics, entities, and trading journal.
+- Lifecycle run now completes with optimized query plan.
+`,
+		},
+		{
+			name: "onboarding.md",
+			content: `# Onboarding
+
+- New-user flow: install -> init -> import --extract -> search -> doctor.
+- Common pitfall: env vars override config values.
+- First-win demo should complete in under 60 seconds.
+`,
+		},
+	}
+
+	files := make([]string, 0, len(defs))
+	for _, d := range defs {
+		path := filepath.Join(dir, d.name)
+		if err := os.WriteFile(path, []byte(d.content), 0o644); err != nil {
+			return nil, fmt.Errorf("writing %s: %w", d.name, err)
+		}
+		files = append(files, path)
+	}
+
+	return files, nil
+}
+
+func cleanupDemoArtifacts(demoDir, dbPath string) error {
+	_ = os.RemoveAll(demoDir)
+
+	paths := []string{dbPath, dbPath + "-wal", dbPath + "-shm"}
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/cortex/demo_test.go
+++ b/cmd/cortex/demo_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateDemoMarkdownFiles(t *testing.T) {
+	dir := t.TempDir()
+	files, err := createDemoMarkdownFiles(dir)
+	if err != nil {
+		t.Fatalf("createDemoMarkdownFiles: %v", err)
+	}
+	if len(files) < 3 {
+		t.Fatalf("expected at least 3 demo files, got %d", len(files))
+	}
+	for _, f := range files {
+		if filepath.Ext(f) != ".md" {
+			t.Fatalf("expected markdown file, got %s", f)
+		}
+		if _, err := os.Stat(f); err != nil {
+			t.Fatalf("expected file to exist: %s (%v)", f, err)
+		}
+	}
+}
+
+func TestCleanupDemoArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	demoDir := filepath.Join(dir, "demo")
+	dbPath := filepath.Join(dir, "cortex-demo.db")
+	if err := os.MkdirAll(demoDir, 0o755); err != nil {
+		t.Fatalf("mkdir demoDir: %v", err)
+	}
+	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	if err := cleanupDemoArtifacts(demoDir, dbPath); err != nil {
+		t.Fatalf("cleanupDemoArtifacts: %v", err)
+	}
+	if _, err := os.Stat(demoDir); !os.IsNotExist(err) {
+		t.Fatalf("expected demoDir removed, stat err=%v", err)
+	}
+	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("expected %s removed, stat err=%v", p, err)
+		}
+	}
+}

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -123,6 +123,8 @@ func main() {
 		exitWithError(runConnect(args[1:]))
 	case "init":
 		exitWithError(runInit(args[1:]))
+	case "demo":
+		exitWithError(runDemo(args[1:]))
 	case "doctor":
 		exitWithError(runDoctor(args[1:]))
 	case "completion":
@@ -8813,7 +8815,7 @@ func execCommand(name string, args ...string) error {
 
 // cortexCommands is the authoritative list of top-level commands for completion.
 var cortexCommands = []string{
-	"import", "reimport", "search", "query", "list", "export", "update",
+	"import", "reimport", "search", "query", "list", "export", "update", "demo",
 	"extract", "classify", "reinforce", "supersede", "fact-history",
 	"stats", "stale", "conflicts", "agents", "projects",
 	"graph", "cluster",
@@ -8902,6 +8904,7 @@ Memory:
   list                  List memories or facts
   export                Export memory store (json, markdown, csv)
   update <id>           Update a memory's content
+  demo                  Run a full 60-second demo on temp data
 
 Facts:
   extract <file>        Extract facts from a file (without importing)


### PR DESCRIPTION
Implements #293.

## What shipped

- Added new top-level command: `cortex demo`
- Runs a complete first-win flow on temporary data + temporary DB (no pollution of user DB):
  1. creates 4 sample markdown files
  2. imports with `--extract --no-enrich --no-classify`
  3. runs demo searches and shows results
  4. runs `cortex doctor`
  5. prints "your turn" commands

### Flags
- `--db <path>`: optional custom temp DB path
- `--dir <path>`: optional custom demo files path
- `--cleanup`: remove demo files + DB artifacts after run

## UX goals covered
- Uses temp DB by default and isolates demo state.
- Uses import progress output from #292.
- Leaves artifacts by default for inspection; supports cleanup.

## Tests
- Added `cmd/cortex/demo_test.go`:
  - `TestCreateDemoMarkdownFiles`
  - `TestCleanupDemoArtifacts`

## Validation
- `go test ./cmd/cortex -run 'Demo|CreateDemo|CleanupDemo' -v` ✅
- `go test ./...` ✅
- Manual smoke: `go run ./cmd/cortex demo --cleanup` ✅
