### PR TITLE
reason: stop injecting hardcoded contract boilerplate

### DIFF
--- a/internal/reason/quality_contract.go
+++ b/internal/reason/quality_contract.go
@@ -16,45 +16,8 @@ var (
 )
 
 func enforceResponseQualityContract(content, query string) string {
-	if !needsContractRepair(content) {
-		return strings.TrimSpace(content)
-	}
-
-	summarySeed := strings.TrimSpace(content)
-	if summarySeed == "" {
-		summarySeed = "Insufficient initial answer content; generated a structured decision-ready response from available context."
-	}
-	summarySeed = strings.ReplaceAll(summarySeed, "\n", " ")
-	summarySeed = strings.Join(strings.Fields(summarySeed), " ")
-	if len(summarySeed) > 360 {
-		summarySeed = summarySeed[:360] + "..."
-	}
-
-	q := strings.TrimSpace(query)
-	if q == "" {
-		q = "the requested analysis"
-	}
-
-	return strings.TrimSpace(strings.Join([]string{
-		"## Summary",
-		"This response was normalized to meet the required output contract for " + q + ".",
-		summarySeed,
-		"",
-		"## Evidence",
-		"- Source: Relevant memory search results and extracted facts were reviewed before synthesis.",
-		"- Fact confidence: Treat lower-confidence memory/fact items as uncertain until verified.",
-		"- Evidence note: If a claim lacks direct source confirmation, it is marked uncertain and queued for verification.",
-		"",
-		"## Conflicts & Trade-offs",
-		"- Uncertain: Some claims may be incomplete due to missing or stale memory context.",
-		"- Trade-off: Faster synthesis can reduce grounding depth; additional verification improves trust but adds latency.",
-		"- Conflict handling: When conflicting facts appear, prefer latest/high-confidence evidence and explicitly reconcile before merge decisions.",
-		"",
-		"## Next Actions",
-		"- Priority: High | Owner: Reason Maintainer | Timeline: Today | Recommendation: Verify top uncertain claims against source files/telemetry and supersede stale facts. | Impact: Improves factual grounding and lowers hard-failure rate.",
-		"- Priority: High | Owner: Reason Maintainer | Timeline: Next 24h | Recommendation: Run the full 30-case eval + guardrail, then patch the lowest-scoring preset prompts first. | Impact: Raises pass rate and stabilizes quality gates.",
-		"- Priority: Medium | Owner: Reason Maintainer | Timeline: This week | Recommendation: Track recurring failure dimensions in outcome logs and add targeted regression fixtures. | Impact: Prevents repeat regressions and improves long-term usefulness.",
-	}, "\n"))
+	_ = query
+	return strings.TrimSpace(content)
 }
 
 func needsContractRepair(content string) bool {

--- a/internal/reason/quality_contract_test.go
+++ b/internal/reason/quality_contract_test.go
@@ -32,16 +32,10 @@ This is a sufficiently long summary with context and operational detail so it is
 	}
 }
 
-func TestEnforceResponseQualityContract_Repairs(t *testing.T) {
-	out := enforceResponseQualityContract("brief", "test query")
-	for _, h := range []string{"## Summary", "## Evidence", "## Conflicts & Trade-offs", "## Next Actions"} {
-		if !strings.Contains(out, h) {
-			t.Fatalf("missing required header %s", h)
-		}
-	}
-	for _, label := range []string{"Priority:", "Owner:", "Timeline:", "Recommendation:", "Impact:"} {
-		if !strings.Contains(out, label) {
-			t.Fatalf("missing required label %s", label)
-		}
+func TestEnforceResponseQualityContract_LeavesModelOutputUntouched(t *testing.T) {
+	in := "brief"
+	out := enforceResponseQualityContract(in, "test query")
+	if strings.TrimSpace(out) != in {
+		t.Fatalf("expected output to remain unchanged, got %q", out)
 	}
 }


### PR DESCRIPTION
## Summary
Removes the internal boilerplate rewrite path in `enforceResponseQualityContract()` so Cortex reason returns the model output unchanged.

## Why
The previous behavior could hide real model behavior and emit repetitive low-signal text ("normalized to required output contract"), which polluted digest workflows.

## Changes
- `internal/reason/quality_contract.go`
  - `enforceResponseQualityContract()` now passthroughs trimmed model output.
- `internal/reason/quality_contract_test.go`
  - updated test to assert passthrough behavior.

## Validation
- `go test ./internal/reason`
- `go test ./...`

## Linked Issue
Closes #299
