### PR TITLE
docs: add repo-level agent operating contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,39 +1,101 @@
-# Repository Guidelines
+# AGENTS.md — Cortex Agent Operating Contract
 
-## Project Structure & Module Organization
-- `cmd/cortex/` contains the main CLI entrypoint; `cmd/codex-rollout-report/` holds an auxiliary command.
-- `internal/` is the core Go codebase (`store`, `ingest`, `extract`, `search`, `observe`, `connect`, `graph`, etc.).
-- `tests/testdata/` and `tests/fixtures/` store shared fixtures (including retrieval/reason/visualizer cases).
-- `docs/` contains architecture notes, PRDs, release notes, and operational runbooks.
-- `plugin/` contains the OpenClaw TypeScript plugin; `npm/` contains the `@cortex-ai/mcp` package wrapper.
-- `scripts/` contains CI, audit, and validation utilities.
+This file is the **repo-level operating contract** for all agent work on Cortex.
+It exists to keep agent behavior stable even when priorities, epics, and lane ownership change.
 
-## Build, Test, and Development Commands
-- `go build ./cmd/cortex/` builds the main CLI binary locally.
-- `go test ./... -v` runs the full Go test suite.
-- `go test ./... -cover` reports package coverage.
-- `go vet ./...` runs static checks expected by CI.
-- `python3 scripts/validate_visualizer_contract.py` validates visualizer fixtures/contracts when visualizer data or APIs change.
-- `npm --prefix npm test` runs the Node-side smoke test for the MCP package.
+## Precedence
+When instructions conflict, use this order:
+1. Direct maintainer instruction
+2. The relevant GitHub issue / epic / PR comment for the active lane
+3. This file
+4. Other repo docs
 
-## Coding Style & Naming Conventions
-- Target Go `1.24+`; run `gofmt -w` before commit.
-- Keep package names short, lowercase, and singular (`store`, `search`).
-- Prefer descriptive, wrapped errors (for example, `fmt.Errorf("opening %s: %w", path, err)`).
-- Follow standard Go test layout: `_test.go`, table-driven tests where appropriate.
+**Rule:** lane-specific comments can refine execution for a slice, but they should not silently replace the repo-wide contract.
 
-## Testing Guidelines
-- Add or update tests with every behavior change.
-- Prefer in-memory SQLite (`:memory:`) for unit tests; use temp dirs/files for integration tests.
-- Keep fixtures deterministic; update `tests/fixtures/visualizer/` when schema/output changes.
-- Core packages (`internal/store`, `internal/search`, `internal/extract`) should stay near or above 80% coverage.
+## Current Default Roles
+These are the current defaults unless a maintainer or lane comment retargets them.
 
-## Commit & Pull Request Guidelines
-- Use Conventional Commit style seen in history: `feat(scope): ...`, `fix: ...`, `docs: ...`, `test: ...`.
-- Keep commits focused and reference related issue/PRD IDs when relevant (example: `feat(graph): ... #186`).
-- Complete `.github/PULL_REQUEST_TEMPLATE.md` sections (`What`, `Why`, `How`, `Testing`, checklist).
-- PR baseline: `go build ./...`, `go test ./...`, and `go vet ./...` must pass; update docs for behavior changes.
+- **Q / maintainer** — sets priorities, reviews work, and merges PRs
+- **Niot** — primary builder / feature delivery agent
+- **Hawk** — QA / release guard
+- **Other agents or humans** — welcome, but must follow the same contract
 
-## Security & Configuration Tips
-- Use `.env.example` as a template and never commit real secrets or local database artifacts.
-- Coordinate major interface or dependency changes through issues/ADRs before implementation.
+## Source of Truth
+- **GitHub issues + PRs are the live work lane** for Cortex
+- This file defines the stable operating rules for all agent work
+- Epic / issue comments define lane-specific slice order, acceptance criteria, and temporary constraints
+- Do not rely on off-repo chat as the only source of instructions for a PR
+
+## Work Intake & Slicing Rules
+- **PR-only delivery.** Never push directly to `main`
+- **One bounded slice per PR**
+- **No blob PRs** that combine multiple root fixes or feature tracks without a clear reason
+- If an issue is too large, narrow the current slice or open a child issue instead of treating the epic as one assignment
+- Prefer the **smallest safe dependency-respecting slice first**
+- Keep the queue concrete: raw epics are roadmap containers, not one-shot implementation prompts
+
+## Required PR Contract
+Every agent-authored PR should include:
+- linked issue(s)
+- a concise **What changed** summary
+- a concise **Why this change exists** summary
+- touched surfaces / files / packages
+- exact test commands run
+- a short risk note
+- docs or release-note updates when behavior changed
+
+If relevant, the PR should also say whether it changed:
+- **product behavior**
+- **benchmark / eval interpretation**
+- **both**
+
+## QA / Review Contract
+The default QA gate for agent PRs is:
+1. `gh pr checks`
+2. touched-surface deterministic tests
+3. `go test ./...` when scope warrants it
+4. concise **PASS / FAIL** verdict
+5. exact fix list on failure
+
+**Merge authority:** Q merges all PRs.
+Agents do not merge their own work.
+
+## Benchmark & Eval Truthfulness
+Cortex uses benchmarks and evals as a **truth surface**, not a vanity surface.
+
+Rules:
+- Do **not** make scores look better by weakening expectations without clear justification
+- Keep product fixes and benchmark fixes conceptually separate, even when they ship together
+- If an eval contract changes, update the docs/tests that explain why
+- Prefer a benchmark that is honest and uncomfortable over one that is green and misleading
+
+## Code / Test Baseline
+- Run `gofmt -w` on edited Go files
+- Run `go vet ./...` when relevant
+- Add or update tests with every behavioral change
+- Keep fixtures deterministic
+- Use focused tests for touched surfaces; use the full suite when the change reaches broadly enough to justify it
+
+Useful commands:
+- `go build ./cmd/cortex/`
+- `go test ./...`
+- `go vet ./...`
+- `python3 scripts/validate_visualizer_contract.py`
+- `npm --prefix npm test`
+
+## Docs Discipline
+- If behavior changes, docs should move in the same PR
+- If a lane has special rules, record them in the relevant issue / epic / PR comment
+- Do not leave critical operating assumptions only in chat or memory
+
+## Security / Repo Hygiene
+- Never commit real secrets, local DB artifacts, or private env values
+- Use `.env.example` as the public template
+- Coordinate major interface changes through issues / ADRs before broad implementation
+
+## Practical Rule of Thumb
+A good agent PR is:
+- small enough to review in one sitting
+- tested enough to trust
+- documented enough to understand later
+- honest enough not to hide risk

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,5 +1,7 @@
 # Multi-Agent Coordination
 
+> **Active contract:** The repo-root `AGENTS.md` is the current operating contract for all agent work in Cortex. If this file conflicts with the root `AGENTS.md`, the root file wins.
+
 This repo is developed by multiple AI agents working in parallel. This document defines coordination conventions to prevent conflicts, maintain quality, and keep development velocity high.
 
 ---


### PR DESCRIPTION
## What\n- turn the repo-root \ into the active agent operating contract\n- clarify that lane-specific issue/epic comments refine execution without replacing repo-wide rules\n- point \ back to the root contract when instructions overlap\n\n## Why\nNiot and Hawk responsibilities are changing fast, and the repo needs a durable GitHub-native contract so agent work stays deterministic even as lanes shift.\n\n## How\n- define precedence\n- define default roles\n- lock PR-only / bounded-slice / QA / benchmark-truth rules\n- preserve extended historical coordination notes in \\n\n## Testing\n- docs-only change; no runtime behavior changed\n\n## Risk\nLow. This changes agent guidance only; no product code path changed.