### PR TITLE
fix: rebuild on corrupt persisted HNSW index

### DIFF
--- a/internal/ann/hnsw_test.go
+++ b/internal/ann/hnsw_test.go
@@ -1,10 +1,12 @@
 package ann
 
 import (
+	"encoding/binary"
 	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -283,6 +285,51 @@ func TestLoadInvalidMagic(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsCorruptNodeLevelWithoutPanicking(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "corrupt-level.hnsw")
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create corrupt file: %v", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write([]byte(magic)); err != nil {
+		t.Fatalf("write magic: %v", err)
+	}
+	write := func(v int32) {
+		t.Helper()
+		if err := binary.Write(f, binary.LittleEndian, v); err != nil {
+			t.Fatalf("write int32 %d: %v", v, err)
+		}
+	}
+	write(1)   // version
+	write(2)   // dims
+	write(1)   // nodeCount
+	write(0)   // entryPoint
+	write(0)   // maxLevel
+	write(16)  // M
+	write(32)  // Mmax0
+	write(200) // EfConstruction
+	write(50)  // EfSearch
+	if err := binary.Write(f, binary.LittleEndian, int64(1)); err != nil {
+		t.Fatalf("write node id: %v", err)
+	}
+	write(-2) // corrupt level that used to trigger makeslice panic
+	if err := f.Close(); err != nil {
+		t.Fatalf("close corrupt file: %v", err)
+	}
+
+	_, err = Load(path)
+	if err == nil {
+		t.Fatal("expected error for corrupt level")
+	}
+	if got := err.Error(); got == "" || !containsAny(got, []string{"invalid value -2", "corrupt persisted data"}) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // --- Distance Tests ---
 
 func TestCosineDistance(t *testing.T) {
@@ -330,4 +377,13 @@ func resultIDs(results []Result) []int64 {
 		ids[i] = r.ID
 	}
 	return ids
+}
+
+func containsAny(s string, wants []string) bool {
+	for _, want := range wants {
+		if want != "" && strings.Contains(s, want) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ann/persist.go
+++ b/internal/ann/persist.go
@@ -14,6 +14,13 @@ import (
 
 const magic = "CXHNSW01"
 
+const (
+	maxPersistedDims       = 65536
+	maxPersistedNodeCount  = 10_000_000
+	maxPersistedLevel      = 1024
+	maxPersistedFriendRefs = 1_000_000
+)
+
 // Save persists the HNSW index to a binary file.
 // The index can be loaded back with Load().
 func (idx *Index) Save(path string) error {
@@ -94,7 +101,13 @@ func (idx *Index) Save(path string) error {
 }
 
 // Load restores an HNSW index from a binary file created by Save().
-func Load(path string) (*Index, error) {
+func Load(path string) (_ *Index, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("loading index %s: corrupt persisted data: %v", path, r)
+		}
+	}()
+
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("opening index file: %w", err)
@@ -152,6 +165,10 @@ func Load(path string) (*Index, error) {
 		return nil, err
 	}
 
+	if err := validateHeader(dims, nodeCount, entryPoint, maxLevel, m, mmax0, efConst, efSearch); err != nil {
+		return nil, err
+	}
+
 	idx := &Index{
 		dims:           int(dims),
 		M:              int(m),
@@ -176,6 +193,13 @@ func Load(path string) (*Index, error) {
 			return nil, fmt.Errorf("reading node %d level: %w", i, err)
 		}
 
+		if level < 0 || level > maxPersistedLevel {
+			return nil, fmt.Errorf("reading node %d level: invalid value %d", i, level)
+		}
+		if level > maxLevel && maxLevel >= 0 {
+			return nil, fmt.Errorf("reading node %d level: %d exceeds header maxLevel %d", i, level, maxLevel)
+		}
+
 		// Vector
 		vector := make([]float32, dims)
 		for d := int32(0); d < dims; d++ {
@@ -193,11 +217,17 @@ func Load(path string) (*Index, error) {
 			if err != nil {
 				return nil, fmt.Errorf("reading node %d layer %d friend count: %w", i, l, err)
 			}
+			if friendCount < 0 || friendCount > nodeCount || friendCount > maxPersistedFriendRefs {
+				return nil, fmt.Errorf("reading node %d layer %d friend count: invalid value %d", i, l, friendCount)
+			}
 			friends[l] = make([]int, friendCount)
 			for j := int32(0); j < friendCount; j++ {
 				fIdx, err := readInt32(f)
 				if err != nil {
 					return nil, fmt.Errorf("reading node %d layer %d friend %d: %w", i, l, j, err)
+				}
+				if fIdx < 0 || fIdx >= nodeCount {
+					return nil, fmt.Errorf("reading node %d layer %d friend %d: invalid node ref %d", i, l, j, fIdx)
 				}
 				friends[l][j] = int(fIdx)
 			}
@@ -254,4 +284,41 @@ func readFloat32(r io.Reader) (float32, error) {
 	var v float32
 	err := binary.Read(r, binary.LittleEndian, &v)
 	return v, err
+}
+
+func validateHeader(dims, nodeCount, entryPoint, maxLevel, m, mmax0, efConst, efSearch int32) error {
+	if dims <= 0 || dims > maxPersistedDims {
+		return fmt.Errorf("invalid dims: %d", dims)
+	}
+	if nodeCount < 0 || nodeCount > maxPersistedNodeCount {
+		return fmt.Errorf("invalid node count: %d", nodeCount)
+	}
+	if nodeCount == 0 {
+		if entryPoint != -1 {
+			return fmt.Errorf("invalid entry point for empty index: %d", entryPoint)
+		}
+		if maxLevel != -1 {
+			return fmt.Errorf("invalid max level for empty index: %d", maxLevel)
+		}
+	} else {
+		if entryPoint < 0 || entryPoint >= nodeCount {
+			return fmt.Errorf("invalid entry point: %d", entryPoint)
+		}
+		if maxLevel < 0 || maxLevel > maxPersistedLevel {
+			return fmt.Errorf("invalid max level: %d", maxLevel)
+		}
+	}
+	if m < 2 {
+		return fmt.Errorf("invalid M: %d", m)
+	}
+	if mmax0 < m {
+		return fmt.Errorf("invalid Mmax0: %d", mmax0)
+	}
+	if efConst <= 0 {
+		return fmt.Errorf("invalid EfConstruction: %d", efConst)
+	}
+	if efSearch <= 0 {
+		return fmt.Errorf("invalid EfSearch: %d", efSearch)
+	}
+	return nil
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -329,6 +329,7 @@ func (e *Engine) LoadOrBuildHNSW(ctx context.Context, path string, staleThreshol
 				e.hnsw = loaded
 				return loaded.Len(), nil
 			}
+			fmt.Fprintf(os.Stderr, "warning: could not load HNSW index %s: %v; rebuilding\n", path, err)
 			// Fall through to rebuild on load error
 		}
 	}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -3,13 +3,16 @@ package search
 import (
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/hurttlocker/cortex/internal/ann"
 	"github.com/hurttlocker/cortex/internal/store"
 )
 
@@ -57,6 +60,38 @@ func findResultByID(results []Result, id int64) (Result, bool) {
 	return Result{}, false
 }
 
+func writeCorruptHNSWFile(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create corrupt hnsw file: %v", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write([]byte("CXHNSW01")); err != nil {
+		t.Fatalf("write magic: %v", err)
+	}
+	write := func(v int32) {
+		t.Helper()
+		if err := binary.Write(f, binary.LittleEndian, v); err != nil {
+			t.Fatalf("write int32 %d: %v", v, err)
+		}
+	}
+	write(1)   // version
+	write(3)   // dims
+	write(1)   // nodeCount
+	write(0)   // entryPoint
+	write(0)   // maxLevel
+	write(16)  // M
+	write(32)  // Mmax0
+	write(200) // EfConstruction
+	write(50)  // EfSearch
+	if err := binary.Write(f, binary.LittleEndian, int64(1)); err != nil {
+		t.Fatalf("write node id: %v", err)
+	}
+	write(-2) // corrupt level that used to trigger panic in ann.Load
+}
+
 // seedTestData inserts a standard set of test memories for search testing.
 func seedTestData(t *testing.T, s store.Store) {
 	t.Helper()
@@ -93,6 +128,45 @@ func TestNewEngine(t *testing.T) {
 	}
 	if engine.store == nil {
 		t.Fatal("expected non-nil store in engine")
+	}
+}
+
+func TestLoadOrBuildHNSW_RebuildsCorruptPersistedIndex(t *testing.T) {
+	s, dbPath := newFileBackedTestStore(t)
+	ctx := context.Background()
+	memID, err := s.AddMemory(ctx, &store.Memory{
+		Content:       "HNSW rebuild should recover from corrupt persisted index",
+		SourceFile:    "search-test.md",
+		SourceLine:    1,
+		SourceSection: "tests",
+	})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if err := s.AddEmbedding(ctx, memID, []float32{0.9, 0.1, 0.0}); err != nil {
+		t.Fatalf("AddEmbedding: %v", err)
+	}
+
+	hnswPath := filepath.Join(filepath.Dir(dbPath), "hnsw.idx")
+	writeCorruptHNSWFile(t, hnswPath)
+
+	engine := NewEngine(s)
+	count, err := engine.LoadOrBuildHNSW(ctx, hnswPath, 3600)
+	if err != nil {
+		t.Fatalf("LoadOrBuildHNSW: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("LoadOrBuildHNSW count = %d, want 1", count)
+	}
+	if engine.hnsw == nil {
+		t.Fatal("expected HNSW index to be rebuilt")
+	}
+	loaded, err := ann.Load(hnswPath)
+	if err != nil {
+		t.Fatalf("ann.Load rebuilt index: %v", err)
+	}
+	if loaded.Len() != 1 {
+		t.Fatalf("rebuilt persisted index len = %d, want 1", loaded.Len())
 	}
 }
 


### PR DESCRIPTION
## What this fixes
Stops `cortex search` from panicking when the persisted HNSW index file is malformed or stale-corrupt.

## Root cause
`ann.Load()` trusted persisted integer counts/levels and could panic with:
- `panic: runtime error: makeslice: len out of range`

That bubbled out of `LoadOrBuildHNSW()` before the engine had a chance to fall back to a rebuild.

## What changed
1. **Defensive HNSW load validation**
   - validate header values before allocation
   - validate node levels / friend counts / friend refs while loading
   - recover from malformed persisted data and return a normal error instead of panicking

2. **Graceful rebuild path**
   - `LoadOrBuildHNSW()` now logs a warning and rebuilds the index when persisted load fails

3. **Regression coverage**
   - added ANN load test for corrupt node level
   - added search-engine test that verifies a corrupt persisted HNSW file gets rebuilt successfully

## Live verification
I reproduced the panic against the real local DB and confirmed the immediate remediation path:
- preserved the bad `~/.cortex/hnsw.idx` out of the load path
- reran the installed `cortex search`
- confirmed search now returns results again and regenerates a clean HNSW file

## Tests
- `go test ./internal/ann ./internal/search ./cmd/cortex -count=1`
- `go test ./...`
- live verification with `cortex search ... --mode hybrid --embed ollama/nomic-embed-text`

## Risk
Low.
This is a persistence hardening fix plus rebuild fallback. It should only change behavior when the on-disk HNSW index is malformed; healthy indexes still load normally.
