### PR TITLE
feat(cortex): add trust visibility to cortex agents (#275 slice A)

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -8328,6 +8328,9 @@ type agentSummary struct {
 	FactCount       int    `json:"fact_count"`
 	ActiveFactCount int    `json:"active_fact_count"`
 	LastSeen        string `json:"last_seen,omitempty"`
+	TrustLevel      string `json:"trust_level"`
+	TrustScope      string `json:"trust_scope"`
+	TrustConfigured bool   `json:"trust_configured"`
 }
 
 type agentsReport struct {
@@ -8344,6 +8347,11 @@ func runAgents(args []string) error {
 		default:
 			return fmt.Errorf("unknown argument: %s\nUsage: cortex agents [--json]", arg)
 		}
+	}
+
+	trustByAgent, err := cfgresolver.ResolveAgentTrustConfig("")
+	if err != nil {
+		return fmt.Errorf("loading trust config: %w", err)
 	}
 
 	cfg := getStoreConfig()
@@ -8420,6 +8428,13 @@ func runAgents(args []string) error {
 			MemoryCount:     memoryCount,
 			FactCount:       factCount,
 			ActiveFactCount: activeFactCount,
+			TrustLevel:      "unconfigured",
+			TrustScope:      "n/a",
+		}
+		if trust, ok := trustByAgent[agentID]; ok {
+			entry.TrustLevel = trust.Trust
+			entry.TrustScope = trust.Scope
+			entry.TrustConfigured = true
 		}
 		if lastSeen.Valid && strings.TrimSpace(lastSeen.String) != "" {
 			entry.LastSeen = lastSeen.String
@@ -8444,17 +8459,20 @@ func runAgents(args []string) error {
 		return nil
 	}
 
-	fmt.Printf("%-16s  %8s  %8s  %8s  %s\n", "AGENT", "MEMORIES", "FACTS", "ACTIVE", "LAST_SEEN")
-	fmt.Println(strings.Repeat("─", 72))
+	fmt.Printf("%-16s  %8s  %8s  %8s  %-13s  %-23s  %s\n", "AGENT", "MEMORIES", "FACTS", "ACTIVE", "TRUST", "SCOPE", "LAST_SEEN")
+	fmt.Println(strings.Repeat("─", 110))
 	for _, a := range agents {
 		lastSeen := a.LastSeen
 		if lastSeen == "" {
 			lastSeen = "-"
 		}
-		fmt.Printf("%-16s  %8d  %8d  %8d  %s\n",
-			a.AgentID, a.MemoryCount, a.FactCount, a.ActiveFactCount, lastSeen)
+		fmt.Printf("%-16s  %8d  %8d  %8d  %-13s  %-23s  %s\n",
+			a.AgentID, a.MemoryCount, a.FactCount, a.ActiveFactCount, a.TrustLevel, a.TrustScope, lastSeen)
 	}
 	fmt.Println()
+	if len(trustByAgent) > 0 {
+		fmt.Printf("Trust visibility loaded from %s (read-only visibility only; no cross-agent write enforcement in this slice).\n", cfgresolver.DefaultConfigPath())
+	}
 	fmt.Println("Global (agent_id='') facts are shared and not listed here.")
 	return nil
 }

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -2255,6 +2255,22 @@ func TestRunAgents_JSON(t *testing.T) {
 	globalDBPath = dbPath
 	t.Cleanup(func() { globalDBPath = oldDBPath })
 
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	cfgDir := filepath.Join(homeDir, ".cortex")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	trustCfg := `agents:
+  mister:
+    trust: owner
+  hawk:
+    trust: reader
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte(trustCfg), 0o600); err != nil {
+		t.Fatalf("write trust config: %v", err)
+	}
+
 	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
@@ -2363,6 +2379,9 @@ func TestRunAgents_JSON(t *testing.T) {
 	if mister.MemoryCount != 1 || mister.FactCount != 1 || mister.ActiveFactCount != 1 {
 		t.Fatalf("unexpected mister stats: %+v", mister)
 	}
+	if !mister.TrustConfigured || mister.TrustLevel != "owner" || mister.TrustScope != "read:all write:all" {
+		t.Fatalf("unexpected mister trust visibility: %+v", mister)
+	}
 
 	hawk, ok := findAgentSummary(payload.Agents, "hawk")
 	if !ok {
@@ -2370,6 +2389,60 @@ func TestRunAgents_JSON(t *testing.T) {
 	}
 	if hawk.MemoryCount != 1 || hawk.FactCount != 2 || hawk.ActiveFactCount != 1 {
 		t.Fatalf("unexpected hawk stats: %+v", hawk)
+	}
+	if !hawk.TrustConfigured || hawk.TrustLevel != "reader" || hawk.TrustScope != "read:all write:none" {
+		t.Fatalf("unexpected hawk trust visibility: %+v", hawk)
+	}
+}
+
+func TestRunAgents_TextIncludesTrustVisibility(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "cortex.db")
+
+	oldDBPath := globalDBPath
+	globalDBPath = dbPath
+	t.Cleanup(func() { globalDBPath = oldDBPath })
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	cfgDir := filepath.Join(homeDir, ".cortex")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	trustCfg := `agents:
+  mister:
+    trust: owner
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte(trustCfg), 0o600); err != nil {
+		t.Fatalf("write trust config: %v", err)
+	}
+
+	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	ctx := context.Background()
+	memID, err := s.AddMemory(ctx, &store.Memory{Content: "mister memory", SourceFile: "mister.md", Metadata: &store.Metadata{AgentID: "mister"}})
+	if err != nil {
+		t.Fatalf("add memory: %v", err)
+	}
+	if _, err := s.AddFact(ctx, &store.Fact{MemoryID: memID, Subject: "deploy", Predicate: "owner", Object: "mister", FactType: "identity", AgentID: "mister"}); err != nil {
+		t.Fatalf("add fact: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	out := captureStdout(func() {
+		if err := runAgents(nil); err != nil {
+			t.Fatalf("runAgents: %v", err)
+		}
+	})
+	if !strings.Contains(out, "TRUST") || !strings.Contains(out, "SCOPE") || !strings.Contains(out, "read:all write:all") {
+		t.Fatalf("expected trust columns in output, got: %s", out)
+	}
+	if !strings.Contains(out, "read-only visibility only") {
+		t.Fatalf("expected read-only note in output, got: %s", out)
 	}
 }
 
@@ -2380,6 +2453,8 @@ func TestRunAgents_NoAgents(t *testing.T) {
 	oldDBPath := globalDBPath
 	globalDBPath = dbPath
 	t.Cleanup(func() { globalDBPath = oldDBPath })
+
+	t.Setenv("HOME", t.TempDir())
 
 	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
 	if err != nil {
@@ -2396,6 +2471,45 @@ func TestRunAgents_NoAgents(t *testing.T) {
 	})
 	if !strings.Contains(out, "No agents found") {
 		t.Fatalf("expected empty-state message, got: %s", out)
+	}
+}
+
+func TestRunAgents_InvalidTrustConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "cortex.db")
+
+	oldDBPath := globalDBPath
+	globalDBPath = dbPath
+	t.Cleanup(func() { globalDBPath = oldDBPath })
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	cfgDir := filepath.Join(homeDir, ".cortex")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	badCfg := `agents:
+  hawk:
+    trust: admin
+`
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte(badCfg), 0o600); err != nil {
+		t.Fatalf("write bad config: %v", err)
+	}
+
+	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	err = runAgents([]string{"--json"})
+	if err == nil {
+		t.Fatal("expected trust config validation error")
+	}
+	if !strings.Contains(err.Error(), "loading trust config") || !strings.Contains(err.Error(), "agents.hawk.trust") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -58,6 +58,16 @@ type PolicyConfig struct {
 	ConflictSupersede ConflictSupersedePolicy `yaml:"conflict_supersede" json:"conflict_supersede"`
 }
 
+type AgentTrustRule struct {
+	Trust string `yaml:"trust" json:"trust"`
+}
+
+type AgentTrustEntry struct {
+	AgentID string `json:"agent_id"`
+	Trust   string `json:"trust"`
+	Scope   string `json:"scope"`
+}
+
 type ObsidianHubTypesConfig struct {
 	Person   string `yaml:"person" json:"person"`
 	Project  string `yaml:"project" json:"project"`
@@ -144,7 +154,8 @@ type fileConfig struct {
 		APIKey   string `yaml:"api_key"`
 		Endpoint string `yaml:"endpoint"`
 	} `yaml:"embed"`
-	Policies PolicyConfig `yaml:"policies"`
+	Policies PolicyConfig              `yaml:"policies"`
+	Agents   map[string]AgentTrustRule `yaml:"agents"`
 	Export   struct {
 		Obsidian ObsidianExportConfig `yaml:"obsidian"`
 	} `yaml:"export"`
@@ -256,6 +267,58 @@ func ResolveObsidianExportConfig(configPath string) (ObsidianExportConfig, error
 		return ObsidianExportConfig{}, err
 	}
 	return resolved.ObsidianExport, nil
+}
+
+func ResolveAgentTrustConfig(configPath string) (map[string]AgentTrustEntry, error) {
+	path := strings.TrimSpace(configPath)
+	if path == "" {
+		path = DefaultConfigPath()
+	}
+
+	cfg, err := loadConfig(path)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := map[string]AgentTrustEntry{}
+	if cfg == nil || len(cfg.Agents) == 0 {
+		return entries, nil
+	}
+
+	for rawAgentID, rule := range cfg.Agents {
+		agentID := strings.TrimSpace(rawAgentID)
+		if agentID == "" {
+			return nil, fmt.Errorf("parsing %s: agents contains an empty agent id", path)
+		}
+		trust := strings.ToLower(strings.TrimSpace(rule.Trust))
+		if trust == "" {
+			return nil, fmt.Errorf("parsing %s: agents.%s.trust is required", path, agentID)
+		}
+		scope, ok := AgentTrustScope(trust)
+		if !ok {
+			return nil, fmt.Errorf("parsing %s: agents.%s.trust=%q is invalid (allowed: owner, collaborator, reader)", path, agentID, trust)
+		}
+		entries[agentID] = AgentTrustEntry{
+			AgentID: agentID,
+			Trust:   trust,
+			Scope:   scope,
+		}
+	}
+
+	return entries, nil
+}
+
+func AgentTrustScope(trustLevel string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(trustLevel)) {
+	case "owner":
+		return "read:all write:all", true
+	case "collaborator":
+		return "read:all write:own", true
+	case "reader":
+		return "read:all write:none", true
+	default:
+		return "", false
+	}
 }
 
 func (r ResolvedConfig) EffectiveLLMModel(purpose, fallback string) ResolvedValue {

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -205,4 +206,66 @@ func TestResolveConfig_ObsidianExportOverrides(t *testing.T) {
 	if obs.HubTypes.Person == "" || obs.HubTypes.Project == "" {
 		t.Fatalf("expected hub type regex overrides, got %+v", obs.HubTypes)
 	}
+}
+
+func TestResolveAgentTrustConfig_Valid(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	yaml := `agents:
+  opus:
+    trust: owner
+  x7:
+    trust: collaborator
+  hawk:
+    trust: reader
+`
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	trust, err := ResolveAgentTrustConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("ResolveAgentTrustConfig: %v", err)
+	}
+	if len(trust) != 3 {
+		t.Fatalf("expected 3 trust entries, got %d", len(trust))
+	}
+	if trust["opus"].Scope != "read:all write:all" {
+		t.Fatalf("unexpected opus scope: %+v", trust["opus"])
+	}
+	if trust["x7"].Scope != "read:all write:own" {
+		t.Fatalf("unexpected x7 scope: %+v", trust["x7"])
+	}
+	if trust["hawk"].Scope != "read:all write:none" {
+		t.Fatalf("unexpected hawk scope: %+v", trust["hawk"])
+	}
+}
+
+func TestResolveAgentTrustConfig_InvalidTrust(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.yaml")
+	yaml := `agents:
+  hawk:
+    trust: admin
+`
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := ResolveAgentTrustConfig(cfgPath)
+	if err == nil {
+		t.Fatal("expected invalid trust error")
+	}
+	if got := err.Error(); got == "" || !containsAll(got, "agents.hawk.trust", "owner", "collaborator", "reader") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func containsAll(s string, needles ...string) bool {
+	for _, n := range needles {
+		if !strings.Contains(s, n) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## What this does
Implements a bounded **#275 slice A** for trust-boundary groundwork by making trust config visible in read-only operator surfaces.

- Adds trust config parsing + validation for `agents.<id>.trust` in `~/.cortex/config.yaml`
- Surfaces `trust_level` + `trust_scope` in `cortex agents --json`
- Extends `cortex agents` table output with TRUST/SCOPE columns
- Explicitly labels this as read-only visibility (no write enforcement in this slice)

## Problem / Context
Issue #275 needs scoped multi-agent trust boundaries, but the full system is too large for one PR. We needed the smallest safe first slice that:
1) validates trust config early, and
2) gives operators a deterministic read-only view of trust metadata.

## How it works
### Files touched
- `internal/config/resolver.go`
  - Added `AgentTrustRule` + `AgentTrustEntry`
  - Added `ResolveAgentTrustConfig(configPath)`
  - Added `AgentTrustScope(trustLevel)` with allowed values:
    - `owner` -> `read:all write:all`
    - `collaborator` -> `read:all write:own`
    - `reader` -> `read:all write:none`
  - Extended config schema with optional `agents:` map
- `cmd/cortex/main.go`
  - `runAgents` now loads/validates trust config before rendering output
  - `agentSummary` now includes trust visibility fields
  - TTY table now includes TRUST + SCOPE columns
  - Added explicit note that this is visibility-only (no cross-agent write enforcement yet)
- `internal/config/resolver_test.go`
  - Added deterministic tests for valid/invalid trust config parsing
- `cmd/cortex/main_test.go`
  - Added deterministic tests for JSON trust visibility, TTY trust visibility, and invalid trust config handling

## Testing done
```bash
go test ./internal/config ./cmd/cortex
go test ./...
```

## Screenshots / before-after
CLI surface change only (no UI). Example `cortex agents` output now includes TRUST/SCOPE columns and a read-only visibility note.

## Breaking changes / risks
None.

Primary risk: `cortex agents` now fails fast when `agents.<id>.trust` is invalid in config. This is intentional validation behavior, but operators with malformed trust config will need to fix it.

## Merge notes
- Bounded #275 slice A only.
- Intentionally out of scope: cross-agent write enforcement, reconciliation engine, shared-fact promotion logic.
- Ready for Hawk deterministic gate before Q review.