### PR TITLE
feat(search): bounded operator-intent query shaping for long prompts (#303 slice A)

### DIFF
--- a/internal/search/query_shape_test.go
+++ b/internal/search/query_shape_test.go
@@ -1,0 +1,81 @@
+package search
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestShapeOperatorIntentQuery_LongWorkflowPrompt(t *testing.T) {
+	query := strings.Join([]string{
+		"Read HEARTBEAT.md if it exists (workspace context). Follow it strictly.",
+		"Do not infer or repeat old tasks from prior chats.",
+		"If nothing needs attention, reply HEARTBEAT_OK.",
+		"Current time: Monday, March 9th, 2026 — 4:30 PM.",
+		"Need operator intent query shaping for long workflow prompts in cortex search.",
+		"Keep the slice bounded and dependency safe.",
+	}, "\n")
+
+	got := shapeOperatorIntentQuery(query)
+	if !got.Applied {
+		t.Fatalf("expected query shaping to apply for long workflow prompt")
+	}
+	if got.RemovedTokens <= 0 {
+		t.Fatalf("expected removed tokens > 0, got %d", got.RemovedTokens)
+	}
+	if strings.Contains(got.Shaped, "heartbeat") {
+		t.Fatalf("expected shaped query to remove heartbeat boilerplate, got %q", got.Shaped)
+	}
+	if !strings.Contains(got.Shaped, "operator") || !strings.Contains(got.Shaped, "workflow") {
+		t.Fatalf("expected shaped query to retain core intent, got %q", got.Shaped)
+	}
+}
+
+func TestShapeOperatorIntentQuery_ShortQueryNoop(t *testing.T) {
+	query := "operator intent query shaping"
+	got := shapeOperatorIntentQuery(query)
+	if got.Applied {
+		t.Fatalf("expected short query not to be shaped")
+	}
+	if got.Shaped != query {
+		t.Fatalf("expected unchanged query %q, got %q", query, got.Shaped)
+	}
+}
+
+func TestSearchExplain_AttachesQueryShape(t *testing.T) {
+	s := newTestStore(t)
+	seedTestData(t, s)
+	engine := NewEngine(s)
+
+	query := strings.Join([]string{
+		"System post-compaction context refresh.",
+		"Read HEARTBEAT.md if it exists and follow it strictly.",
+		"Do not infer old tasks. Reply HEARTBEAT_OK if idle.",
+		"Need Go memory management guidance for garbage collector workflow debugging.",
+		"Operator wants long workflow prompt retrieval shaping.",
+	}, "\n")
+
+	results, err := engine.Search(context.Background(), query, Options{Mode: ModeKeyword, Limit: 5, Explain: true})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("expected search results")
+	}
+	if results[0].Explain == nil || results[0].Explain.QueryShape == nil {
+		t.Fatalf("expected explain.query_shape payload")
+	}
+	qs := results[0].Explain.QueryShape
+	if !qs.Applied {
+		t.Fatalf("expected query_shape.applied=true")
+	}
+	if qs.Raw == "" || qs.Shaped == "" {
+		t.Fatalf("expected raw and shaped query values, got raw=%q shaped=%q", qs.Raw, qs.Shaped)
+	}
+	if strings.Contains(strings.ToLower(qs.Shaped), "heartbeat") {
+		t.Fatalf("expected shaped query without heartbeat boilerplate, got %q", qs.Shaped)
+	}
+	if !strings.Contains(results[0].Explain.Why, "query shaping applied") {
+		t.Fatalf("expected explain.why to mention query shaping, got %q", results[0].Explain.Why)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -58,6 +58,27 @@ var lowSignalIntentQueries = map[string]struct{}{
 	"heartbeat_ok":  {},
 }
 
+const (
+	operatorQueryShapeMinChars  = 120
+	operatorQueryShapeMinTokens = 18
+	operatorQueryShapeMaxTokens = 40
+	queryShapeExplainMaxChars   = 260
+)
+
+var operatorBoilerplateTokens = map[string]struct{}{
+	"read": {}, "follow": {}, "strictly": {}, "infer": {}, "repeat": {}, "prior": {}, "chats": {},
+	"nothing": {}, "needs": {}, "attention": {}, "reply": {}, "heartbeat": {}, "current": {}, "time": {},
+	"relevant": {}, "memories": {}, "local": {}, "knowledge": {}, "base": {}, "conversation": {}, "summary": {},
+	"source": {}, "session": {}, "channel": {}, "message": {}, "system": {}, "assistant": {}, "user": {},
+	"instructions": {}, "format": {}, "output": {}, "include": {}, "section": {}, "sections": {}, "exactly": {},
+	"respond": {}, "post": {}, "compaction": {}, "refresh": {}, "exists": {},
+}
+
+var operatorCueTokens = map[string]struct{}{
+	"heartbeat": {}, "workflow": {}, "operator": {}, "summary": {}, "audit": {}, "session": {},
+	"assistant": {}, "user": {}, "system": {}, "format": {}, "output": {}, "current": {}, "time": {},
+}
+
 var (
 	tradingIntentTokens = map[string]struct{}{
 		"trading": {}, "orb": {}, "breakout": {}, "qqq": {}, "spy": {}, "crypto": {}, "coinbase": {}, "v23": {}, "options": {},
@@ -208,10 +229,20 @@ type Result struct {
 
 // ExplainDetails surfaces provenance and ranking factors for operator trust/debugging.
 type ExplainDetails struct {
-	Provenance     ExplainProvenance `json:"provenance"`
-	Confidence     ExplainConfidence `json:"confidence"`
-	RankComponents RankComponents    `json:"rank_components"`
-	Why            string            `json:"why,omitempty"`
+	Provenance     ExplainProvenance  `json:"provenance"`
+	Confidence     ExplainConfidence  `json:"confidence"`
+	RankComponents RankComponents     `json:"rank_components"`
+	QueryShape     *ExplainQueryShape `json:"query_shape,omitempty"`
+	Why            string             `json:"why,omitempty"`
+}
+
+// ExplainQueryShape captures raw-vs-shaped retrieval query context when query shaping is applied.
+type ExplainQueryShape struct {
+	Raw           string `json:"raw"`
+	Shaped        string `json:"shaped"`
+	Applied       bool   `json:"applied"`
+	RemovedTokens int    `json:"removed_tokens,omitempty"`
+	Reason        string `json:"reason,omitempty"`
 }
 
 type ExplainProvenance struct {
@@ -253,6 +284,14 @@ type RankComponents struct {
 type confidenceDetail struct {
 	confidence          float64
 	effectiveConfidence float64
+}
+
+type queryShapeDecision struct {
+	Raw           string
+	Shaped        string
+	Applied       bool
+	RemovedTokens int
+	Reason        string
 }
 
 // Searcher performs searches across the memory store.
@@ -356,8 +395,15 @@ func (e *Engine) LoadOrBuildHNSW(ctx context.Context, path string, staleThreshol
 // After retrieving results, it applies confidence decay weighting and
 // reinforces facts linked to the returned memories (Ebbinghaus reinforcement-on-recall).
 func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Result, error) {
-	if query == "" {
+	rawQuery := strings.TrimSpace(query)
+	if rawQuery == "" {
 		return nil, nil
+	}
+
+	queryShape := shapeOperatorIntentQuery(rawQuery)
+	retrievalQuery := rawQuery
+	if queryShape.Applied {
+		retrievalQuery = queryShape.Shaped
 	}
 
 	requestedLimit := opts.Limit
@@ -392,13 +438,13 @@ func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Resu
 
 	switch opts.Mode {
 	case ModeKeyword, "":
-		results, err = e.searchBM25(ctx, query, opts)
+		results, err = e.searchBM25(ctx, retrievalQuery, opts)
 	case ModeSemantic:
-		results, err = e.searchSemantic(ctx, query, opts)
+		results, err = e.searchSemantic(ctx, retrievalQuery, opts)
 	case ModeHybrid:
-		results, err = e.searchHybrid(ctx, query, opts)
+		results, err = e.searchHybrid(ctx, retrievalQuery, opts)
 	case ModeRRF:
-		results, err = e.searchRRF(ctx, query, opts)
+		results, err = e.searchRRF(ctx, retrievalQuery, opts)
 	default:
 		return nil, fmt.Errorf("unknown search mode: %q", opts.Mode)
 	}
@@ -429,12 +475,12 @@ func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Resu
 		results = applyClassBoost(results, opts.Explain)
 	}
 
-	results = applyIntentBucketPriors(query, results, opts.Explain)
+	results = applyIntentBucketPriors(retrievalQuery, results, opts.Explain)
 	results = applyCaptureNoisePenalty(results, opts.Explain)
-	results = applyLowSignalIntentSuppression(query, results, opts.Explain)
-	results = applyOffTopicLowSignalSuppression(query, results, opts.Explain)
-	results = applyWrapperNoiseSuppression(query, results, opts.Explain)
-	results = applyLexicalOverlapFilter(query, results, opts.Explain)
+	results = applyLowSignalIntentSuppression(retrievalQuery, results, opts.Explain)
+	results = applyOffTopicLowSignalSuppression(retrievalQuery, results, opts.Explain)
+	results = applyWrapperNoiseSuppression(retrievalQuery, results, opts.Explain)
+	results = applyLexicalOverlapFilter(retrievalQuery, results, opts.Explain)
 
 	// Metadata-aware ranking boosts (Issue #148)
 	results = applyMetadataBoosts(results, opts)
@@ -451,6 +497,7 @@ func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Resu
 
 	if opts.Explain {
 		e.addExplainability(results, confidenceDetails)
+		attachQueryShapeExplain(results, queryShape)
 	}
 
 	if len(results) > requestedLimit {
@@ -773,6 +820,106 @@ func normalizeIntentText(s string) string {
 		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
 	})
 	return strings.Join(parts, " ")
+}
+
+// shapeOperatorIntentQuery condenses long operator workflow prompts by stripping
+// known answer-contract/transport boilerplate tokens while preserving core intent.
+// This is a retrieval-only transform; callers should keep using the raw query for
+// downstream reasoning/answer generation surfaces.
+func shapeOperatorIntentQuery(query string) queryShapeDecision {
+	raw := strings.TrimSpace(query)
+	if raw == "" {
+		return queryShapeDecision{}
+	}
+
+	normalized := normalizeIntentText(raw)
+	tokens := strings.Fields(normalized)
+	if len(raw) < operatorQueryShapeMinChars || len(tokens) < operatorQueryShapeMinTokens {
+		return queryShapeDecision{Raw: raw, Shaped: raw, Applied: false}
+	}
+
+	cueCount := countTokensInSet(tokens, operatorCueTokens)
+	hasStructuredScaffold := strings.Contains(raw, "<") || strings.Contains(raw, "\n") || strings.Contains(raw, "[")
+	if cueCount < 3 && !hasStructuredScaffold {
+		return queryShapeDecision{Raw: raw, Shaped: raw, Applied: false}
+	}
+
+	shapedTokens := make([]string, 0, len(tokens))
+	removed := 0
+	for _, tok := range tokens {
+		if _, drop := operatorBoilerplateTokens[tok]; drop {
+			removed++
+			continue
+		}
+		shapedTokens = append(shapedTokens, tok)
+	}
+
+	if len(shapedTokens) > operatorQueryShapeMaxTokens {
+		removed += len(shapedTokens) - operatorQueryShapeMaxTokens
+		shapedTokens = shapedTokens[:operatorQueryShapeMaxTokens]
+	}
+	if len(shapedTokens) < 5 {
+		return queryShapeDecision{Raw: raw, Shaped: raw, Applied: false}
+	}
+
+	shaped := strings.Join(shapedTokens, " ")
+	if shaped == "" || shaped == normalized {
+		return queryShapeDecision{Raw: raw, Shaped: raw, Applied: false}
+	}
+
+	reason := fmt.Sprintf("long operator prompt condensed (cue_tokens=%d removed_tokens=%d)", cueCount, removed)
+	return queryShapeDecision{
+		Raw:           raw,
+		Shaped:        shaped,
+		Applied:       true,
+		RemovedTokens: removed,
+		Reason:        reason,
+	}
+}
+
+func countTokensInSet(tokens []string, lookup map[string]struct{}) int {
+	n := 0
+	for _, tok := range tokens {
+		if _, ok := lookup[tok]; ok {
+			n++
+		}
+	}
+	return n
+}
+
+func attachQueryShapeExplain(results []Result, shape queryShapeDecision) {
+	if !shape.Applied || len(results) == 0 {
+		return
+	}
+
+	raw := truncateForExplain(shape.Raw, queryShapeExplainMaxChars)
+	shaped := truncateForExplain(shape.Shaped, queryShapeExplainMaxChars)
+	for i := range results {
+		ensureExplain(&results[i])
+		results[i].Explain.QueryShape = &ExplainQueryShape{
+			Raw:           raw,
+			Shaped:        shaped,
+			Applied:       true,
+			RemovedTokens: shape.RemovedTokens,
+			Reason:        shape.Reason,
+		}
+		if results[i].Explain.Why == "" {
+			results[i].Explain.Why = "query shaping applied before retrieval"
+		} else {
+			results[i].Explain.Why += "; query shaping applied before retrieval"
+		}
+	}
+}
+
+func truncateForExplain(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
 }
 
 func isLowSignalCaptureContent(content string) bool {


### PR DESCRIPTION
## What this does
Implements **#303 slice A** as a bounded retrieval-only improvement: long operator workflow prompts are query-shaped before retrieval to reduce answer-contract/transport boilerplate noise.

This slice is intentionally narrow and dependency-safe.

## Problem / Context
Long workflow prompts (especially operator/heartbeat style prompts) often include high-noise boilerplate (`current time`, `reply HEARTBEAT_OK`, session wrappers, etc.).

That noise can dilute retrieval query quality and make top results less focused.

Issue: #303

## How it works
### Retrieval-only query shaping
In `search.Engine.Search`:
- keep `rawQuery` intact
- derive `retrievalQuery` via `shapeOperatorIntentQuery(rawQuery)` **only when prompt is long and operator-scaffold cues are present**
- use `retrievalQuery` for search + ranking filters only

### Guardrails (bounded behavior)
Shaping applies only when all are true:
- query length >= 120 chars
- token count >= 18
- cue/scaffold present (operator/workflow/session/format markers)

Then it:
- strips known boilerplate tokens
- caps shaped query to 40 tokens
- no-op fallback when shaping would be too destructive

### Debug/telemetry visibility
When `--explain` is enabled, each result now includes:
- `explain.query_shape.raw`
- `explain.query_shape.shaped`
- `explain.query_shape.applied`
- `explain.query_shape.removed_tokens`
- `explain.query_shape.reason`

This provides explicit raw-vs-shaped comparison for operator debugging/evidence.

### Files changed
- `internal/search/search.go`
- `internal/search/query_shape_test.go` (new)

## Testing done
Exact commands run:
1. `go test ./internal/search -run 'QueryShape|SearchExplain_AttachesQueryShape|SearchExplain' -count=1`
2. `go test ./...`

## Screenshots / before-after
Terminal/JSON behavior change:
- `search --explain --json` now surfaces `query_shape` when shaping is applied.

## Breaking changes / risks
Breaking changes: **None**.

Concise risk note:
- Main risk is over-shaping/false-positive shaping on atypical long prompts.
- Guardrails + no-op fallback + deterministic tests are included to keep blast radius narrow.
- No ranking-model rewrites and no actionability/reason-lane changes in this PR.

## Explicit out-of-scope (kept for later slices)
- No #304 ranking hardening in this PR.
- No #305 actionability hardening in this PR.
- No lifecycle policy widening.

## Merge notes
- Bounded #303 slice A only.
- Q merges; no direct main merges by Niot.
