### PR TITLE
feat(search): bounded top-1 tie-break hardening for operator retrieval (#304 slice A)

### DIFF
--- a/internal/search/operator_tiebreak_test.go
+++ b/internal/search/operator_tiebreak_test.go
@@ -1,0 +1,66 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyOperatorTop1TieBreak_ReordersNearTop(t *testing.T) {
+	shape := queryShapeDecision{Applied: true}
+	query := "operator workflow runbook retrieval prompt ranking tie break"
+	results := []Result{
+		{MemoryID: 1, Score: 1.00, SourceFile: "notes/general.md", SourceSection: "misc notes", Content: "general memo"},
+		{MemoryID: 2, Score: 0.99, SourceFile: "docs/operator-workflow.md", SourceSection: "operator workflow runbook", Content: "retrieval runbook"},
+		{MemoryID: 3, Score: 0.70, SourceFile: "notes/other.md", SourceSection: "other", Content: "unrelated"},
+	}
+
+	got := applyOperatorTop1TieBreak(shape, query, results, false)
+	if got[0].MemoryID != 2 {
+		t.Fatalf("expected memory_id=2 to win top-1 tie-break, got %d", got[0].MemoryID)
+	}
+}
+
+func TestApplyOperatorTop1TieBreak_NoopWhenNotShaped(t *testing.T) {
+	shape := queryShapeDecision{Applied: false}
+	query := "operator workflow runbook retrieval prompt ranking tie break"
+	results := []Result{
+		{MemoryID: 1, Score: 1.00, SourceFile: "notes/general.md", SourceSection: "misc notes", Content: "general memo"},
+		{MemoryID: 2, Score: 0.99, SourceFile: "docs/operator-workflow.md", SourceSection: "operator workflow runbook", Content: "retrieval runbook"},
+	}
+
+	got := applyOperatorTop1TieBreak(shape, query, results, false)
+	if got[0].MemoryID != 1 {
+		t.Fatalf("expected no-op when query shaping not applied; got top memory_id=%d", got[0].MemoryID)
+	}
+}
+
+func TestApplyOperatorTop1TieBreak_NoopWhenScoresNotNearTop(t *testing.T) {
+	shape := queryShapeDecision{Applied: true}
+	query := "operator workflow runbook retrieval prompt ranking tie break"
+	results := []Result{
+		{MemoryID: 1, Score: 1.00, SourceFile: "notes/general.md", SourceSection: "misc notes", Content: "general memo"},
+		{MemoryID: 2, Score: 0.90, SourceFile: "docs/operator-workflow.md", SourceSection: "operator workflow runbook", Content: "retrieval runbook"},
+	}
+
+	got := applyOperatorTop1TieBreak(shape, query, results, false)
+	if got[0].MemoryID != 1 {
+		t.Fatalf("expected no-op when candidate is outside tie window; got top memory_id=%d", got[0].MemoryID)
+	}
+}
+
+func TestApplyOperatorTop1TieBreak_ExplainAnnotation(t *testing.T) {
+	shape := queryShapeDecision{Applied: true}
+	query := "operator workflow runbook retrieval prompt ranking tie break"
+	results := []Result{
+		{MemoryID: 1, Score: 1.00, SourceFile: "notes/general.md", SourceSection: "misc notes", Content: "general memo", Explain: &ExplainDetails{Why: "base", RankComponents: RankComponents{FinalScore: 1.00}}},
+		{MemoryID: 2, Score: 0.99, SourceFile: "docs/operator-workflow.md", SourceSection: "operator workflow runbook", Content: "retrieval runbook", Explain: &ExplainDetails{Why: "base", RankComponents: RankComponents{FinalScore: 0.99}}},
+	}
+
+	got := applyOperatorTop1TieBreak(shape, query, results, true)
+	if got[0].Explain == nil {
+		t.Fatalf("expected explain payload on top result")
+	}
+	if !strings.Contains(got[0].Explain.Why, "operator top-1 tie-break") {
+		t.Fatalf("expected explain why to mention tie-break, got %q", got[0].Explain.Why)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -63,6 +63,11 @@ const (
 	operatorQueryShapeMinTokens = 18
 	operatorQueryShapeMaxTokens = 40
 	queryShapeExplainMaxChars   = 260
+
+	operatorTop1TieBreakWindow        = 0.03
+	operatorTop1TieBreakMaxCandidates = 5
+	operatorTop1TieBreakMaxBoost      = 0.08
+	operatorTop1OverlapDenominatorCap = 8
 )
 
 var operatorBoilerplateTokens = map[string]struct{}{
@@ -497,6 +502,11 @@ func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Resu
 
 	if opts.Explain {
 		e.addExplainability(results, confidenceDetails)
+	}
+
+	results = applyOperatorTop1TieBreak(queryShape, retrievalQuery, results, opts.Explain)
+
+	if opts.Explain {
 		attachQueryShapeExplain(results, queryShape)
 	}
 
@@ -920,6 +930,113 @@ func truncateForExplain(s string, max int) string {
 		return s[:max]
 	}
 	return s[:max-3] + "..."
+}
+
+// applyOperatorTop1TieBreak hardens top-1 ranking for operator-style prompts by
+// applying a bounded tie-break boost to near-top candidates based on section/file
+// lexical overlap with the (already-shaped) retrieval query.
+func applyOperatorTop1TieBreak(shape queryShapeDecision, query string, results []Result, explain bool) []Result {
+	if !shape.Applied || len(results) < 2 {
+		return results
+	}
+	queryTokens := queryTokenSet(query)
+	if len(queryTokens) == 0 {
+		return results
+	}
+	topScore := results[0].Score
+	if topScore <= 0 {
+		return results
+	}
+
+	candidates := make([]int, 0, operatorTop1TieBreakMaxCandidates)
+	for i := range results {
+		if i >= operatorTop1TieBreakMaxCandidates {
+			break
+		}
+		if results[i].Score >= topScore*(1.0-operatorTop1TieBreakWindow) {
+			candidates = append(candidates, i)
+			continue
+		}
+		if i > 0 {
+			break
+		}
+	}
+	if len(candidates) < 2 {
+		return results
+	}
+
+	applied := false
+	for _, idx := range candidates {
+		signal := operatorTop1TieBreakSignal(queryTokens, results[idx])
+		if signal <= 0 {
+			continue
+		}
+		boost := 1.0 + (signal * operatorTop1TieBreakMaxBoost)
+		results[idx].Score *= boost
+		applied = true
+		if explain {
+			ensureExplain(&results[idx])
+			results[idx].Explain.RankComponents.FinalScore = results[idx].Score
+			msg := fmt.Sprintf("operator top-1 tie-break %.2fx (signal=%.2f)", boost, signal)
+			if results[idx].Explain.Why == "" {
+				results[idx].Explain.Why = msg
+			} else {
+				results[idx].Explain.Why += "; " + msg
+			}
+		}
+	}
+	if !applied {
+		return results
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score == results[j].Score {
+			return results[i].MemoryID > results[j].MemoryID
+		}
+		return results[i].Score > results[j].Score
+	})
+	return results
+}
+
+func operatorTop1TieBreakSignal(queryTokens map[string]struct{}, r Result) float64 {
+	if len(queryTokens) == 0 {
+		return 0
+	}
+	section := overlapCoverage(queryTokens, queryTokenSet(r.SourceSection))
+	source := overlapCoverage(queryTokens, queryTokenSet(r.SourceFile))
+	content := overlapCoverage(queryTokens, queryTokenSet(r.Content))
+	signal := section*0.55 + source*0.30 + content*0.15
+	if signal > 1 {
+		signal = 1
+	}
+	return signal
+}
+
+func overlapCoverage(queryTokens, resultTokens map[string]struct{}) float64 {
+	if len(queryTokens) == 0 || len(resultTokens) == 0 {
+		return 0
+	}
+	matches := 0
+	for tok := range queryTokens {
+		if _, ok := resultTokens[tok]; ok {
+			matches++
+		}
+	}
+	if matches == 0 {
+		return 0
+	}
+	denom := len(queryTokens)
+	if denom > operatorTop1OverlapDenominatorCap {
+		denom = operatorTop1OverlapDenominatorCap
+	}
+	if denom <= 0 {
+		return 0
+	}
+	coverage := float64(matches) / float64(denom)
+	if coverage > 1 {
+		coverage = 1
+	}
+	return coverage
 }
 
 func isLowSignalCaptureContent(content string) bool {


### PR DESCRIPTION
## What this does
Implements **#304 slice A** as a bounded ranking hardening pass for operator-style retrieval.

Focus: improve **top-1 tie-break behavior** for long operator prompts after #303 query shaping.

## Problem / Context
After #303, long operator prompts are cleaner at retrieval input, but near-tie top candidates can still rank in the wrong order for operator intent.

Issue: #304

## How it works
### Bounded operator top-1 tie-break
Added a narrow, deterministic post-retrieval tie-break stage in `search.Engine.Search`:
- only runs when query shaping was applied (`#303` signal)
- only considers near-top candidates (within 3% of top score, top 5 max)
- computes tie-break signal from query-token overlap with:
  - `SourceSection` (highest weight)
  - `SourceFile`
  - `Content` (lowest weight)
- applies small bounded boost (max +8%) to break near ties toward operator-relevant section/file matches

### Explainability (operator trust)
When `--explain` is enabled, tie-break appends reason text:
- `operator top-1 tie-break <boost>x (signal=<...>)`

This keeps top-1 movement auditable for Hawk/Q.

### Files changed
- `internal/search/search.go`
- `internal/search/operator_tiebreak_test.go` (new)

## Testing done
Exact commands run:
1. `go test ./internal/search -run 'OperatorTop1TieBreak|QueryShape|SearchExplain' -count=1`
2. `go test ./...`

## Screenshots / before-after
Terminal/JSON behavior change (operator explain mode):
- top results can now include tie-break rationale in `explain.why`
- no CLI flag changes required

## Breaking changes / risks
Breaking changes: **None**.

Concise risk note for Hawk:
- Primary risk is over-boosting atypical long prompts (false-positive tie-break influence).
- Mitigations: strict activation gate (must be shaped), narrow candidate window, small bounded boost, deterministic tests.

## Explicit out-of-scope
- No #305 actionability/reason changes.
- No release packaging.
- No lifecycle/benchmark lane widening.

## Merge notes
- Bounded #304 slice A only.
- Q merges; Niot does not merge.
