### PR TITLE
feat(reason): deterministic actionability contract repair (#305 slice A)

### DIFF
--- a/internal/reason/quality_contract.go
+++ b/internal/reason/quality_contract.go
@@ -1,6 +1,7 @@
 package reason
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -16,8 +17,11 @@ var (
 )
 
 func enforceResponseQualityContract(content, query string) string {
-	_ = query
-	return strings.TrimSpace(content)
+	cleaned := strings.TrimSpace(content)
+	if !needsContractRepair(cleaned) {
+		return cleaned
+	}
+	return buildContractRepair(cleaned, query)
 }
 
 func needsContractRepair(content string) bool {
@@ -61,4 +65,52 @@ func sectionBody(content, header string) string {
 		body = body[:next]
 	}
 	return body
+}
+
+func buildContractRepair(content, query string) string {
+	excerpt := summarizeSnippet(content, 420)
+	if excerpt == "" {
+		excerpt = "No substantive model output was produced."
+	}
+
+	focus := summarizeSnippet(query, 140)
+	if focus == "" {
+		focus = "operator request"
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## Summary\n")
+	sb.WriteString("The original response was too thin or structurally incomplete for operator use, so this repaired output preserves intent while restoring the required decision-ready format. ")
+	sb.WriteString(fmt.Sprintf("Query focus: %q.\n\n", focus))
+
+	sb.WriteString("## Evidence\n")
+	sb.WriteString("- Recovered source excerpt: \"")
+	sb.WriteString(excerpt)
+	sb.WriteString("\"\n")
+	sb.WriteString("- Structural gate outcome: required headers/action labels were missing or incomplete, which reduced actionability confidence.\n")
+	sb.WriteString("- Confidence status: Uncertain until evidence claims are validated directly against source memories/facts.\n\n")
+
+	sb.WriteString("## Conflicts & Trade-offs\n")
+	sb.WriteString("- Uncertain: this repair adds deterministic structure, but cannot invent missing evidence beyond the original content.\n")
+	sb.WriteString("- Trade-off: enforcing structure improves execution readiness, while preserving the excerpt avoids hallucinating unsupported claims.\n")
+	sb.WriteString("- Risk: acting without validation can still propagate stale context, so verification remains mandatory.\n\n")
+
+	sb.WriteString("## Next Actions\n")
+	sb.WriteString("- Priority: High | Owner: Operator | Timeline: Now | Recommendation: Re-run `cortex reason` for the same prompt and compare sections against this repaired draft before execution. | Impact: Confirms current context and reduces hard-failure risk.\n")
+	sb.WriteString("- Priority: High | Owner: Operator | Timeline: Today | Recommendation: Validate key claims against cited memories/facts and mark anything unresolved as Uncertain. | Impact: Improves factual grounding and contradiction safety.\n")
+	sb.WriteString("- Priority: Medium | Owner: Operator | Timeline: Today | Recommendation: Convert accepted recommendations into a checklist with explicit assignees and due times. | Impact: Raises actionability and execution follow-through.\n")
+	sb.WriteString("- Priority: Medium | Owner: Operator | Timeline: This week | Recommendation: Capture missing constraints discovered during validation and feed them into the next reason-quality eval pass. | Impact: Prevents repeat low-structure outputs.\n")
+
+	return strings.TrimSpace(sb.String())
+}
+
+func summarizeSnippet(text string, maxLen int) string {
+	trimmed := strings.Join(strings.Fields(strings.TrimSpace(text)), " ")
+	if maxLen <= 0 || len(trimmed) <= maxLen {
+		return trimmed
+	}
+	if maxLen <= 3 {
+		return trimmed[:maxLen]
+	}
+	return trimmed[:maxLen-3] + "..."
 }

--- a/internal/reason/quality_contract_test.go
+++ b/internal/reason/quality_contract_test.go
@@ -5,24 +5,27 @@ import (
 	"testing"
 )
 
-func TestNeedsContractRepair(t *testing.T) {
-	good := `## Summary
-This is a sufficiently long summary with context and operational detail so it is not considered too short. It includes references to risk, impact, and decision outcomes to keep usefulness high.
+const compliantReasonOutput = `## Summary
+This is a sufficiently long summary with context and operational detail so it is not considered too short. It includes references to risk, impact, and decision outcomes to keep usefulness high. It also states execution assumptions so operators can verify what is known versus what still needs confirmation.
 
 ## Evidence
 - Source: memory and fact review completed.
 - Fact confidence: key facts validated with confidence tags.
+- Provenance note: references are consistent with the latest indexed workspace snapshots and no obvious stale source was promoted as current truth.
 
 ## Conflicts & Trade-offs
 - Uncertain: one source may be stale and needs verification.
 - Trade-off: speed vs depth is an active conflict.
+- Constraint: raising confidence requires additional source checks that slow immediate execution.
 
 ## Next Actions
 - Priority: High | Owner: A | Timeline: Today | Recommendation: Verify source links. | Impact: Better grounding.
 - Priority: High | Owner: A | Timeline: Tomorrow | Recommendation: Patch weak prompt terms. | Impact: Better actionability.
 - Priority: Medium | Owner: A | Timeline: This week | Recommendation: Re-run eval and guardrails. | Impact: Fewer regressions.
 `
-	if needsContractRepair(good) {
+
+func TestNeedsContractRepair(t *testing.T) {
+	if needsContractRepair(compliantReasonOutput) {
 		t.Fatal("expected good content not to need repair")
 	}
 
@@ -32,10 +35,34 @@ This is a sufficiently long summary with context and operational detail so it is
 	}
 }
 
-func TestEnforceResponseQualityContract_LeavesModelOutputUntouched(t *testing.T) {
-	in := "brief"
-	out := enforceResponseQualityContract(in, "test query")
-	if strings.TrimSpace(out) != in {
-		t.Fatalf("expected output to remain unchanged, got %q", out)
+func TestEnforceResponseQualityContract_PreservesCompliantOutput(t *testing.T) {
+	out := enforceResponseQualityContract(compliantReasonOutput, "operator follow-up")
+	if strings.TrimSpace(out) != strings.TrimSpace(compliantReasonOutput) {
+		t.Fatalf("expected compliant output to remain unchanged")
+	}
+}
+
+func TestEnforceResponseQualityContract_RepairsThinOutput(t *testing.T) {
+	out := enforceResponseQualityContract("brief", "weekly architecture review")
+
+	for _, expected := range []string{
+		"## Summary",
+		"## Evidence",
+		"## Conflicts & Trade-offs",
+		"## Next Actions",
+		"Priority:",
+		"Owner:",
+		"Timeline:",
+		"Recommendation:",
+		"Impact:",
+		"weekly architecture review",
+	} {
+		if !strings.Contains(out, expected) {
+			t.Fatalf("expected repaired output to contain %q\noutput:\n%s", expected, out)
+		}
+	}
+
+	if !nextActionBulletRE.MatchString(sectionBody(out, "## Next Actions")) {
+		t.Fatalf("expected repaired next actions to include bullet lines")
 	}
 }


### PR DESCRIPTION
## What this does
Implements a **bounded #305 slice A** to harden actionability when reason output is thin/unstructured.

When the LLM output fails the existing response-quality contract, we now deterministically repair it into an operator-ready format instead of returning raw low-action text.

## Problem / Context
Issue: #305

Recent reason quality runs identified actionability + hard-failure weakness. We already had contract detection (`needsContractRepair`) but no enforced repair path in runtime output.

## How it works
### Runtime enforcement (bounded)
- `enforceResponseQualityContract` now:
  - keeps compliant outputs unchanged
  - repairs only outputs that fail structural/actionability checks
- Added deterministic repair builder that emits required sections:
  - `## Summary`
  - `## Evidence`
  - `## Conflicts & Trade-offs`
  - `## Next Actions`
- Repaired `Next Actions` include explicit labels (`Priority/Owner/Timeline/Recommendation/Impact`) and operator-safe verification language.
- Query focus is threaded into repaired output to preserve request context.

### Files touched
- `internal/reason/quality_contract.go`
- `internal/reason/quality_contract_test.go`

## Testing done
Exact commands run:
1. `go test ./internal/reason -run 'QualityContract|NeedsContractRepair' -count=1`
2. `go test ./internal/reason -count=1`
3. `go test ./...`

## Screenshots / before-after
Terminal/behavioral before-after:
- **Before:** thin output (e.g. `brief`) passed through unchanged.
- **After:** thin output is repaired into contract-compliant sections with actionable Next Actions labels.

## Breaking changes / risks
Breaking changes: **None**.

Concise risk note:
- Primary risk is over-normalization for intentionally short outputs.
- Mitigation: repair is gated by existing contract checks; compliant outputs are untouched.

## Explicit out-of-scope
- No #304 ranking/tie-break work.
- No #313 ANN panic hardening.
- No reason eval gate threshold changes.

## Merge notes
- Bounded #305 slice A only.
- Q merges; Niot does not merge.