### PR TITLE
fix(ci): repair reason-quality-eval-nightly workflow file failure (#314)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Guard workflow `if` expressions against direct secrets context
+        run: |
+          if grep -RInE "^[[:space:]]*if:[[:space:]]*\$\{\{[[:space:]]*secrets\." .github/workflows/*.yml; then
+            echo "Direct secrets.* in if expressions is invalid; use env indirection (see #314)."
+            exit 1
+          fi
+
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'

--- a/.github/workflows/reason-quality-eval-nightly.yml
+++ b/.github/workflows/reason-quality-eval-nightly.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   reason-quality-eval:
     runs-on: ubuntu-latest
+    env:
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4
@@ -24,9 +26,7 @@ jobs:
         run: mkdir -p tests/output/reason-eval
 
       - name: Run nightly eval (if API key available)
-        if: ${{ secrets.OPENROUTER_API_KEY != '' }}
-        env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        if: ${{ env.OPENROUTER_API_KEY != '' }}
         run: |
           python3 scripts/reason_quality_eval.py \
             --binary /tmp/cortex \
@@ -36,7 +36,7 @@ jobs:
             --timeout-sec 300
 
       - name: Reliability guardrail gate (Track 2)
-        if: ${{ secrets.OPENROUTER_API_KEY != '' }}
+        if: ${{ env.OPENROUTER_API_KEY != '' }}
         run: |
           latest_json=$(ls -1t tests/output/reason-eval/reason-quality-eval-*.json | head -n 1)
           python3 scripts/reason_guardrail_gate.py \
@@ -54,7 +54,7 @@ jobs:
             --output tests/output/reason-eval/reason-outcome-rollup.json
 
       - name: Dry-run eval plan (fallback when no API key)
-        if: ${{ secrets.OPENROUTER_API_KEY == '' }}
+        if: ${{ env.OPENROUTER_API_KEY == '' }}
         run: |
           python3 scripts/reason_quality_eval.py \
             --fixture tests/fixtures/reason/eval-set-v1.json \


### PR DESCRIPTION
## What this does
Repairs `.github/workflows/reason-quality-eval-nightly.yml` so GitHub Actions accepts the workflow file on `main` again.

Also adds a tiny pre-merge guard in CI to catch this exact workflow-file class before merge.

## Problem / Context
Issue: #314

Root cause was workflow-file validation failure (not benchmark logic):
- nightly workflow used `secrets.OPENROUTER_API_KEY` directly inside step `if:` expressions
- GitHub rejects direct `secrets.*` in `if:` expressions at workflow-parse time
- evidence from failed run (`22954659012`) shows:
  - `Invalid workflow file`
  - `Unrecognized named-value: 'secrets'` at the `if:` lines

## How it works
### 1) Fix nightly workflow validity
File: `.github/workflows/reason-quality-eval-nightly.yml`
- added job-level env indirection:
  - `OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}`
- changed step guards from:
  - `if: ${{ secrets.OPENROUTER_API_KEY != '' }}`
  - `if: ${{ secrets.OPENROUTER_API_KEY == '' }}`
- to:
  - `if: ${{ env.OPENROUTER_API_KEY != '' }}`
  - `if: ${{ env.OPENROUTER_API_KEY == '' }}`

### 2) Small pre-merge prevention step
File: `.github/workflows/ci.yml`
- added a cheap guard step that fails CI if any workflow contains direct `secrets.*` usage in `if:` expressions
- this prevents recurrence of the same parse-time breakage class before merge

## Testing done
Exact commands run:
1. `go test ./...`
2. `if grep -RInE "^[[:space:]]*if:[[:space:]]*\$\{\{[[:space:]]*secrets\." .github/workflows/*.yml; then echo "found invalid secrets-if"; exit 1; else echo "workflow-if guard check passed"; fi`

## Screenshots / before-after
Terminal evidence (pre-fix root cause):
- `Invalid workflow file`
- `(Line: 27, Col: 13): Unrecognized named-value: 'secrets'`
- `(Line: 39, Col: 13): Unrecognized named-value: 'secrets'`
- `(Line: 57, Col: 13): Unrecognized named-value: 'secrets'`

## Breaking changes / risks
Breaking changes: **None**.

Risk note:
- CI guard regex is intentionally narrow to this failure class; low false-positive risk, but future edge cases may need guard pattern tuning.

## Merge notes
- Bounded #314 workflow fix only.
- No benchmark logic changes.
- No widening into #318/#320 or search/retrieval code.
