### PR TITLE
fix(plugin): keep collapsed-hit detail marker visible in #318-lite packing (#326)

### DIFF
--- a/plugin/recall.test.ts
+++ b/plugin/recall.test.ts
@@ -64,6 +64,34 @@ test("buildRecallPlan collapses same source hits with provenance-safe metadata",
   assert.equal(plan.manifest.selected[0]?.packed_hits, 2);
 });
 
+test("buildRecallPlan keeps collapsed marker + secondary detail under long primary snippet", () => {
+  const raw = [
+    makeResult({
+      memory_id: 10,
+      score: 0.99,
+      source_file: "project-alpha/notes.md",
+      source_section: "runbook",
+      content: "A".repeat(1200),
+    }),
+    makeResult({
+      memory_id: 11,
+      score: 0.95,
+      source_file: "project-alpha/notes.md",
+      source_section: "runbook",
+      content: "secondary critical detail token for collapsed tail visibility",
+    }),
+  ];
+
+  const plan = buildRecallPlan(raw, raw, { limit: 3, budgetChars: 5000 });
+  assert.equal(plan.selected.length, 1);
+
+  const packed = plan.selected[0];
+  assert.equal(packed?.packed_hits, 2);
+  assert.ok((packed?.content || "").includes("[collapsed 2 same-source hits:"));
+  assert.ok((packed?.content || "").includes("secondary"));
+  assert.ok((packed?.content || "").length <= 520);
+});
+
 test("buildRecallPlan drops deterministically under hard budget", () => {
   const longA = "A".repeat(900);
   const longB = "B".repeat(900);

--- a/plugin/recall.ts
+++ b/plugin/recall.ts
@@ -69,6 +69,7 @@ const maxRecallLimit = 20;
 const maxPackedPreviewsPerSource = 3;
 const maxPackedPreviewChars = 140;
 const maxPackedContentChars = 520;
+const minCollapsedTailChars = 24;
 
 function normalizeRecallLimit(limit: number): number {
   if (!Number.isFinite(limit)) return 3;
@@ -158,8 +159,20 @@ function collapseSameSourceHits(hits: RecallResult[]): string {
   }
 
   const tail = previews.slice(1).join(" | ");
-  const combined = `${previews[0]} [collapsed ${hits.length} same-source hits: ${tail}]`;
-  return truncate(combined, maxPackedContentChars);
+  const collapsePrefix = ` [collapsed ${hits.length} same-source hits: `;
+  const collapseSuffix = "]";
+
+  const minTailBudget = Math.min(minCollapsedTailChars, Math.max(1, tail.length));
+  const primaryBudget = Math.max(40, maxPackedContentChars - collapsePrefix.length - collapseSuffix.length - minTailBudget);
+  const primary = truncate(previews[0], primaryBudget);
+
+  const tailBudget = Math.max(
+    minTailBudget,
+    maxPackedContentChars - primary.length - collapsePrefix.length - collapseSuffix.length,
+  );
+  const tailPreview = truncate(tail, tailBudget);
+
+  return `${primary}${collapsePrefix}${tailPreview}${collapseSuffix}`;
 }
 
 function buildPackedCandidates(rankedResults: RecallResult[]): PackedRecallCandidate[] {


### PR DESCRIPTION
## What this does
Fixes the #318-lite transparency defect tracked in **#326** by ensuring packed same-source entries retain the collapse-detail marker/tail even when the primary snippet is very long.

## Problem / Context
Issue: #326

Dogfood showed this defect on `main`:
- grouped packed entry had `packed_hits > 1`
- but packed content sometimes lost `[collapsed ...]` tail after truncation
- this reduced hidden-detail transparency under prompt budget pressure

Root cause:
- `collapseSameSourceHits` concatenated `primary + [collapsed ...: tail]`
- then truncated the full combined string to `maxPackedContentChars`
- long primary snippet consumed the whole cap and cut off marker/tail

## How it works
File: `plugin/recall.ts`

- Added bounded budgeting logic inside `collapseSameSourceHits`:
  - reserve a minimum tail budget (`minCollapsedTailChars`) for the collapse marker/tail
  - trim primary content budget first
  - then fit tail into remaining space
- Result: for multi-hit packed entries, packed content keeps collapse marker + secondary detail token while staying under existing caps.

No architecture changes. No storage changes. No #320 behavior.

## Tests added
File: `plugin/recall.test.ts`

New deterministic regression test:
- `buildRecallPlan keeps collapsed marker + secondary detail under long primary snippet`
- verifies for long-primary same-source packed entry:
  - `packed_hits === 2`
  - packed content includes `[collapsed 2 same-source hits:`
  - packed content includes secondary detail token
  - packed content remains within cap (`<= 520`)

## Testing done
Exact commands run:
1. `node --check plugin/index.ts`
2. `node --check plugin/recall.ts`
3. `node --test plugin/*.test.ts`
4. `go test ./...`

## Integrated dogfood rerun (post-fix)
Reran integrated recall-lane operator pass on main-equivalent branch with the same prompt set (+ defect repro prompt).

Observed on defect repro prompt (`Q merged 323 then 324 then 325 next 318 lite`):
- packed entry retained marker/tail:
  - snippet evidence: `... [collapsed 2 same-source hits: - Mister told Q he wi...]`
- transparency defect no longer reproduced.

## Breaking changes / risks
Breaking changes: **None**.

Risk note:
- Slightly more aggressive truncation of primary snippet in packed multi-hit entries to preserve collapse-tail transparency.
- This is intentional and bounded to `packed_hits > 1` paths.

## Out of scope (enforced)
- no #320 widening
- no summary-store or full #318 architecture work
- no retrieval/ranking model changes

## Merge notes
- Bounded #326 follow-up only.
- After merge, this should close the dogfood transparency gap without promoting #320.
