### PR TITLE
fix(search): harden HNSW load/rebuild against malformed-length persisted state (#313)

### DIFF
--- a/internal/ann/hnsw_test.go
+++ b/internal/ann/hnsw_test.go
@@ -330,6 +330,60 @@ func TestLoadRejectsCorruptNodeLevelWithoutPanicking(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsMalformedFriendCountWithoutPanicking(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "malformed-friend-count.hnsw")
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create malformed file: %v", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write([]byte(magic)); err != nil {
+		t.Fatalf("write magic: %v", err)
+	}
+	write := func(v int32) {
+		t.Helper()
+		if err := binary.Write(f, binary.LittleEndian, v); err != nil {
+			t.Fatalf("write int32 %d: %v", v, err)
+		}
+	}
+	write(1)   // version
+	write(2)   // dims
+	write(1)   // nodeCount
+	write(0)   // entryPoint
+	write(0)   // maxLevel
+	write(16)  // M
+	write(32)  // Mmax0
+	write(200) // EfConstruction
+	write(50)  // EfSearch
+
+	if err := binary.Write(f, binary.LittleEndian, int64(42)); err != nil {
+		t.Fatalf("write node id: %v", err)
+	}
+	write(0) // valid level
+	if err := binary.Write(f, binary.LittleEndian, float32(0.1)); err != nil {
+		t.Fatalf("write vec[0]: %v", err)
+	}
+	if err := binary.Write(f, binary.LittleEndian, float32(0.2)); err != nil {
+		t.Fatalf("write vec[1]: %v", err)
+	}
+	write(2147483647) // malformed friend count (len out-of-range case)
+
+	if err := f.Close(); err != nil {
+		t.Fatalf("close malformed file: %v", err)
+	}
+
+	_, err = Load(path)
+	if err == nil {
+		t.Fatal("expected error for malformed friend count")
+	}
+	if got := err.Error(); got == "" || !containsAny(got, []string{"invalid value", "corrupt persisted data"}) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // --- Distance Tests ---
 
 func TestCosineDistance(t *testing.T) {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -339,21 +339,54 @@ func (e *Engine) BuildHNSW(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 
-	// Detect dimensions from first embedding
-	firstVec, err := e.store.GetEmbedding(ctx, ids[0])
-	if err != nil {
-		return 0, fmt.Errorf("getting first embedding: %w", err)
+	var (
+		idx                   *ann.Index
+		expectedDims          int
+		skippedDimensionCount int
+		skippedLoadErrorCount int
+	)
+
+	for _, id := range ids {
+		vec, err := e.store.GetEmbedding(ctx, id)
+		if err != nil {
+			skippedLoadErrorCount++
+			continue // keep building from remaining embeddings
+		}
+		if len(vec) == 0 {
+			skippedDimensionCount++
+			continue
+		}
+
+		if idx == nil {
+			expectedDims = len(vec)
+			idx = ann.New(expectedDims)
+		}
+
+		if len(vec) != expectedDims {
+			skippedDimensionCount++
+			continue
+		}
+
+		idx.Insert(id, vec)
 	}
 
-	idx := ann.New(len(firstVec))
-	idx.Insert(ids[0], firstVec)
-
-	for i := 1; i < len(ids); i++ {
-		vec, err := e.store.GetEmbedding(ctx, ids[i])
-		if err != nil {
-			continue // skip errors, don't abort entire build
+	if idx == nil || idx.Len() == 0 {
+		e.hnsw = nil
+		if skippedLoadErrorCount > 0 {
+			return 0, fmt.Errorf("building HNSW: no usable embeddings (load errors=%d)", skippedLoadErrorCount)
 		}
-		idx.Insert(ids[i], vec)
+		return 0, nil
+	}
+
+	if skippedDimensionCount > 0 || skippedLoadErrorCount > 0 {
+		fmt.Fprintf(
+			os.Stderr,
+			"warning: HNSW build skipped %d embeddings (dimension mismatch/empty) and %d load errors; indexed %d vectors with %d dims\n",
+			skippedDimensionCount,
+			skippedLoadErrorCount,
+			idx.Len(),
+			expectedDims,
+		)
 	}
 
 	e.hnsw = idx

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -170,6 +170,71 @@ func TestLoadOrBuildHNSW_RebuildsCorruptPersistedIndex(t *testing.T) {
 	}
 }
 
+func TestBuildHNSW_SkipsMismatchedEmbeddingDimensionsAndPersistsValidIndex(t *testing.T) {
+	s, dbPath := newFileBackedTestStore(t)
+	ctx := context.Background()
+
+	memA, err := s.AddMemory(ctx, &store.Memory{
+		Content:       "embedding dims 3 A",
+		SourceFile:    "dims-test.md",
+		SourceLine:    1,
+		SourceSection: "tests",
+	})
+	if err != nil {
+		t.Fatalf("AddMemory A: %v", err)
+	}
+	if err := s.AddEmbedding(ctx, memA, []float32{0.1, 0.2, 0.3}); err != nil {
+		t.Fatalf("AddEmbedding A: %v", err)
+	}
+
+	memB, err := s.AddMemory(ctx, &store.Memory{
+		Content:       "embedding dims 2 B (mismatch)",
+		SourceFile:    "dims-test.md",
+		SourceLine:    2,
+		SourceSection: "tests",
+	})
+	if err != nil {
+		t.Fatalf("AddMemory B: %v", err)
+	}
+	if err := s.AddEmbedding(ctx, memB, []float32{0.9, 0.8}); err != nil {
+		t.Fatalf("AddEmbedding B: %v", err)
+	}
+
+	memC, err := s.AddMemory(ctx, &store.Memory{
+		Content:       "embedding dims 3 C",
+		SourceFile:    "dims-test.md",
+		SourceLine:    3,
+		SourceSection: "tests",
+	})
+	if err != nil {
+		t.Fatalf("AddMemory C: %v", err)
+	}
+	if err := s.AddEmbedding(ctx, memC, []float32{0.7, 0.6, 0.5}); err != nil {
+		t.Fatalf("AddEmbedding C: %v", err)
+	}
+
+	engine := NewEngine(s)
+	count, err := engine.BuildHNSW(ctx)
+	if err != nil {
+		t.Fatalf("BuildHNSW: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("BuildHNSW count = %d, want 2 (mismatched dims should be skipped)", count)
+	}
+
+	hnswPath := filepath.Join(filepath.Dir(dbPath), "hnsw.idx")
+	if err := engine.SaveHNSW(hnswPath); err != nil {
+		t.Fatalf("SaveHNSW: %v", err)
+	}
+	loaded, err := ann.Load(hnswPath)
+	if err != nil {
+		t.Fatalf("ann.Load persisted index: %v", err)
+	}
+	if loaded.Len() != 2 {
+		t.Fatalf("persisted index len = %d, want 2", loaded.Len())
+	}
+}
+
 // --- BM25 Keyword Search ---
 
 func TestSearchBM25_SingleTerm(t *testing.T) {


### PR DESCRIPTION
## What this does
Implements a bounded reliability fix for **#313** so malformed ANN/HNSW persisted state no longer causes repeated unstable load/rebuild loops and potential panic-adjacent behavior.

This keeps the lane strictly reliability-focused (no ranking/search-quality widening).

## Problem / Context
Issue: #313

Observed on current `main` + current DB shape:
- repeated HNSW load failures on every semantic/hybrid search run:
  - `warning: could not load HNSW index ... friend count: invalid value -1152003907; rebuilding`
- this indicates malformed persisted index state was being rebuilt into another malformed persisted index, causing repeated degraded behavior.

Root cause:
- `BuildHNSW` assumed all stored embeddings share dimensions of the first vector.
- mixed-dimension embedding rows were inserted into HNSW without dimension filtering.
- persisted file could become structurally invalid for `ann.Load` parse expectations (malformed-length style failure surface).

## How it works
### 1) Harden HNSW build path against mixed/malformed dimensions
File: `internal/search/search.go`

`BuildHNSW` now:
- discovers first usable embedding dimensions
- skips embeddings with empty or mismatched dimensions
- continues building from valid vectors only
- logs a bounded warning summary with skipped counts and indexed dims

This prevents persisting malformed HNSW structure from mixed-dimension rows.

### 2) Add deterministic regression for malformed-length load case
Files:
- `internal/ann/hnsw_test.go`
- `internal/search/search_test.go`

Added tests:
- `TestLoadRejectsMalformedFriendCountWithoutPanicking`
  - covers malformed-length friend-count load case explicitly
- `TestBuildHNSW_SkipsMismatchedEmbeddingDimensionsAndPersistsValidIndex`
  - proves mixed-dimension embedding store no longer produces invalid persisted index

## Repro/disprove evidence on current main/current DB shape
Baseline (`/tmp/cortex-313-main`, 10 semantic/hybrid runs):
- `main_warnings=10` (load failure + rebuild every run)
- recurring message: `friend count: invalid value -1152003907; rebuilding`

Fixed branch build (`/tmp/cortex-313-fix-bin`, same 10 runs):
- `load_warnings=1`
- `skip_warnings=1`
- first run rebuilds once, then subsequent runs no repeated malformed-load warnings

This demonstrates graceful recovery to stable persisted state.

## Testing done
Exact commands run:
1. `go test ./internal/ann -run 'RejectsCorruptNodeLevel|RejectsMalformedFriendCount' -count=1`
2. `go test ./internal/search -run 'LoadOrBuildHNSW_RebuildsCorruptPersistedIndex|BuildHNSW_SkipsMismatchedEmbeddingDimensionsAndPersistsValidIndex' -count=1`
3. `go test ./...`
4. Runtime repro loop on current DB with baseline and fixed binaries (10 semantic/hybrid runs each)

## Screenshots / before-after
Terminal before/after evidence:
- Before: malformed HNSW load warning on every run
- After: one-time rebuild warning, then stable runs

## Breaking changes / risks
Breaking changes: **None**.

Risk note:
- mixed-dimension embeddings are now skipped from HNSW build (rather than silently inserted), so ANN index cardinality may be lower than total embedding rows when DB contains dim drift.
- This is intentional for reliability; skipped counts are surfaced in warning output.

## Explicit out-of-scope
- no ranking/search-quality tuning
- no recall-lane packaging changes
- no #320 / architecture widening

## Merge notes
- Bounded #313 reliability fix only.
- Q merges; Niot does not merge.
