### PR TITLE
docs(release): refresh v1.2.4 package notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,45 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [1.2.4] - 2026-03-08
+## [1.2.4] - 2026-03-11
 
-### 🛠️ v1.2.4 — Operator Maintenance + Trust Hardening
+### 🛠️ v1.2.4 — Operator Retrieval + Recall Packaging + Reliability Hardening
 
-Patch release that packages the merged operator/trust hardening lane into a coherent maintenance release.
+Release that packages the post-`v1.2.3` operator-quality wave into one honest cut: stronger operator retrieval, a cleaner OpenClaw happy path, bounded recall packaging, workflow repair, and ANN/HNSW reliability hardening.
 
-#### Operator visibility + maintenance safety
-- **Belief/operator surface:** `cortex beliefs` lifecycle visibility + manual state controls (`promote`, `retire`, `activate`, `set`).
-- **Lifecycle explainability:** `cortex lifecycle run` now reports per-policy skip stats (for example `needs_reinforcements`, `too_fresh`, `confidence_too_high`) so zero-action runs are diagnosable.
-- **Safe per-source refresh path:** `cortex refresh-source <path>` and `store.DeleteMemoriesBySourceFile` provide isolated, source-scoped refresh/repair without touching unrelated memories.
-- **Source-scoped embedding completion:** source-level embed repair/finish paths now reduce broad blast radius during maintenance workflows.
+#### Operator retrieval + actionability
+- **Trust visibility surface:** better visibility into Cortex trust boundaries and agent-facing operator state.
+- **Operator-intent query shaping:** retrieval path now shapes long workflow prompts without mutating the raw query surface.
+- **Top-1 tie-break hardening:** operator-style retrieval is more stable when multiple candidates compete closely.
+- **Deterministic actionability repair:** operator outputs preserve a cleaner actionability contract for downstream use.
 
-#### Trust + signal quality hardening
-- **Doctor false-warning fix:** provider-only LLM config is treated as resolved in `cortex doctor` (issue #301 closed by merged work in this lane).
-- **Hybrid search auto-embedder resolution:** `--mode hybrid|rrf|semantic` auto-resolves embed provider from config/env when available, with graceful BM25 fallback.
-- **Predicate-aware conflict detection:** `cortex conflicts` suppresses obviously multi-valued append-only predicates from attribute-conflict noise.
-- **Extraction noise hardening:** preserves hierarchical section paths, suppresses URL/envelope noise, and tightens subject semantics (`MaxSubjectLength` 50→40 plus natural-language date subject filtering).
-- **Docs sync:** architecture/deep-dive docs updated to reflect current search and trust-hardening behavior.
+#### OpenClaw setup + recall packaging
+- **Canonical OpenClaw happy path:** clearer zero-to-working Cortex + OpenClaw setup flow.
+- **Bounded recall manifest selection:** recall injection now plans against a hard budget instead of naïve slice-only behavior.
+- **Grouped recall packing:** same-lane recall can be packed more usefully by project/file/section.
+- **Packed-entry transparency follow-up:** collapsed same-source detail remains visible in packed output instead of disappearing under long primary snippets.
+
+#### Reliability + CI hardening
+- **Reason-quality nightly workflow repaired:** the broken nightly eval workflow runs cleanly again on `main`.
+- **ANN/HNSW malformed-state hardening:** malformed persisted ANN state no longer causes repeated unstable load/rebuild loops; rebuilds recover to a stable state.
 
 #### Included PRs
-- **#302** — feat: harden Cortex search, lifecycle, and conflict trust signals
+- **#312** — trust visibility
+- **#315** — operator-intent query shaping (#303 slice A)
+- **#316** — top-1 ranking hardening (#304 slice A)
+- **#317** — deterministic actionability repair (#305 slice A)
+- **#322** — canonical OpenClaw happy path (#321)
+- **#323** — bounded recall manifest budget selection (#319 slice A)
+- **#324** — reason-quality nightly workflow repair (#314)
+- **#325** — grouped recall packing for #318-lite
+- **#327** — collapsed-hit detail marker visibility follow-up (#326)
+- **#328** — ANN/HNSW malformed-state reliability hardening (#313)
 
-#### Not shipped in v1.2.4
-- **#308** (`feat(beliefs): add read-only conviction inspect operator surface`) remains open/queued and is intentionally excluded from this release cut.
+#### Not fully shipped in v1.2.4
+- **#318** remains broader than the shipped `#318-lite` harvest.
+- **#319** remains broader than shipped Slice A.
+- **#320** (ghost cues + archive stubs) remains intentionally held and is not part of this release.
+- **#307** remains the broader operator-mode umbrella beyond the shipped bounded slices.
 
 ## [1.2.3] - 2026-03-05
 

--- a/docs/releases/v1.2.4.md
+++ b/docs/releases/v1.2.4.md
@@ -1,38 +1,45 @@
 # Cortex v1.2.4 Release Notes
 
-Date: 2026-03-08
+Date: 2026-03-11
 Tag: `v1.2.4`
 
-Patch release focused on **operator-grade memory maintenance + trust hardening**.
-
-This is a maintenance/trust packaging release (not a feature-epic jump).
+`v1.2.4` packages the post-`v1.2.3` operator-quality wave into one honest release: stronger operator retrieval, a cleaner OpenClaw happy path, bounded recall packaging, workflow repair, and ANN/HNSW reliability hardening.
 
 ## Shipped in v1.2.4 (merged on `main`)
 
-### Operator maintenance safety
-- **Safe per-source repair path** via `cortex refresh-source <path>`.
-- **Source-scoped refresh behavior** to avoid broad database blast radius.
-- **Source-scoped embedding completion/repair** path for targeted maintenance workflows.
+### Operator retrieval + actionability
+- **Trust visibility surface** for clearer operator/agent trust boundaries.
+- **Operator-intent query shaping** for long workflow prompts without mutating the raw query surface.
+- **Top-1 tie-break hardening** for operator-style retrieval.
+- **Deterministic actionability repair** so downstream operator outputs stay cleaner and more usable.
 
-### Belief/operator visibility baseline
-- **`cortex beliefs` visibility surface** for lifecycle state counts + policy visibility.
-- **Manual belief state controls** (`promote`, `retire`, `activate`, `set`) for explicit operator handling.
-- **Lifecycle skip-stats visibility** in `cortex lifecycle run` to explain zero-action runs without silently changing behavior.
+### OpenClaw setup + recall packaging
+- **Canonical OpenClaw happy path** for getting Cortex + OpenClaw working from a single obvious flow.
+- **Bounded recall manifest selection** so recall injection works against a hard budget.
+- **Grouped recall packing** by project/file/section.
+- **Collapsed-hit detail-marker preservation** so packed same-source detail stays visible under long primary snippets.
 
-### Trust and signal-quality hardening
-- **`cortex doctor` provider-only false warning fixed** (issue #301 closed by merged lane work).
-- **Hybrid search auto-embedder resolution** for configured environments, with graceful BM25 fallback.
-- **Predicate-aware conflict filtering** to suppress multi-valued append-only noise.
-- **Extraction noise hardening** (subject semantics + envelope/url noise suppression + hierarchy handling).
+### Reliability + CI hardening
+- **Reason-quality nightly workflow repaired** on `main`.
+- **ANN/HNSW malformed-state hardening** so malformed persisted ANN state recovers to a stable rebuilt index instead of repeatedly degrading.
 
 ## Included PRs
-- #302 — `feat: harden Cortex search, lifecycle, and conflict trust signals`
+- **#312** — `feat(cortex): add trust visibility to cortex agents (#275 slice A)`
+- **#315** — `feat(search): bounded operator-intent query shaping for long prompts (#303 slice A)`
+- **#316** — `feat(search): bounded top-1 tie-break hardening for operator retrieval (#304 slice A)`
+- **#317** — `feat(reason): deterministic actionability contract repair (#305 slice A)`
+- **#322** — `feat(setup): canonical OpenClaw happy-path + actionable setup checks (#321)`
+- **#323** — `feat(plugin): add bounded recall manifest budget selection (#319 slice A)`
+- **#324** — `fix(ci): repair reason-quality-eval-nightly workflow file failure (#314)`
+- **#325** — `feat(plugin): bounded grouped recall packing for #318-lite`
+- **#327** — `fix(plugin): keep collapsed-hit detail marker visible in #318-lite packing (#326)`
+- **#328** — `fix(search): harden HNSW load/rebuild against malformed-length persisted state (#313)`
 
-## Queued next (NOT shipped in v1.2.4)
-- **PR #308** (`feat(beliefs): add read-only conviction inspect operator surface`) is open and intentionally excluded from this release cut.
-- **#275 slice A/B** trust-boundary follow-up slices.
-- Parallel hardening lane slices **#303 / #304 / #305 / #306** under epic **#307**.
-- Epic container **#267** remains roadmap-only.
+## Intentionally not fully shipped in v1.2.4
+- **#318** remains broader than the shipped `#318-lite` harvest.
+- **#319** remains broader than shipped Slice A.
+- **#320** remains intentionally held / parked and is not part of this release.
+- **#307** remains the broader operator-mode umbrella beyond the shipped bounded slices.
 
 ## Upgrade
 ```bash
@@ -43,9 +50,9 @@ brew upgrade hurttlocker/cortex/cortex-memory
 curl -sSL https://github.com/hurttlocker/cortex/releases/download/v1.2.4/cortex-darwin-arm64.tar.gz | tar xz
 ```
 
-## Post-merge release block for Q
+## Release block for Q
 ```bash
-# 1) Merge release package PR (#310) to main
+# 1) Merge this release packaging PR to main
 
 # 2) Sync local main
 git checkout main


### PR DESCRIPTION
## What this does
Refreshes the `v1.2.4` release package docs so they match what actually shipped on `main` after `v1.2.3`.

## Why
The repo was already versioned at `1.2.4`, but the release notes/changelog still reflected the earlier narrow packaging story and under-described the merged operator/retrieval/recall/reliability wave.

## Included in this PR
- updates `CHANGELOG.md` `v1.2.4` section
- rewrites `docs/releases/v1.2.4.md` to match the real shipped set
- keeps scope docs-only

## Shipped set now reflected
- #312
- #315
- #316
- #317
- #322
- #323
- #324
- #325
- #327
- #328

## Explicit not-fully-shipped / held
- #318 broader than `#318-lite`
- #319 broader than Slice A
- #320 intentionally held
- #307 still broader umbrella work

## Testing
Docs-only packaging refresh; no code/runtime changes.

## Merge notes
After merge, this becomes the release-note source for tagging `v1.2.4`.
Q merges.