### PR TITLE
feat(recall): bias auto-recall toward current session context

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -754,10 +754,12 @@ func runSearch(args []string) error {
 	disableClassBoost := false
 	agentFlag := ""
 	channelFlag := ""
+	sessionKeyFlag := ""
 	afterFlag := ""
 	beforeFlag := ""
 	boostAgentFlag := ""
 	boostChannelFlag := ""
+	boostSessionKeyFlag := ""
 	sourceFlag := ""
 	intentFlag := "all"
 	sourceBoostFlags := []string{}
@@ -791,6 +793,11 @@ func runSearch(args []string) error {
 			channelFlag = args[i]
 		case strings.HasPrefix(args[i], "--channel="):
 			channelFlag = strings.TrimPrefix(args[i], "--channel=")
+		case args[i] == "--session-key" && i+1 < len(args):
+			i++
+			sessionKeyFlag = args[i]
+		case strings.HasPrefix(args[i], "--session-key="):
+			sessionKeyFlag = strings.TrimPrefix(args[i], "--session-key=")
 		case args[i] == "--after" && i+1 < len(args):
 			i++
 			afterFlag = args[i]
@@ -828,6 +835,11 @@ func runSearch(args []string) error {
 			boostChannelFlag = args[i]
 		case strings.HasPrefix(args[i], "--boost-channel="):
 			boostChannelFlag = strings.TrimPrefix(args[i], "--boost-channel=")
+		case args[i] == "--boost-session-key" && i+1 < len(args):
+			i++
+			boostSessionKeyFlag = args[i]
+		case strings.HasPrefix(args[i], "--boost-session-key="):
+			boostSessionKeyFlag = strings.TrimPrefix(args[i], "--boost-session-key=")
 		case args[i] == "--explain":
 			explain = true
 		case args[i] == "--include-superseded":
@@ -892,7 +904,7 @@ func runSearch(args []string) error {
 
 	query := strings.Join(queryParts, " ")
 	if query == "" {
-		return fmt.Errorf("usage: cortex search <query> [--mode keyword|semantic|hybrid|rrf] [--limit N] [--embed <provider/model>] [--expand] [--llm <provider/model>] [--class rule,decision] [--no-class-boost] [--include-superseded] [--explain] [--json] [--agent <id>] [--channel <name>] [--source <provider>] [--intent memory|import|connector|all] [--source-boost <prefix[:weight]>] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--show-metadata]")
+		return fmt.Errorf("usage: cortex search <query> [--mode keyword|semantic|hybrid|rrf] [--limit N] [--embed <provider/model>] [--expand] [--llm <provider/model>] [--class rule,decision] [--no-class-boost] [--include-superseded] [--explain] [--json] [--agent <id>] [--channel <name>] [--session-key <key>] [--boost-agent <id>] [--boost-channel <name>] [--boost-session-key <key>] [--source <provider>] [--intent memory|import|connector|all] [--source-boost <prefix[:weight]>] [--after YYYY-MM-DD] [--before YYYY-MM-DD] [--show-metadata]")
 	}
 	if limit < 1 || limit > 1000 {
 		return fmt.Errorf("--limit must be between 1 and 1000")
@@ -988,6 +1000,7 @@ func runSearch(args []string) error {
 		DisableClassBoost: disableClassBoost,
 		Agent:             agentFlag,
 		Channel:           channelFlag,
+		SessionKey:        sessionKeyFlag,
 		After:             afterFlag,
 		Before:            beforeFlag,
 		Source:            sourceFlag,
@@ -997,6 +1010,7 @@ func runSearch(args []string) error {
 		Explain:           explain,
 		BoostAgent:        boostAgentFlag,
 		BoostChannel:      boostChannelFlag,
+		BoostSessionKey:   boostSessionKeyFlag,
 	}
 
 	// Query expansion: use LLM to generate multiple search queries

--- a/internal/search/metadata_boost_test.go
+++ b/internal/search/metadata_boost_test.go
@@ -56,6 +56,22 @@ func TestApplyMetadataBoosts_NoBoostContext(t *testing.T) {
 	}
 }
 
+func TestFilterByMetadata_SessionKey(t *testing.T) {
+	results := []Result{
+		{Content: "same session", Metadata: &store.Metadata{SessionKey: "agent:main:main"}},
+		{Content: "other session", Metadata: &store.Metadata{SessionKey: "agent:main:discord:channel:1"}},
+		{Content: "no metadata"},
+	}
+
+	filtered := filterByMetadata(results, Options{SessionKey: "agent:main:main"})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(filtered))
+	}
+	if filtered[0].Content != "same session" {
+		t.Fatalf("expected same-session result, got %q", filtered[0].Content)
+	}
+}
+
 func TestApplyRecencyBoost_TodayBoosted(t *testing.T) {
 	now := time.Now()
 	results := []Result{
@@ -134,6 +150,23 @@ func TestApplyMetadataBoosts_BothAgentAndChannel(t *testing.T) {
 	// Double boost should be > single boost
 	if boosted[0].Score <= boosted[1].Score {
 		t.Errorf("expected double boost (%f) > single boost (%f)", boosted[0].Score, boosted[1].Score)
+	}
+}
+
+func TestApplyMetadataBoosts_SessionKeyMatch(t *testing.T) {
+	results := []Result{
+		{Content: "same session", Score: 1.0, Metadata: &store.Metadata{SessionKey: "agent:main:discord:channel:1"}},
+		{Content: "different session", Score: 1.0, Metadata: &store.Metadata{SessionKey: "agent:main:discord:channel:2"}},
+	}
+
+	opts := Options{BoostSessionKey: "agent:main:discord:channel:1"}
+	boosted := applyMetadataBoosts(results, opts)
+
+	if boosted[0].Content != "same session" {
+		t.Errorf("expected same-session result first, got %q", boosted[0].Content)
+	}
+	if boosted[0].Score <= boosted[1].Score {
+		t.Errorf("expected same-session boost (%f) > other score (%f)", boosted[0].Score, boosted[1].Score)
 	}
 }
 

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -168,11 +168,13 @@ type Options struct {
 	DisableClassBoost bool     // Disable class-aware weighting (default: false)
 	Agent             string   // Filter by metadata agent_id (Issue #30)
 	Channel           string   // Filter by metadata channel (Issue #30)
+	SessionKey        string   // Filter by metadata session_key (Issue #230)
 
-	// Metadata-aware ranking context (Issue #148)
+	// Metadata-aware ranking context (Issue #148 / #230)
 	// These don't filter — they boost results that match the calling context.
 	BoostAgent        string        // Boost results from this agent (e.g., "main", "ace")
 	BoostChannel      string        // Boost results from this channel (e.g., "discord", "telegram")
+	BoostSessionKey   string        // Boost results from this exact session key (e.g., "agent:main:discord:channel:...")
 	After             string        // Filter memories imported after date YYYY-MM-DD (Issue #30)
 	Before            string        // Filter memories imported before date YYYY-MM-DD (Issue #30)
 	Source            string        // Filter by source prefix (e.g., "github", "gmail") (Issue #199)
@@ -275,10 +277,11 @@ type RankComponents struct {
 	HybridBM25Contribution     *float64 `json:"hybrid_bm25_contribution,omitempty"`
 	HybridSemanticContribution *float64 `json:"hybrid_semantic_contribution,omitempty"`
 
-	// Metadata-aware ranking (Issue #148)
-	AgentBoost   float64 `json:"agent_boost,omitempty"`
-	ChannelBoost float64 `json:"channel_boost,omitempty"`
-	RecencyBoost float64 `json:"recency_boost,omitempty"`
+	// Metadata-aware ranking (Issue #148 / #230)
+	AgentBoost      float64 `json:"agent_boost,omitempty"`
+	ChannelBoost    float64 `json:"channel_boost,omitempty"`
+	SessionKeyBoost float64 `json:"session_key_boost,omitempty"`
+	RecencyBoost    float64 `json:"recency_boost,omitempty"`
 
 	// Source weighting (Issue #199)
 	SourceWeight          float64 `json:"source_weight,omitempty"`
@@ -500,8 +503,8 @@ func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Resu
 		results = filterByIntent(results, intent)
 	}
 
-	// Apply metadata filters (Issue #30)
-	if opts.Agent != "" || opts.Channel != "" || opts.After != "" || opts.Before != "" {
+	// Apply metadata filters (Issue #30 / #230)
+	if opts.Agent != "" || opts.Channel != "" || opts.SessionKey != "" || opts.After != "" || opts.Before != "" {
 		results = filterByMetadata(results, opts)
 	}
 
@@ -558,6 +561,9 @@ func filterByMetadata(results []Result, opts Options) []Result {
 			continue
 		}
 		if opts.Channel != "" && !matchChannel(r, opts.Channel) {
+			continue
+		}
+		if opts.SessionKey != "" && !matchSessionKey(r, opts.SessionKey) {
 			continue
 		}
 		if opts.After != "" && r.ImportedAt.Format("2006-01-02") < opts.After {
@@ -1222,13 +1228,16 @@ func hasResultTokenOverlap(r Result, queryTokens map[string]struct{}) bool {
 	return false
 }
 
-// Metadata-aware ranking boost constants (Issue #148).
+// Metadata-aware ranking boost constants (Issue #148 / #230).
 const (
 	// Boost for results from the same agent as the querier.
 	metadataAgentBoost = 1.08
 
 	// Boost for results from the same channel as the querier.
 	metadataChannelBoost = 1.05
+
+	// Stronger boost for results from the same exact session as the querier.
+	metadataSessionKeyBoost = 1.15
 
 	// Recency boost tiers: recent memories are more likely relevant.
 	recencyBoostToday     = 1.10
@@ -1241,10 +1250,10 @@ const (
 	sourceWeightConnector = 0.97 // Slight penalty for connector-imported records
 )
 
-// applyMetadataBoosts boosts results that match the calling agent/channel context.
+// applyMetadataBoosts boosts results that match the calling agent/channel/session context.
 // This is ranking-only — no results are filtered out.
 func applyMetadataBoosts(results []Result, opts Options) []Result {
-	if opts.BoostAgent == "" && opts.BoostChannel == "" {
+	if opts.BoostAgent == "" && opts.BoostChannel == "" && opts.BoostSessionKey == "" {
 		return results
 	}
 
@@ -1267,6 +1276,14 @@ func applyMetadataBoosts(results []Result, opts Options) []Result {
 			if opts.Explain {
 				ensureExplain(&results[i])
 				results[i].Explain.RankComponents.ChannelBoost = metadataChannelBoost
+			}
+		}
+
+		if opts.BoostSessionKey != "" && strings.EqualFold(meta.SessionKey, opts.BoostSessionKey) {
+			results[i].Score *= metadataSessionKeyBoost
+			if opts.Explain {
+				ensureExplain(&results[i])
+				results[i].Explain.RankComponents.SessionKeyBoost = metadataSessionKeyBoost
 			}
 		}
 	}
@@ -1508,6 +1525,13 @@ func matchChannel(r Result, channel string) bool {
 		return false
 	}
 	return r.Metadata.Channel == channel || r.Metadata.ChannelName == channel
+}
+
+func matchSessionKey(r Result, sessionKey string) bool {
+	if r.Metadata == nil {
+		return false
+	}
+	return strings.EqualFold(r.Metadata.SessionKey, sessionKey)
 }
 
 // applyConfidenceDecay adjusts search result scores based on the effective confidence

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -77,6 +77,16 @@ interface CortexSearchResult {
   snippet?: string;
 }
 
+interface CortexSearchOptions {
+  agent?: string;
+  channel?: string;
+  sessionKey?: string;
+  boostAgent?: string;
+  boostChannel?: string;
+  boostSessionKey?: string;
+  after?: string;
+}
+
 interface CortexStats {
   memories: number;
   facts: number;
@@ -233,6 +243,17 @@ const knownPluginConfigKeys = new Set([
   "binaryPath", "dbPath", "embedProvider", "searchMode", "autoCapture", "autoRecall", "recallLimit", "recallBudgetChars", "minScore",
   "captureMaxChars", "extractFacts", "capture", "recallDedupe",
 ]);
+
+function isCompactionLikePrompt(prompt: string): boolean {
+  return /(post-compaction context refresh|pre-compaction memory flush|compaction|memory flush)/i.test(prompt);
+}
+
+function formatDateYYYYMMDD(date: Date): string {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
 
 function expandHomePath(input: string): string {
   const trimmed = input.trim();
@@ -392,7 +413,13 @@ class CortexCLI {
     }
   }
 
-  async search(query: string, limit = 5, mode?: string, minScore?: number): Promise<CortexSearchResult[]> {
+  async search(
+    query: string,
+    limit = 5,
+    mode?: string,
+    minScore?: number,
+    options?: CortexSearchOptions,
+  ): Promise<CortexSearchResult[]> {
     const searchMode = mode ?? this.defaultMode;
     const args = ["search", query, "--limit", String(limit), "--json"];
 
@@ -405,6 +432,14 @@ class CortexCLI {
     if (minScore !== undefined) {
       args.push("--min-score", String(minScore));
     }
+
+    if (options?.agent) args.push("--agent", options.agent);
+    if (options?.channel) args.push("--channel", options.channel);
+    if (options?.sessionKey) args.push("--session-key", options.sessionKey);
+    if (options?.boostAgent) args.push("--boost-agent", options.boostAgent);
+    if (options?.boostChannel) args.push("--boost-channel", options.boostChannel);
+    if (options?.boostSessionKey) args.push("--boost-session-key", options.boostSessionKey);
+    if (options?.after) args.push("--after", options.after);
 
     const output = await this.exec(args);
     if (!output || output === "null" || output === "[]") return [];
@@ -1118,21 +1153,73 @@ const cortexPlugin = {
     // ========================================================================
 
     if (cfg.autoRecall) {
-      api.on("before_agent_start", async (event) => {
+      api.on("before_agent_start", async (event, ctx) => {
         if (!event.prompt || event.prompt.length < 10) return;
 
         try {
+          const compactionMode = isCompactionLikePrompt(event.prompt);
           const fetchLimit = Math.max(cfg.recallLimit, cfg.recallLimit * 3);
-          const rawResults = await cli.search(event.prompt, fetchLimit, cfg.searchMode, cfg.minScore);
-          if (rawResults.length === 0) return;
+          const now = new Date();
+          const todayKey = formatDateYYYYMMDD(now);
+          const yesterday = new Date(now);
+          yesterday.setDate(yesterday.getDate() - 1);
+          const yesterdayKey = formatDateYYYYMMDD(yesterday);
+
+          const baseSearchOptions: CortexSearchOptions = {
+            boostAgent: typeof ctx?.agentId === "string" ? ctx.agentId : undefined,
+            boostChannel: typeof ctx?.channelId === "string" ? ctx.channelId : undefined,
+            boostSessionKey: typeof ctx?.sessionKey === "string" ? ctx.sessionKey : undefined,
+          };
+
+          const mergedRawResults: CortexSearchResult[] = [];
+          const seenMemoryIds = new Set<number>();
+          const appendResults = (rows: CortexSearchResult[]) => {
+            for (const row of rows) {
+              if (seenMemoryIds.has(row.memory_id)) continue;
+              seenMemoryIds.add(row.memory_id);
+              mergedRawResults.push(row);
+            }
+          };
+
+          if (typeof ctx?.sessionKey === "string" && ctx.sessionKey.trim() !== "") {
+            appendResults(
+              await cli.search(event.prompt, fetchLimit, cfg.searchMode, cfg.minScore, {
+                ...baseSearchOptions,
+                sessionKey: ctx.sessionKey,
+                after: compactionMode ? todayKey : undefined,
+              }),
+            );
+
+            if (mergedRawResults.length === 0 && compactionMode) {
+              appendResults(
+                await cli.search(event.prompt, fetchLimit, cfg.searchMode, cfg.minScore, {
+                  ...baseSearchOptions,
+                  sessionKey: ctx.sessionKey,
+                  after: yesterdayKey,
+                }),
+              );
+            }
+          }
+
+          if (mergedRawResults.length < cfg.recallLimit) {
+            appendResults(
+              await cli.search(event.prompt, fetchLimit, cfg.searchMode, cfg.minScore, {
+                ...baseSearchOptions,
+                agent: typeof ctx?.agentId === "string" ? ctx.agentId : undefined,
+                after: compactionMode ? yesterdayKey : undefined,
+              }),
+            );
+          }
+
+          if (mergedRawResults.length === 0) return;
 
           const deduped = cfg.recallDedupe.enabled
-            ? dedupeRecallResults(rawResults, cfg.recallDedupe.similarityThreshold)
-            : rawResults;
+            ? dedupeRecallResults(mergedRawResults, cfg.recallDedupe.similarityThreshold)
+            : mergedRawResults;
 
-          const recallPlan = buildRecallPlan(rawResults, deduped, {
-            limit: cfg.recallLimit,
-            budgetChars: cfg.recallBudgetChars,
+          const recallPlan = buildRecallPlan(mergedRawResults, deduped, {
+            limit: compactionMode ? Math.min(cfg.recallLimit, 1) : cfg.recallLimit,
+            budgetChars: compactionMode ? Math.min(cfg.recallBudgetChars, 900) : cfg.recallBudgetChars,
           });
 
           if (recallPlan.selected.length === 0) {
@@ -1149,7 +1236,7 @@ const cortexPlugin = {
             `cortex: recall manifest budget=${recallPlan.manifest.budget_chars} chars (used=${recallPlan.manifest.context_chars}) selected=${recallPlan.manifest.selected_count} dropped=${recallPlan.manifest.dropped_count}`,
           );
           api.logger.info(
-            `cortex: injecting ${recallPlan.selected.length} packed recall entries (scores: ${recallPlan.selected.map((r) => r.score.toFixed(2)).join(", ")})`,
+            `cortex: injecting ${recallPlan.selected.length} packed recall entries${compactionMode ? " (compaction-biased)" : ""} (scores: ${recallPlan.selected.map((r) => r.score.toFixed(2)).join(", ")})`,
           );
 
           return {


### PR DESCRIPTION
## Summary
- use hook context in plugin auto-recall instead of prompt-only retrieval
- add `--session-key` and `--boost-session-key` to Cortex search
- bias compaction recall toward same-session / same-agent context with smaller payloads

## Why
Fixes the recall-injection issue tracked in #333.

OpenClaw already passes `sessionKey`, `agentId`, and `channelId` into plugin hooks, but the Cortex plugin was ignoring that context during `before_agent_start`. That made compaction recall look too historical even when model behavior stayed good.

## What changed
### Cortex plugin
- exact-session-first recall when `sessionKey` is available
- same-agent fallback with current-lane boosts
- compaction-style prompts use tighter limits and smaller recall budgets

### Cortex search CLI/engine
- filter by `session_key`
- boost by `session_key`
- added search tests for same-session filtering/boosting

## Validation
- `go test ./internal/search ./cmd/cortex`
- `node --experimental-strip-types --test plugin/recall.test.ts`
