### PR TITLE
fix(search): include fact_ids in search JSON output (#336)

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -1091,7 +1091,8 @@ func runSearch(args []string) error {
 
 	// Determine output format
 	if jsonOutput || !isTTY() {
-		return outputJSON(results)
+		enriched := enrichSearchResultsWithFactIDs(ctx, s, results, includeSuperseded)
+		return outputJSON(enriched)
 	}
 
 	// Show expanded queries header in TTY mode
@@ -7115,6 +7116,70 @@ func getExtendedStats(ctx context.Context, s store.Store) (int, string, error) {
 	}
 
 	return len(files), dateRange, nil
+}
+
+func enrichSearchResultsWithFactIDs(ctx context.Context, s store.Store, results []search.Result, includeSuperseded bool) []search.Result {
+	if len(results) == 0 {
+		return results
+	}
+
+	enriched := make([]search.Result, len(results))
+	copy(enriched, results)
+
+	memoryIDs := make([]int64, 0, len(enriched))
+	seenMemory := make(map[int64]struct{}, len(enriched))
+	for _, result := range enriched {
+		if result.MemoryID <= 0 {
+			continue
+		}
+		if _, ok := seenMemory[result.MemoryID]; ok {
+			continue
+		}
+		seenMemory[result.MemoryID] = struct{}{}
+		memoryIDs = append(memoryIDs, result.MemoryID)
+	}
+
+	factIDsByMemory := make(map[int64][]int64, len(memoryIDs))
+	for _, memoryID := range memoryIDs {
+		factIDsByMemory[memoryID] = []int64{}
+	}
+
+	if len(memoryIDs) > 0 {
+		var (
+			facts []*store.Fact
+			err   error
+		)
+		if includeSuperseded {
+			facts, err = s.GetFactsByMemoryIDsIncludingSuperseded(ctx, memoryIDs)
+		} else {
+			facts, err = s.GetFactsByMemoryIDs(ctx, memoryIDs)
+		}
+		if err == nil {
+			for _, fact := range facts {
+				factIDsByMemory[fact.MemoryID] = append(factIDsByMemory[fact.MemoryID], fact.ID)
+			}
+			for memoryID := range factIDsByMemory {
+				sort.Slice(factIDsByMemory[memoryID], func(i, j int) bool {
+					return factIDsByMemory[memoryID][i] < factIDsByMemory[memoryID][j]
+				})
+			}
+		}
+	}
+
+	for i := range enriched {
+		if enriched[i].MemoryID <= 0 {
+			enriched[i].FactIDs = []int64{}
+			continue
+		}
+		ids, ok := factIDsByMemory[enriched[i].MemoryID]
+		if !ok || ids == nil {
+			enriched[i].FactIDs = []int64{}
+			continue
+		}
+		enriched[i].FactIDs = ids
+	}
+
+	return enriched
 }
 
 func outputJSON(results []search.Result) error {

--- a/cmd/cortex/search_fact_ids_test.go
+++ b/cmd/cortex/search_fact_ids_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hurttlocker/cortex/internal/search"
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+func TestEnrichSearchResultsWithFactIDs_ActiveOnly(t *testing.T) {
+	s, err := store.NewStore(store.StoreConfig{DBPath: ":memory:"})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	memoryID, err := s.AddMemory(ctx, &store.Memory{Content: "cortex ide notes", ImportedAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	secondMemoryID, err := s.AddMemory(ctx, &store.Memory{Content: "no facts", ImportedAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("AddMemory (second): %v", err)
+	}
+
+	oldFactID, err := s.AddFact(ctx, &store.Fact{MemoryID: memoryID, Subject: "cortex ide", Predicate: "status", Object: "initial", FactType: "state", Confidence: 0.8})
+	if err != nil {
+		t.Fatalf("AddFact old: %v", err)
+	}
+	newFactID, err := s.AddFact(ctx, &store.Fact{MemoryID: memoryID, Subject: "cortex ide", Predicate: "status", Object: "current", FactType: "state", Confidence: 0.9})
+	if err != nil {
+		t.Fatalf("AddFact new: %v", err)
+	}
+	if err := s.SupersedeFact(ctx, oldFactID, newFactID, "updated status"); err != nil {
+		t.Fatalf("SupersedeFact: %v", err)
+	}
+
+	results := []search.Result{
+		{MemoryID: memoryID, Content: "result 1"},
+		{MemoryID: secondMemoryID, Content: "result 2"},
+	}
+
+	enriched := enrichSearchResultsWithFactIDs(ctx, s, results, false)
+	if len(enriched) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(enriched))
+	}
+	if len(enriched[0].FactIDs) != 1 || enriched[0].FactIDs[0] != newFactID {
+		t.Fatalf("expected active fact id [%d], got %v", newFactID, enriched[0].FactIDs)
+	}
+	if enriched[1].FactIDs == nil {
+		t.Fatalf("expected empty fact_ids array, got nil")
+	}
+	if len(enriched[1].FactIDs) != 0 {
+		t.Fatalf("expected no fact ids for second memory, got %v", enriched[1].FactIDs)
+	}
+}
+
+func TestEnrichSearchResultsWithFactIDs_IncludingSuperseded(t *testing.T) {
+	s, err := store.NewStore(store.StoreConfig{DBPath: ":memory:"})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	memoryID, err := s.AddMemory(ctx, &store.Memory{Content: "cortex ide notes", ImportedAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+
+	oldFactID, err := s.AddFact(ctx, &store.Fact{MemoryID: memoryID, Subject: "cortex ide", Predicate: "status", Object: "initial", FactType: "state", Confidence: 0.8})
+	if err != nil {
+		t.Fatalf("AddFact old: %v", err)
+	}
+	newFactID, err := s.AddFact(ctx, &store.Fact{MemoryID: memoryID, Subject: "cortex ide", Predicate: "status", Object: "current", FactType: "state", Confidence: 0.9})
+	if err != nil {
+		t.Fatalf("AddFact new: %v", err)
+	}
+	if err := s.SupersedeFact(ctx, oldFactID, newFactID, "updated status"); err != nil {
+		t.Fatalf("SupersedeFact: %v", err)
+	}
+
+	results := []search.Result{{MemoryID: memoryID, Content: "result"}}
+	enriched := enrichSearchResultsWithFactIDs(ctx, s, results, true)
+
+	if len(enriched) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(enriched))
+	}
+	if len(enriched[0].FactIDs) != 2 {
+		t.Fatalf("expected 2 fact ids (active + superseded), got %v", enriched[0].FactIDs)
+	}
+	if enriched[0].FactIDs[0] != oldFactID || enriched[0].FactIDs[1] != newFactID {
+		t.Fatalf("expected sorted fact ids [%d %d], got %v", oldFactID, newFactID, enriched[0].FactIDs)
+	}
+}
+
+func TestOutputJSON_IncludesFactIDsField(t *testing.T) {
+	results := []search.Result{{MemoryID: 42, FactIDs: []int64{}, Content: "cortex ide", MatchType: "bm25"}}
+
+	out := captureStdout(func() {
+		if err := outputJSON(results); err != nil {
+			t.Fatalf("outputJSON: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "\"fact_ids\"") {
+		t.Fatalf("expected JSON output to include fact_ids field, got: %s", out)
+	}
+
+	var decoded []map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(decoded) != 1 {
+		t.Fatalf("expected 1 result in JSON output, got %d", len(decoded))
+	}
+	if _, ok := decoded[0]["fact_ids"]; !ok {
+		t.Fatalf("expected fact_ids key in JSON object")
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -230,6 +230,7 @@ type Result struct {
 	Snippet       string          `json:"snippet,omitempty"`
 	MatchType     string          `json:"match_type"` // "bm25", "semantic", "hybrid", "rrf"
 	MemoryID      int64           `json:"memory_id"`
+	FactIDs       []int64         `json:"fact_ids"`              // Facts linked to memory_id (for mutate-after-search workflows)
 	ImportedAt    time.Time       `json:"imported_at,omitempty"` // For metadata date filtering
 	Explain       *ExplainDetails `json:"explain,omitempty"`
 }


### PR DESCRIPTION
## What this does
Adds `fact_ids` to each `cortex search --json` result so consumers can safely perform search→mutation flows (`reinforce`, `supersede`, `beliefs set`) in the correct ID space.

## Problem / Context
`cortex search` only returned `memory_id`, but mutation commands operate on fact IDs. This made IDE integrations silently target the wrong records when chaining search results into mutation commands.

## How it works
- Added `FactIDs []int64` to `search.Result` JSON schema (`fact_ids`).
- Added `enrichSearchResultsWithFactIDs(...)` in `cmd/cortex/main.go` to resolve linked fact IDs per result memory before JSON output.
- Uses `GetFactsByMemoryIDs` by default and `GetFactsByMemoryIDsIncludingSuperseded` when `--include-superseded` is set.
- Ensures `fact_ids` is always an array in JSON output (empty array when none).

## Testing done
- `go test ./cmd/cortex -run "TestEnrichSearchResultsWithFactIDs|TestOutputJSON_IncludesFactIDsField"`
- `go test ./cmd/cortex ./internal/search`
- Added tests in `cmd/cortex/search_fact_ids_test.go` for:
  - active-only fact mapping
  - include-superseded behavior
  - JSON output includes `fact_ids` key

## Screenshots / before-after
CLI JSON before:
```json
{ "memory_id": 123 }
```
CLI JSON after:
```json
{ "memory_id": 123, "fact_ids": [456, 457] }
```

## Breaking changes / risks
- Non-breaking additive JSON field. Existing consumers continue working; new consumers can now safely mutate by fact ID.

## Merge notes
- Close #336 on merge.