### PR TITLE
fix(stale): add --limit flag with all-results default (#337)

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -2150,7 +2150,7 @@ func runStale(args []string) error {
 	opts := observe.StaleOpts{
 		MaxConfidence: 0.5,
 		MaxDays:       30,
-		Limit:         50,
+		Limit:         math.MaxInt, // default to all stale facts unless caller sets --limit
 	}
 	jsonOutput := false
 	agentFlag := ""
@@ -2195,6 +2195,25 @@ func runStale(args []string) error {
 				return fmt.Errorf("invalid --min-confidence value: %s", args[i])
 			}
 			opts.MaxConfidence = conf
+		case args[i] == "--limit" && i+1 < len(args):
+			i++
+			limit, err := strconv.Atoi(args[i])
+			if err != nil {
+				return fmt.Errorf("invalid --limit value: %s", args[i])
+			}
+			if limit < 1 {
+				return fmt.Errorf("--limit must be >= 1")
+			}
+			opts.Limit = limit
+		case strings.HasPrefix(args[i], "--limit="):
+			limit, err := strconv.Atoi(strings.TrimPrefix(args[i], "--limit="))
+			if err != nil {
+				return fmt.Errorf("invalid --limit value: %s", args[i])
+			}
+			if limit < 1 {
+				return fmt.Errorf("--limit must be >= 1")
+			}
+			opts.Limit = limit
 		case args[i] == "--json":
 			jsonOutput = true
 		case args[i] == "--include-superseded":

--- a/cmd/cortex/stale_flags_test.go
+++ b/cmd/cortex/stale_flags_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hurttlocker/cortex/internal/observe"
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+func seedStaleFactsDB(t *testing.T, factCount int) string {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "cortex-stale.db")
+	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	ctx := context.Background()
+	memoryID, err := s.AddMemory(ctx, &store.Memory{Content: "stale test memory", ImportedAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+
+	for i := 0; i < factCount; i++ {
+		_, err := s.AddFact(ctx, &store.Fact{
+			MemoryID:   memoryID,
+			Subject:    fmt.Sprintf("subject-%d", i),
+			Predicate:  "status",
+			Object:     "value",
+			FactType:   "state",
+			Confidence: 0.4,
+			DecayRate:  0.01,
+		})
+		if err != nil {
+			t.Fatalf("AddFact %d: %v", i, err)
+		}
+	}
+
+	sqlStore, ok := s.(*store.SQLiteStore)
+	if !ok {
+		t.Fatalf("expected SQLiteStore")
+	}
+	if _, err := sqlStore.ExecContext(ctx, "UPDATE facts SET last_reinforced = ?", time.Now().UTC().AddDate(0, 0, -90)); err != nil {
+		t.Fatalf("backdate facts: %v", err)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close store: %v", err)
+	}
+	return dbPath
+}
+
+func TestRunStale_Flags_JSONAndLimitAccepted(t *testing.T) {
+	err := runStale([]string{"--json", "--limit", "10"})
+	if err != nil && strings.Contains(err.Error(), "unknown flag") {
+		t.Fatalf("expected --json/--limit flags to parse, got: %v", err)
+	}
+}
+
+func TestRunStale_DefaultLimitReturnsAll(t *testing.T) {
+	dbPath := seedStaleFactsDB(t, 60)
+	globalDBPath = ""
+	t.Cleanup(func() { globalDBPath = "" })
+	t.Setenv("CORTEX_DB", dbPath)
+
+	out := captureStdout(func() {
+		err := runStale([]string{"--json", "--days", "1", "--min-confidence", "1.0"})
+		if err != nil {
+			t.Fatalf("runStale: %v", err)
+		}
+	})
+
+	var stale []observe.StaleFact
+	if err := json.Unmarshal([]byte(out), &stale); err != nil {
+		t.Fatalf("unmarshal stale output: %v\noutput=%s", err, out)
+	}
+	if len(stale) != 60 {
+		t.Fatalf("expected default stale limit to return all 60 facts, got %d", len(stale))
+	}
+}
+
+func TestRunStale_LimitFlagRestrictsResults(t *testing.T) {
+	dbPath := seedStaleFactsDB(t, 60)
+	globalDBPath = ""
+	t.Cleanup(func() { globalDBPath = "" })
+	t.Setenv("CORTEX_DB", dbPath)
+
+	out := captureStdout(func() {
+		err := runStale([]string{"--json", "--days", "1", "--min-confidence", "1.0", "--limit", "7"})
+		if err != nil {
+			t.Fatalf("runStale: %v", err)
+		}
+	})
+
+	var stale []observe.StaleFact
+	if err := json.Unmarshal([]byte(out), &stale); err != nil {
+		t.Fatalf("unmarshal stale output: %v\noutput=%s", err, out)
+	}
+	if len(stale) != 7 {
+		t.Fatalf("expected --limit 7 to return 7 facts, got %d", len(stale))
+	}
+}
+
+func TestRunStale_LimitFlagRejectsNonPositive(t *testing.T) {
+	err := runStale([]string{"--limit", "0"})
+	if err == nil {
+		t.Fatalf("expected error for --limit 0")
+	}
+	if !strings.Contains(err.Error(), "--limit must be >= 1") {
+		t.Fatalf("expected non-positive limit error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What this does
Adds `--limit` support to `cortex stale` and sets stale-command default behavior to return all matching stale facts unless a limit is provided.

`--json` is also covered by tests to guarantee machine-readable stale output for IDE/automation clients.

## Problem / Context
Issue #337 reported that stale consumers need parity with other commands (`conflicts`) for:
- bounded result windows (`--limit N`), and
- JSON-safe machine output (`--json`).

Without `--limit`, clients cannot control payload size; with the previous default of 50, clients also could not request “all” by default.

## How it works
- `runStale` now parses:
  - `--limit <N>`
  - `--limit=<N>`
- Validation added:
  - invalid numeric values fail with `invalid --limit value`
  - non-positive limits fail with `--limit must be >= 1`
- Stale command default limit is now `all` by setting `opts.Limit = math.MaxInt` unless overridden.
- Existing `--json` behavior remains and is now covered by regression tests.

## Testing done
- `go test ./cmd/cortex -run "TestRunStale_(Flags_JSONAndLimitAccepted|DefaultLimitReturnsAll|LimitFlagRestrictsResults|LimitFlagRejectsNonPositive)"`
- `go test ./cmd/cortex`
- New tests in `cmd/cortex/stale_flags_test.go`:
  - accepts `--json` + `--limit`
  - default returns all (60 seeded stale facts)
  - `--limit` bounds result count
  - rejects non-positive limit

## Screenshots / before-after
Before:
- `cortex stale --limit 10` → unknown flag
- default output effectively capped at 50

After:
- `cortex stale --limit 10 --json` → valid JSON with 10 results
- `cortex stale --json` (no limit) → all matching stale facts

## Breaking changes / risks
- Behavior change: default stale output is no longer capped at 50.
- Mitigation: clients can explicitly set `--limit` for bounded payloads.

## Merge notes
- Close #337 on merge.
