### PR TITLE
feat(graph): add --subject entry-point traversal mode (#338)

### DIFF
--- a/cmd/cortex/graph_subject_test.go
+++ b/cmd/cortex/graph_subject_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+func TestResolveGraphSeedFactIDsBySubject_CaseInsensitiveActiveOnly(t *testing.T) {
+	s, err := store.NewStore(store.StoreConfig{DBPath: ":memory:"})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer s.Close()
+
+	sqlStore, ok := s.(*store.SQLiteStore)
+	if !ok {
+		t.Fatalf("expected SQLiteStore")
+	}
+
+	ctx := context.Background()
+	memoryID, err := s.AddMemory(ctx, &store.Memory{Content: "graph seed memory", ImportedAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+
+	oldFactID, err := s.AddFact(ctx, &store.Fact{MemoryID: memoryID, Subject: "Cortex IDE", Predicate: "status", Object: "legacy", FactType: "state", Confidence: 0.7})
+	if err != nil {
+		t.Fatalf("AddFact old: %v", err)
+	}
+	newFactID, err := s.AddFact(ctx, &store.Fact{MemoryID: memoryID, Subject: "cortex ide", Predicate: "status", Object: "current", FactType: "state", Confidence: 0.9})
+	if err != nil {
+		t.Fatalf("AddFact new: %v", err)
+	}
+	if err := s.SupersedeFact(ctx, oldFactID, newFactID, "updated"); err != nil {
+		t.Fatalf("SupersedeFact: %v", err)
+	}
+
+	seedIDs, err := resolveGraphSeedFactIDsBySubject(ctx, sqlStore.GetDB(), "CoRtEx IdE", 0.0)
+	if err != nil {
+		t.Fatalf("resolveGraphSeedFactIDsBySubject: %v", err)
+	}
+	if len(seedIDs) != 1 || seedIDs[0] != newFactID {
+		t.Fatalf("expected only active fact id [%d], got %v", newFactID, seedIDs)
+	}
+}
+
+func TestRunGraph_SubjectJSONIncludesSeedFactIDs(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "graph-subject.db")
+	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	sqlStore, ok := s.(*store.SQLiteStore)
+	if !ok {
+		t.Fatalf("expected SQLiteStore")
+	}
+
+	ctx := context.Background()
+	memoryID, err := s.AddMemory(ctx, &store.Memory{Content: "graph run memory", ImportedAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+
+	f1, err := s.AddFact(ctx, &store.Fact{MemoryID: memoryID, Subject: "Cortex IDE", Predicate: "uses", Object: "cortex", FactType: "relationship", Confidence: 0.8})
+	if err != nil {
+		t.Fatalf("AddFact f1: %v", err)
+	}
+	if _, err := s.AddFact(ctx, &store.Fact{MemoryID: memoryID, Subject: "cortex ide", Predicate: "needs", Object: "fact ids", FactType: "relationship", Confidence: 0.9}); err != nil {
+		t.Fatalf("AddFact f2: %v", err)
+	}
+	f3, err := s.AddFact(ctx, &store.Fact{MemoryID: memoryID, Subject: "Cortex Memory", Predicate: "links", Object: "IDE", FactType: "relationship", Confidence: 0.85})
+	if err != nil {
+		t.Fatalf("AddFact f3: %v", err)
+	}
+	if err := sqlStore.AddEdge(ctx, &store.FactEdge{SourceFactID: f1, TargetFactID: f3, EdgeType: store.EdgeTypeRelatesTo, Confidence: 0.7, Source: store.EdgeSourceInferred}); err != nil {
+		t.Fatalf("AddEdge: %v", err)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close store: %v", err)
+	}
+
+	globalDBPath = ""
+	t.Cleanup(func() { globalDBPath = "" })
+	t.Setenv("CORTEX_DB", dbPath)
+
+	out := captureStdout(func() {
+		err := runGraph([]string{"--subject", "cortex ide", "--depth", "1", "--export", "json"})
+		if err != nil {
+			t.Fatalf("runGraph: %v", err)
+		}
+	})
+
+	var payload struct {
+		Nodes []struct {
+			ID int64 `json:"id"`
+		} `json:"nodes"`
+		Meta map[string]interface{} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal graph output: %v\noutput=%s", err, out)
+	}
+
+	if got, _ := payload.Meta["root_subject"].(string); got != "cortex ide" {
+		t.Fatalf("expected root_subject=cortex ide, got %v", payload.Meta["root_subject"])
+	}
+	seedRaw, ok := payload.Meta["seed_fact_ids"].([]interface{})
+	if !ok {
+		t.Fatalf("expected seed_fact_ids array in meta, got %T", payload.Meta["seed_fact_ids"])
+	}
+	if len(seedRaw) != 2 {
+		t.Fatalf("expected 2 subject seed fact ids, got %d (%v)", len(seedRaw), seedRaw)
+	}
+	if len(payload.Nodes) < 2 {
+		t.Fatalf("expected at least 2 nodes for subject graph, got %d", len(payload.Nodes))
+	}
+}
+
+func TestRunGraph_SubjectAndFactIDMutuallyExclusive(t *testing.T) {
+	err := runGraph([]string{"123", "--subject", "cortex ide"})
+	if err == nil {
+		t.Fatalf("expected argument conflict error")
+	}
+	if !strings.Contains(err.Error(), "either <fact_id> or --subject") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -4283,9 +4283,13 @@ func runInfer(args []string) error {
 	return nil
 }
 
+func graphUsageError() error {
+	return fmt.Errorf("usage: cortex graph <fact_id> [--depth 2] [--min-confidence 0.5] [--export json] [--agent <id>]\n       cortex graph --subject \"topic\" [--depth 2] [--min-confidence 0.5] [--export json] [--agent <id>]\n       cortex graph --serve [--port 8090]")
+}
+
 func runGraph(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: cortex graph <fact_id> [--depth 2] [--min-confidence 0.5] [--export json] [--agent <id>]\n       cortex graph --serve [--port 8090]")
+		return graphUsageError()
 	}
 
 	// Handle --serve mode
@@ -4293,17 +4297,27 @@ func runGraph(args []string) error {
 		return runGraphServe(args[1:])
 	}
 
-	factID, err := strconv.ParseInt(args[0], 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid fact id: %s", args[0])
-	}
-
 	depth := 2
 	minConf := 0.0
 	exportJSON := false
 	agentFilter := ""
-	for i := 1; i < len(args); i++ {
+	subjectFilter := ""
+	factID := int64(0)
+	hasFactID := false
+
+	for i := 0; i < len(args); i++ {
 		switch {
+		case args[i] == "--subject" && i+1 < len(args):
+			i++
+			subjectFilter = strings.TrimSpace(args[i])
+			if subjectFilter == "" {
+				return fmt.Errorf("--subject cannot be empty")
+			}
+		case strings.HasPrefix(args[i], "--subject="):
+			subjectFilter = strings.TrimSpace(strings.TrimPrefix(args[i], "--subject="))
+			if subjectFilter == "" {
+				return fmt.Errorf("--subject cannot be empty")
+			}
 		case args[i] == "--depth" && i+1 < len(args):
 			i++
 			d, err := strconv.Atoi(args[i])
@@ -4333,7 +4347,28 @@ func runGraph(args []string) error {
 		case args[i] == "--agent" && i+1 < len(args):
 			i++
 			agentFilter = args[i]
+		case strings.HasPrefix(args[i], "--agent="):
+			agentFilter = strings.TrimPrefix(args[i], "--agent=")
+		case strings.HasPrefix(args[i], "-"):
+			return fmt.Errorf("unknown flag: %s", args[i])
+		default:
+			if hasFactID {
+				return fmt.Errorf("unexpected argument: %s", args[i])
+			}
+			parsedFactID, err := strconv.ParseInt(args[i], 10, 64)
+			if err != nil || parsedFactID <= 0 {
+				return fmt.Errorf("invalid fact id: %s", args[i])
+			}
+			hasFactID = true
+			factID = parsedFactID
 		}
+	}
+
+	if subjectFilter != "" && hasFactID {
+		return fmt.Errorf("provide either <fact_id> or --subject, not both")
+	}
+	if subjectFilter == "" && !hasFactID {
+		return graphUsageError()
 	}
 
 	s, err := store.NewStore(getStoreConfig())
@@ -4348,14 +4383,39 @@ func runGraph(args []string) error {
 	}
 
 	ctx := context.Background()
-	nodes, err := sqlStore.TraverseGraph(ctx, factID, depth, minConf)
-	if err != nil {
-		return err
+	var nodes []store.GraphNode
+	seedFactIDs := []int64{}
+
+	if subjectFilter != "" {
+		seedFactIDs, err = resolveGraphSeedFactIDsBySubject(ctx, sqlStore.GetDB(), subjectFilter, minConf)
+		if err != nil {
+			return err
+		}
+		if len(seedFactIDs) == 0 {
+			if exportJSON {
+				fmt.Println("{}")
+			} else {
+				fmt.Printf("No graph found from subject %q\n", subjectFilter)
+			}
+			return nil
+		}
+
+		nodes, err = traverseGraphFromSeedFacts(ctx, sqlStore, seedFactIDs, depth, minConf)
+		if err != nil {
+			return err
+		}
+	} else {
+		nodes, err = sqlStore.TraverseGraph(ctx, factID, depth, minConf)
+		if err != nil {
+			return err
+		}
 	}
 
 	if len(nodes) == 0 {
 		if exportJSON {
 			fmt.Println("{}")
+		} else if subjectFilter != "" {
+			fmt.Printf("No graph found from subject %q\n", subjectFilter)
 		} else {
 			fmt.Printf("No graph found from fact #%d\n", factID)
 		}
@@ -4363,11 +4423,142 @@ func runGraph(args []string) error {
 	}
 
 	if exportJSON {
+		if subjectFilter != "" {
+			return runGraphExportJSONWithMeta(ctx, sqlStore, nodes, map[string]interface{}{
+				"root_subject":  subjectFilter,
+				"seed_fact_ids": seedFactIDs,
+				"depth":         depth,
+			}, agentFilter)
+		}
 		return runGraphExportJSON(ctx, sqlStore, nodes, factID, depth, agentFilter)
 	}
 
-	fmt.Printf("🔗 Knowledge graph from fact #%d (depth %d, %d nodes):\n\n", factID, depth, len(nodes))
+	if subjectFilter != "" {
+		fmt.Printf("🔗 Knowledge graph from subject %q (depth %d, %d seed facts, %d nodes):\n\n", subjectFilter, depth, len(seedFactIDs), len(nodes))
+	} else {
+		fmt.Printf("🔗 Knowledge graph from fact #%d (depth %d, %d nodes):\n\n", factID, depth, len(nodes))
+	}
+	outputGraphNodesTTY(nodes)
+	return nil
+}
+
+func resolveGraphSeedFactIDsBySubject(ctx context.Context, db *sql.DB, subject string, minConf float64) ([]int64, error) {
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
+		return nil, fmt.Errorf("--subject cannot be empty")
+	}
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT id
+		   FROM facts
+		  WHERE LOWER(TRIM(subject)) = LOWER(TRIM(?))
+		    AND (superseded_by IS NULL OR superseded_by = 0)
+		    AND confidence >= ?
+		  ORDER BY confidence DESC, id DESC`,
+		subject, minConf,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying graph seed facts for subject %q: %w", subject, err)
+	}
+	defer rows.Close()
+
+	seedFactIDs := make([]int64, 0)
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning graph seed fact id: %w", err)
+		}
+		seedFactIDs = append(seedFactIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating graph seed fact rows: %w", err)
+	}
+	return seedFactIDs, nil
+}
+
+func traverseGraphFromSeedFacts(ctx context.Context, sqlStore *store.SQLiteStore, seedFactIDs []int64, depth int, minConf float64) ([]store.GraphNode, error) {
+	merged := make(map[int64]store.GraphNode)
+
+	for _, seedFactID := range seedFactIDs {
+		nodes, err := sqlStore.TraverseGraph(ctx, seedFactID, depth, minConf)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, node := range nodes {
+			if node.Fact == nil {
+				continue
+			}
+
+			existing, ok := merged[node.Fact.ID]
+			if !ok {
+				merged[node.Fact.ID] = store.GraphNode{
+					Fact:  node.Fact,
+					Edges: dedupeGraphEdges(node.Edges),
+					Depth: node.Depth,
+				}
+				continue
+			}
+
+			if node.Depth < existing.Depth {
+				existing.Depth = node.Depth
+			}
+			existing.Fact = node.Fact
+			existing.Edges = dedupeGraphEdges(append(existing.Edges, node.Edges...))
+			merged[node.Fact.ID] = existing
+		}
+	}
+
+	combined := make([]store.GraphNode, 0, len(merged))
+	for _, node := range merged {
+		sort.Slice(node.Edges, func(i, j int) bool {
+			if node.Edges[i].SourceFactID != node.Edges[j].SourceFactID {
+				return node.Edges[i].SourceFactID < node.Edges[j].SourceFactID
+			}
+			if node.Edges[i].TargetFactID != node.Edges[j].TargetFactID {
+				return node.Edges[i].TargetFactID < node.Edges[j].TargetFactID
+			}
+			return node.Edges[i].EdgeType < node.Edges[j].EdgeType
+		})
+		combined = append(combined, node)
+	}
+
+	sort.Slice(combined, func(i, j int) bool {
+		if combined[i].Depth != combined[j].Depth {
+			return combined[i].Depth < combined[j].Depth
+		}
+		if combined[i].Fact == nil || combined[j].Fact == nil {
+			return combined[i].Fact != nil
+		}
+		return combined[i].Fact.ID < combined[j].Fact.ID
+	})
+
+	return combined, nil
+}
+
+func dedupeGraphEdges(edges []store.FactEdge) []store.FactEdge {
+	if len(edges) < 2 {
+		return edges
+	}
+
+	seen := make(map[string]struct{}, len(edges))
+	unique := make([]store.FactEdge, 0, len(edges))
+	for _, edge := range edges {
+		key := fmt.Sprintf("%d:%d:%s:%.6f:%s", edge.SourceFactID, edge.TargetFactID, edge.EdgeType, edge.Confidence, edge.Source)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, edge)
+	}
+	return unique
+}
+
+func outputGraphNodesTTY(nodes []store.GraphNode) {
 	for _, node := range nodes {
+		if node.Fact == nil {
+			continue
+		}
 		indent := strings.Repeat("  ", node.Depth)
 		factText := fmt.Sprintf("%s %s %s", node.Fact.Subject, node.Fact.Predicate, node.Fact.Object)
 		if len(factText) > 60 {
@@ -4386,7 +4577,6 @@ func runGraph(args []string) error {
 			fmt.Printf("%s  └─[%s]→ #%d (%.0f%%)\n", indent, e.EdgeType, otherID, e.Confidence*100)
 		}
 	}
-	return nil
 }
 
 func runGraphServe(args []string) error {
@@ -4609,11 +4799,19 @@ type graphExportResult struct {
 }
 
 func runGraphExportJSON(ctx context.Context, sqlStore *store.SQLiteStore, nodes []store.GraphNode, rootID int64, depth int, agentFilter string) error {
+	return runGraphExportJSONWithMeta(ctx, sqlStore, nodes, map[string]interface{}{
+		"root_fact_id": rootID,
+		"depth":        depth,
+	}, agentFilter)
+}
+
+func runGraphExportJSONWithMeta(ctx context.Context, sqlStore *store.SQLiteStore, nodes []store.GraphNode, meta map[string]interface{}, agentFilter string) error {
+	if meta == nil {
+		meta = map[string]interface{}{}
+	}
+
 	result := graphExportResult{
-		Meta: map[string]interface{}{
-			"root_fact_id": rootID,
-			"depth":        depth,
-		},
+		Meta: meta,
 	}
 
 	seenNodes := make(map[int64]bool)
@@ -5964,7 +6162,7 @@ Tools (17):
   cortex_reinforce      Reset decay timer on important facts
   cortex_reason         Synthesize answers from multiple memories (LLM)
   cortex_edge_add       Create relationship edges between facts
-  cortex_graph          Traverse knowledge graph from a fact ID
+  cortex_graph          Traverse knowledge graph from a fact ID or subject
   cortex_graph_export   Export subgraph as structured JSON
   cortex_graph_explore  Explore graph around a topic/subject
   cortex_graph_impact   Analyze blast radius for a subject
@@ -10020,6 +10218,7 @@ Observe:
 
 Knowledge Graph:
   graph <fact_id>       Explore fact relationships (CLI)
+  graph --subject <s>   Explore graph from all facts matching a subject
   graph --serve         Launch interactive graph explorer (web UI)
   cluster               List or rebuild topic clusters
 


### PR DESCRIPTION
## What this does
Adds a subject-first graph entry point to the CLI:

- `cortex graph --subject "cortex ide" [--depth 2] [--export json]`

This lets IDE/automation clients explore topic graphs directly without requiring a separate search step to discover a fact ID first.

## Problem / Context
Issue #338: `cortex graph` only accepted `<fact_id>`, forcing a two-step workflow (search → extract fact id → graph). For topic-driven exploration this is unnecessary friction.

## How it works
- Extended `runGraph` parsing to support:
  - `--subject <text>`
  - `--subject=<text>`
- Added argument validation:
  - must provide either `<fact_id>` or `--subject`
  - cannot provide both at once
- Added `resolveGraphSeedFactIDsBySubject(...)`:
  - case-insensitive subject match
  - active-only seed facts (`superseded_by IS NULL OR 0`)
  - confidence floor honors `--min-confidence`
- Added `traverseGraphFromSeedFacts(...)` to run traversal from all matching subject seeds and merge/dedupe nodes/edges into one combined graph.
- Added `runGraphExportJSONWithMeta(...)` and subject-mode JSON metadata:
  - `meta.root_subject`
  - `meta.seed_fact_ids`
  - `meta.depth`
- Updated CLI usage text to document `graph --subject`.

## Testing done
- `go test ./cmd/cortex -run "TestResolveGraphSeedFactIDsBySubject|TestRunGraph_SubjectJSONIncludesSeedFactIDs|TestRunGraph_SubjectAndFactIDMutuallyExclusive"`
- `go test ./cmd/cortex`
- `go test ./...`
- New tests in `cmd/cortex/graph_subject_test.go`:
  - case-insensitive subject seed resolution (active-only)
  - end-to-end `runGraph --subject ... --export json` payload with `seed_fact_ids`
  - fact_id + --subject mutual exclusion validation

## Screenshots / before-after
Before:
- `cortex graph --subject "cortex ide"` → unsupported/invalid usage

After:
- `cortex graph --subject "cortex ide" --export json` returns merged graph JSON with subject-root metadata.

## Breaking changes / risks
- Non-breaking additive CLI capability.
- Existing `cortex graph <fact_id>` behavior remains supported.

## Merge notes
- Close #338 on merge.
