### PR TITLE
fix: content-hash dedup + filter retired from conflicts (#335)

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -320,6 +320,18 @@ func (e *Engine) processMemory(ctx context.Context, raw RawMemory, opts ImportOp
 		return nil
 	}
 
+	// Cross-source content-only dedup (#335): same content from a different source
+	// file should not create a duplicate memory. Check content-only hash.
+	contentOnlyHash := store.HashContentOnly(raw.Content)
+	crossSourceDup, err := e.store.FindByContentOnly(ctx, contentOnlyHash)
+	if err != nil {
+		return err
+	}
+	if crossSourceDup != nil {
+		result.MemoriesUnchanged++
+		return nil
+	}
+
 	if shouldSkipLowSignalCapture(raw.Content, opts) {
 		result.MemoriesUnchanged++
 		return nil

--- a/internal/store/alerts.go
+++ b/internal/store/alerts.go
@@ -236,6 +236,7 @@ func (s *SQLiteStore) CheckConflictsForFact(ctx context.Context, fact *Fact) ([]
 		   AND LOWER(predicate) = LOWER(?)
 		   AND id != ?
 		   AND superseded_by IS NULL
+		   AND state NOT IN ('retired', 'superseded')
 		   AND confidence > 0
 		 LIMIT 20`,
 		fact.Subject, fact.Predicate, fact.ID,

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -472,9 +472,11 @@ func (s *SQLiteStore) GetAttributeConflictsLimitWithSuperseded(ctx context.Conte
 		limit = 100
 	}
 
-	supersededClause := "AND f.superseded_by IS NULL"
+	// Filter out retired and superseded facts from conflict detection.
+	// Retired facts are resolved — they should not generate conflict pairs.
+	supersededClause := "AND f.superseded_by IS NULL AND f.state NOT IN ('retired', 'superseded')"
 	if includeSuperseded {
-		supersededClause = ""
+		supersededClause = "AND f.state != 'retired'"
 	}
 
 	// Build SQL exclusion clauses for known noisy predicates and generic section-bucket

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -31,10 +31,12 @@ func (s *SQLiteStore) AddMemory(ctx context.Context, m *Memory) (int64, error) {
 		return 0, fmt.Errorf("invalid memory class %q", m.MemoryClass)
 	}
 
+	contentOnlyHash := HashContentOnly(m.Content)
+
 	result, err := s.db.ExecContext(ctx,
-		`INSERT INTO memories (content, source_file, source_line, source_section, content_hash, project, memory_class, metadata, imported_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		m.Content, m.SourceFile, m.SourceLine, m.SourceSection, m.ContentHash, m.Project, m.MemoryClass, metadataArg, now, now,
+		`INSERT INTO memories (content, source_file, source_line, source_section, content_hash, content_only_hash, project, memory_class, metadata, imported_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		m.Content, m.SourceFile, m.SourceLine, m.SourceSection, m.ContentHash, contentOnlyHash, m.Project, m.MemoryClass, metadataArg, now, now,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("inserting memory: %w", err)
@@ -325,6 +327,28 @@ func (s *SQLiteStore) FindByHash(ctx context.Context, hash string) (*Memory, err
 	}
 	if err != nil {
 		return nil, fmt.Errorf("finding memory by hash: %w", err)
+	}
+	m.MemoryClass = memClass.String
+	return m, nil
+}
+
+// FindByContentOnly looks up a memory by content-only hash (ignoring source file).
+// This enables cross-source deduplication: same text from two different files is
+// recognized as a duplicate. Returns the first match or nil.
+func (s *SQLiteStore) FindByContentOnly(ctx context.Context, contentHash string) (*Memory, error) {
+	m := &Memory{}
+	var memClass sql.NullString
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id, content, source_file, source_line, source_section, content_hash, project, memory_class, imported_at, updated_at
+		 FROM memories WHERE content_only_hash = ? AND deleted_at IS NULL LIMIT 1`, contentHash,
+	).Scan(&m.ID, &m.Content, &m.SourceFile, &m.SourceLine, &m.SourceSection,
+		&m.ContentHash, &m.Project, &memClass, &m.ImportedAt, &m.UpdatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("finding memory by content-only hash: %w", err)
 	}
 	m.MemoryClass = memClass.String
 	return m, nil

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -114,6 +114,11 @@ func (s *SQLiteStore) migrate() error {
 		return fmt.Errorf("migrating cluster tables: %w", err)
 	}
 
+	// Schema evolution: content-only hash for cross-source dedup (v1.3 — Issue #335)
+	if err := s.migrateContentOnlyHash(); err != nil {
+		return fmt.Errorf("migrating content_only_hash: %w", err)
+	}
+
 	return nil
 }
 
@@ -121,15 +126,16 @@ func (s *SQLiteStore) runBootstrapDDL() error {
 	statements := []string{
 		// Core memory table
 		`CREATE TABLE IF NOT EXISTS memories (
-			id             INTEGER PRIMARY KEY AUTOINCREMENT,
-			content        TEXT NOT NULL,
-			source_file    TEXT,
-			source_line    INTEGER,
-			source_section TEXT,
-			content_hash   TEXT UNIQUE NOT NULL,
-			imported_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
-			updated_at     DATETIME DEFAULT CURRENT_TIMESTAMP,
-			deleted_at     DATETIME
+			id                INTEGER PRIMARY KEY AUTOINCREMENT,
+			content           TEXT NOT NULL,
+			source_file       TEXT,
+			source_line       INTEGER,
+			source_section    TEXT,
+			content_hash      TEXT UNIQUE NOT NULL,
+			content_only_hash TEXT DEFAULT '',
+			imported_at       DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at        DATETIME DEFAULT CURRENT_TIMESTAMP,
+			deleted_at        DATETIME
 		)`,
 
 		// FTS5 full-text search index (multi-column)
@@ -1170,6 +1176,95 @@ func (s *SQLiteStore) migrateWatchesTable() error {
 	`)
 	if err != nil {
 		return fmt.Errorf("creating watches_v1 table: %w", err)
+	}
+
+	return nil
+}
+
+// migrateContentOnlyHash adds content_only_hash column to memories for cross-source
+// deduplication (Issue #335). This column stores SHA-256(content) without the source
+// path, enabling detection of identical content imported from different files.
+func (s *SQLiteStore) migrateContentOnlyHash() error {
+	var count int
+	err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM pragma_table_info('memories') WHERE name='content_only_hash'",
+	).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("checking for content_only_hash column: %w", err)
+	}
+	if count > 0 {
+		return nil // Already migrated
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("beginning content_only_hash migration: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmts := []string{
+		`ALTER TABLE memories ADD COLUMN content_only_hash TEXT DEFAULT ''`,
+		`CREATE INDEX IF NOT EXISTS idx_memories_content_only_hash ON memories(content_only_hash)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			if isDuplicateColumnError(err) {
+				continue
+			}
+			return fmt.Errorf("executing %q: %w", truncate(stmt, 60), err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing content_only_hash migration: %w", err)
+	}
+
+	// Backfill existing rows outside the DDL transaction.
+	rows, err := s.db.Query(`SELECT id, content FROM memories WHERE content_only_hash = '' OR content_only_hash IS NULL`)
+	if err != nil {
+		return fmt.Errorf("reading memories for backfill: %w", err)
+	}
+
+	type backfillRow struct {
+		id      int64
+		content string
+	}
+	var pending []backfillRow
+	for rows.Next() {
+		var r backfillRow
+		if err := rows.Scan(&r.id, &r.content); err != nil {
+			rows.Close()
+			return fmt.Errorf("scanning memory for backfill: %w", err)
+		}
+		pending = append(pending, r)
+	}
+	rows.Close()
+
+	if len(pending) > 0 {
+		backfillTx, err := s.db.Begin()
+		if err != nil {
+			return fmt.Errorf("beginning backfill transaction: %w", err)
+		}
+		defer backfillTx.Rollback()
+
+		updateStmt, err := backfillTx.Prepare(`UPDATE memories SET content_only_hash = ? WHERE id = ?`)
+		if err != nil {
+			return fmt.Errorf("preparing backfill statement: %w", err)
+		}
+		defer updateStmt.Close()
+
+		for _, r := range pending {
+			h := HashContentOnly(r.content)
+			if _, err := updateStmt.Exec(h, r.id); err != nil {
+				return fmt.Errorf("backfilling memory %d: %w", r.id, err)
+			}
+		}
+
+		if err := backfillTx.Commit(); err != nil {
+			return fmt.Errorf("committing backfill: %w", err)
+		}
+
+		fmt.Printf("  Content-only hash migration: backfilled %d memories\n", len(pending))
 	}
 
 	return nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -251,6 +251,7 @@ type Store interface {
 
 	// Deduplication
 	FindByHash(ctx context.Context, hash string) (*Memory, error)
+	FindByContentOnly(ctx context.Context, contentHash string) (*Memory, error)
 
 	// Projects
 	ListProjects(ctx context.Context) ([]ProjectInfo, error)


### PR DESCRIPTION
## Root Fix for Conflict Explosion

Closes #335.

### Problem
Three launchd services (`file-watch`, `session-sync`, `lifecycle`) continuously import the same content from different source files. Since `HashMemoryContent` includes the source path, identical text from different files creates separate memories, each triggering fact extraction → duplicate facts → conflict explosion. The `conflicts` command also reports retired fact pairs, making the count appear inflated even after cleanup.

### Fix 1: Cross-source content dedup at import
- New `content_only_hash` column on memories (SHA-256 of content only, no source path)
- Auto-migration backfills all existing rows
- `processMemory()` checks content-only hash after source-specific hash — if same content exists from any source, skip
- Cuts the feedback loop at the root

### Fix 2: Filter retired/superseded from conflict detection
- `GetAttributeConflictsLimitWithSuperseded()`: add `f.state NOT IN ('retired', 'superseded')`
- `CheckConflictsForFact()`: same filter
- Retired facts stop generating phantom conflict pairs
- The "conflict count never drops after retirement" bug is fixed

### Testing
All 18 test suites pass. No new dependencies.

### Stats
6 files changed, +149/-14