### PR TITLE
feat: maintenance automation scripts (dedup + lifecycle orchestrator)

### DIFF
--- a/examples/launchd/com.cortex.maintenance.plist
+++ b/examples/launchd/com.cortex.maintenance.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- 
+  Cortex daily maintenance: lifecycle policies + dedup sweep.
+  
+  Install:
+    cp com.cortex.maintenance.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.cortex.maintenance.plist
+  
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.cortex.maintenance.plist
+    rm ~/Library/LaunchAgents/com.cortex.maintenance.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cortex.maintenance</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>$HOME/bin/cortex-maintenance.sh</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:$HOME/bin</string>
+    </dict>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/cortex-maintenance.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/cortex-maintenance.stderr.log</string>
+</dict>
+</plist>

--- a/scripts/cortex-dedup.sh
+++ b/scripts/cortex-dedup.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# cortex-dedup.sh — Keep only the newest fact per subject, retire older duplicates.
+#
+# Prevents unbounded fact growth from slightly-different content being
+# re-imported and generating new facts on the same subject.
+#
+# Run after `cortex lifecycle run` as part of daily maintenance, or on-demand.
+#
+# Usage:
+#   ./cortex-dedup.sh              # retire duplicates
+#   ./cortex-dedup.sh --dry-run    # show count without changing anything
+#
+# Environment:
+#   CORTEX_DB  — path to cortex.db (default: ~/.cortex/cortex.db)
+
+set -euo pipefail
+
+DB="${CORTEX_DB:-$HOME/.cortex/cortex.db}"
+DRY_RUN=false
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+if [ ! -f "$DB" ]; then
+  echo "ERROR: Cortex DB not found at $DB"
+  exit 1
+fi
+
+# Count duplicates (active facts that aren't the newest per subject)
+DUPE_COUNT=$(sqlite3 "$DB" "
+SELECT COUNT(*) FROM facts 
+WHERE state NOT IN ('retired', 'superseded') 
+AND id NOT IN (
+    SELECT id FROM (
+        SELECT id, subject, ROW_NUMBER() OVER (PARTITION BY subject ORDER BY created_at DESC) as rn
+        FROM facts 
+        WHERE state NOT IN ('retired', 'superseded')
+    ) WHERE rn = 1
+);")
+
+if [ "$DUPE_COUNT" -eq 0 ]; then
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) cortex-dedup: clean — 0 duplicates found"
+  exit 0
+fi
+
+if [ "$DRY_RUN" = true ]; then
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) cortex-dedup: DRY RUN — would retire $DUPE_COUNT duplicate facts"
+  exit 0
+fi
+
+# Retire all duplicates in one SQL statement (keep newest per subject)
+RETIRED=$(sqlite3 "$DB" "
+UPDATE facts SET state = 'retired'
+WHERE state NOT IN ('retired', 'superseded') 
+AND id NOT IN (
+    SELECT id FROM (
+        SELECT id, subject, ROW_NUMBER() OVER (PARTITION BY subject ORDER BY created_at DESC) as rn
+        FROM facts 
+        WHERE state NOT IN ('retired', 'superseded')
+    ) WHERE rn = 1
+);
+SELECT changes();")
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) cortex-dedup: retired $RETIRED duplicate facts (kept newest per subject)"

--- a/scripts/cortex-maintenance.sh
+++ b/scripts/cortex-maintenance.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# cortex-maintenance.sh — Daily maintenance: lifecycle + dedup + stats.
+#
+# Designed to run as a launchd/systemd timer (daily, e.g., 3:30 AM).
+# Runs lifecycle policies first, then dedup sweep, then logs summary.
+#
+# Usage:
+#   ./cortex-maintenance.sh
+#
+# Environment:
+#   CORTEX_DB      — path to cortex.db (default: ~/.cortex/cortex.db)
+#   CORTEX_BIN     — path to cortex binary (default: cortex in PATH)
+#   CORTEX_LOGDIR  — log directory (default: ~/.cortex/logs)
+
+set -euo pipefail
+
+CORTEX_BIN="${CORTEX_BIN:-cortex}"
+LOGDIR="${CORTEX_LOGDIR:-$HOME/.cortex/logs}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+mkdir -p "$LOGDIR"
+LOG="$LOGDIR/maintenance.log"
+
+echo "=== Cortex maintenance: $TIMESTAMP ===" >> "$LOG"
+
+# Step 1: Lifecycle policies (decay, supersede, promote)
+echo "[$TIMESTAMP] Running lifecycle policies..." >> "$LOG"
+$CORTEX_BIN lifecycle run >> "$LOG" 2>&1 || echo "[$TIMESTAMP] WARNING: lifecycle run failed" >> "$LOG"
+
+# Step 2: Dedup sweep (keep newest per subject)
+echo "[$TIMESTAMP] Running dedup sweep..." >> "$LOG"
+"$SCRIPT_DIR/cortex-dedup.sh" >> "$LOG" 2>&1 || echo "[$TIMESTAMP] WARNING: dedup failed" >> "$LOG"
+
+# Step 3: Summary stats
+ACTIVE=$(sqlite3 "${CORTEX_DB:-$HOME/.cortex/cortex.db}" "SELECT COUNT(*) FROM facts WHERE state NOT IN ('retired','superseded');")
+CONFLICTS=$($CORTEX_BIN conflicts --json 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "?")
+echo "[$TIMESTAMP] Post-maintenance: $ACTIVE active facts, $CONFLICTS conflicts" >> "$LOG"
+
+echo "cortex-maintenance: done — $ACTIVE active facts, $CONFLICTS conflicts"


### PR DESCRIPTION
## Maintenance Automation for Cortex

Closes the operational side of #343.

### What's Included

**`scripts/cortex-dedup.sh`**
- Keeps only the newest fact per subject, retires all older duplicates
- Single SQL statement — processes thousands of facts instantly
- Supports `--dry-run` mode
- Respects `CORTEX_DB` env var

**`scripts/cortex-maintenance.sh`**
- Daily maintenance orchestrator: lifecycle policies → dedup sweep → stats summary
- Logs to `~/.cortex/logs/maintenance.log`
- Designed to run as a cron/launchd timer

**`examples/launchd/com.cortex.maintenance.plist`**
- macOS launchd template — runs daily at 3:30 AM
- Drop-in install instructions in XML comments

### Context
PR #342 fixed the root cause (cross-source content dedup at import). These scripts handle the remaining growth vector: slightly different content creating new facts on the same subject over time. Together they keep the fact store lean without manual intervention.

### Stats
3 files, +146 lines. No Go code changes. No new dependencies.