### PR TITLE
feat(extract): auto-supersede stale facts on subject updates (#343)

### DIFF
--- a/cmd/cortex/extraction_auto_supersede_test.go
+++ b/cmd/cortex/extraction_auto_supersede_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hurttlocker/cortex/internal/ingest"
+	"github.com/hurttlocker/cortex/internal/observe"
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+func importAndExtractFacts(t *testing.T, ctx context.Context, engine *ingest.Engine, s store.Store, filePath string) (*ingest.ImportResult, *ExtractionStats) {
+	t.Helper()
+
+	importResult, err := engine.ImportFile(ctx, filePath, ingest.ImportOptions{})
+	if err != nil {
+		t.Fatalf("ImportFile(%s): %v", filePath, err)
+	}
+
+	extractionStats, err := runExtractionOnImportedMemories(ctx, s, "", importResult.NewMemoryIDs, nil)
+	if err != nil {
+		t.Fatalf("runExtractionOnImportedMemories(%s): %v", filePath, err)
+	}
+
+	return importResult, extractionStats
+}
+
+func TestRunExtractionOnImportedMemories_AutoSupersedesChangedObject(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "cortex.db")
+
+	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer s.Close()
+
+	engine := ingest.NewEngine(s)
+
+	filePath := filepath.Join(t.TempDir(), "service-status.md")
+	if err := os.WriteFile(filePath, []byte("status: running\nnotes: this service keeps telemetry pipeline healthy during daily sync runs.\n"), 0o644); err != nil {
+		t.Fatalf("write v1 file: %v", err)
+	}
+
+	firstImport, firstExtraction := importAndExtractFacts(t, ctx, engine, s, filePath)
+	if firstImport.MemoriesNew != 1 {
+		t.Fatalf("expected first import to create 1 memory, got %d", firstImport.MemoriesNew)
+	}
+	if firstExtraction.FactsExtracted == 0 {
+		t.Fatalf("expected first extraction to produce at least one fact")
+	}
+
+	activeBefore, err := s.ListFacts(ctx, store.ListOpts{Limit: 50})
+	if err != nil {
+		t.Fatalf("ListFacts active before: %v", err)
+	}
+	if len(activeBefore) == 0 {
+		t.Fatalf("expected at least one active fact after first import")
+	}
+
+	var seed *store.Fact
+	for _, f := range activeBefore {
+		if strings.EqualFold(strings.TrimSpace(f.Object), "running") {
+			seed = f
+			break
+		}
+	}
+	if seed == nil {
+		t.Fatalf("expected to find extracted running fact; active facts=%d", len(activeBefore))
+	}
+
+	if err := os.WriteFile(filePath, []byte("status: stopped\nnotes: this service keeps telemetry pipeline healthy during daily sync runs.\n"), 0o644); err != nil {
+		t.Fatalf("write v2 file: %v", err)
+	}
+
+	secondImport, secondExtraction := importAndExtractFacts(t, ctx, engine, s, filePath)
+	if secondImport.MemoriesNew != 1 {
+		t.Fatalf("expected second import to create 1 new memory for changed content, got %d", secondImport.MemoriesNew)
+	}
+	if secondExtraction.FactsExtracted == 0 {
+		t.Fatalf("expected second extraction to produce at least one fact")
+	}
+
+	allFacts, err := s.ListFacts(ctx, store.ListOpts{Limit: 200, IncludeSuperseded: true})
+	if err != nil {
+		t.Fatalf("ListFacts include superseded: %v", err)
+	}
+
+	matching := make([]*store.Fact, 0)
+	for _, f := range allFacts {
+		if strings.EqualFold(strings.TrimSpace(f.Subject), strings.TrimSpace(seed.Subject)) &&
+			strings.EqualFold(strings.TrimSpace(f.Predicate), strings.TrimSpace(seed.Predicate)) {
+			matching = append(matching, f)
+		}
+	}
+	if len(matching) != 2 {
+		t.Fatalf("expected 2 facts for same subject+predicate after value change, got %d", len(matching))
+	}
+
+	var activeFact *store.Fact
+	var supersededFact *store.Fact
+	for _, f := range matching {
+		if f.SupersededBy == nil {
+			activeFact = f
+		} else {
+			supersededFact = f
+		}
+	}
+	if activeFact == nil || supersededFact == nil {
+		t.Fatalf("expected one active + one superseded fact, got active=%v superseded=%v", activeFact != nil, supersededFact != nil)
+	}
+	if !strings.EqualFold(strings.TrimSpace(activeFact.Object), "stopped") {
+		t.Fatalf("expected active object to be 'stopped', got %q", activeFact.Object)
+	}
+	if supersededFact.SupersededBy == nil || *supersededFact.SupersededBy != activeFact.ID {
+		t.Fatalf("expected old fact to be superseded by new fact (%d), got %v", activeFact.ID, supersededFact.SupersededBy)
+	}
+	if !strings.EqualFold(strings.TrimSpace(supersededFact.State), store.FactStateSuperseded) {
+		t.Fatalf("expected superseded fact state=%q, got %q", store.FactStateSuperseded, supersededFact.State)
+	}
+
+	engineObs := observe.NewEngine(s, dbPath)
+	conflicts, err := engineObs.GetConflicts(ctx)
+	if err != nil {
+		t.Fatalf("GetConflicts: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("expected no active conflicts after auto-supersede, got %d", len(conflicts))
+	}
+}
+
+func TestRunExtractionOnImportedMemories_SkipsDuplicateObjectForSameSubjectPredicate(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "cortex.db")
+
+	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer s.Close()
+
+	engine := ingest.NewEngine(s)
+
+	filePath := filepath.Join(t.TempDir(), "deploy-status.md")
+	if err := os.WriteFile(filePath, []byte("status: running\nnotes: first capture includes context so markdown chunk length stays above threshold.\n"), 0o644); err != nil {
+		t.Fatalf("write v1 file: %v", err)
+	}
+
+	_, firstExtraction := importAndExtractFacts(t, ctx, engine, s, filePath)
+	if firstExtraction.FactsExtracted == 0 {
+		t.Fatalf("expected first extraction to produce facts")
+	}
+
+	allBefore, err := s.ListFacts(ctx, store.ListOpts{Limit: 200, IncludeSuperseded: true})
+	if err != nil {
+		t.Fatalf("ListFacts before second import: %v", err)
+	}
+	countRunningBefore := 0
+	for _, f := range allBefore {
+		if strings.EqualFold(strings.TrimSpace(f.Predicate), "status") && strings.EqualFold(strings.TrimSpace(f.Object), "running") {
+			countRunningBefore++
+		}
+	}
+
+	if err := os.WriteFile(filePath, []byte("status: running\nnotes: changed line now references an updated paragraph but same status value.\n"), 0o644); err != nil {
+		t.Fatalf("write v2 file: %v", err)
+	}
+
+	_, secondExtraction := importAndExtractFacts(t, ctx, engine, s, filePath)
+	if secondExtraction.FactsExtracted == 0 {
+		t.Fatalf("expected second extraction to still produce facts for changed content")
+	}
+
+	allAfter, err := s.ListFacts(ctx, store.ListOpts{Limit: 200, IncludeSuperseded: true})
+	if err != nil {
+		t.Fatalf("ListFacts after second import: %v", err)
+	}
+	countRunningAfter := 0
+	for _, f := range allAfter {
+		if strings.EqualFold(strings.TrimSpace(f.Predicate), "status") && strings.EqualFold(strings.TrimSpace(f.Object), "running") {
+			countRunningAfter++
+		}
+	}
+
+	if countRunningAfter != countRunningBefore {
+		t.Fatalf("expected duplicate same-object status fact to be skipped (before=%d after=%d)", countRunningBefore, countRunningAfter)
+	}
+}

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -3663,9 +3663,12 @@ func runExtractionOnImportedMemories(ctx context.Context, s store.Store, llmFlag
 				SourceQuote: extractedFact.SourceQuote,
 			}
 
-			factID, err := s.AddFact(ctx, fact)
+			factID, stored, err := ingest.StoreExtractedFact(ctx, s, fact)
 			if err != nil {
-				continue // Skip storage errors
+				continue // Skip storage/supersession errors
+			}
+			if !stored {
+				continue // Existing active fact already represents current object
 			}
 
 			stats.FactsExtracted++
@@ -4994,7 +4997,7 @@ func runUpdate(args []string) error {
 		}
 
 		for _, extractedFact := range extractedFacts {
-			_, err := s.AddFact(ctx, &store.Fact{
+			_, stored, err := ingest.StoreExtractedFact(ctx, s, &store.Fact{
 				MemoryID:    memoryID,
 				Subject:     extractedFact.Subject,
 				Predicate:   extractedFact.Predicate,
@@ -5007,7 +5010,9 @@ func runUpdate(args []string) error {
 			if err != nil {
 				continue
 			}
-			factCount++
+			if stored {
+				factCount++
+			}
 		}
 	}
 

--- a/internal/ingest/extracted_facts.go
+++ b/internal/ingest/extracted_facts.go
@@ -1,0 +1,118 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+type activeFactMatch struct {
+	ID     int64
+	Object string
+}
+
+func findActiveFactMatchesBySubjectPredicate(ctx context.Context, s store.Store, subject, predicate, agentID string) ([]activeFactMatch, error) {
+	sqlStore, ok := s.(*store.SQLiteStore)
+	if !ok {
+		return nil, nil
+	}
+
+	rows, err := sqlStore.GetDB().QueryContext(ctx,
+		`SELECT id, object
+		   FROM facts
+		  WHERE superseded_by IS NULL
+		    AND LOWER(TRIM(subject)) = LOWER(TRIM(?))
+		    AND LOWER(TRIM(predicate)) = LOWER(TRIM(?))
+		    AND COALESCE(agent_id, '') = ?
+		    AND COALESCE(LOWER(state), 'active') IN ('active', 'core')
+		  ORDER BY created_at DESC, id DESC`,
+		subject, predicate, agentID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying active fact matches: %w", err)
+	}
+	defer rows.Close()
+
+	matches := make([]activeFactMatch, 0)
+	for rows.Next() {
+		var match activeFactMatch
+		if err := rows.Scan(&match.ID, &match.Object); err != nil {
+			return nil, fmt.Errorf("scanning active fact match: %w", err)
+		}
+		matches = append(matches, match)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating active fact matches: %w", err)
+	}
+
+	return matches, nil
+}
+
+// StoreExtractedFact writes an extracted fact through the ingest-layer conflict-prevention policy.
+//
+// Rules:
+//   - If no active same subject+predicate fact exists, insert the candidate.
+//   - If an active fact exists with the same object, skip inserting a duplicate.
+//   - If active facts exist with different objects, supersede them in favor of the current object.
+//   - If the current object already exists, reuse the newest matching active fact as winner and
+//     supersede only the conflicting older-object facts.
+func StoreExtractedFact(ctx context.Context, s store.Store, fact *store.Fact) (factID int64, stored bool, err error) {
+	if fact == nil {
+		return 0, false, fmt.Errorf("fact is nil")
+	}
+
+	subject := strings.TrimSpace(fact.Subject)
+	predicate := strings.TrimSpace(fact.Predicate)
+	if subject == "" || predicate == "" {
+		factID, err := s.AddFact(ctx, fact)
+		return factID, err == nil, err
+	}
+
+	matches, err := findActiveFactMatchesBySubjectPredicate(ctx, s, subject, predicate, fact.AgentID)
+	if err != nil {
+		return 0, false, err
+	}
+
+	candidateObject := strings.TrimSpace(fact.Object)
+	var winnerID int64
+	conflictingIDs := make([]int64, 0, len(matches))
+	for _, match := range matches {
+		if strings.TrimSpace(match.Object) == candidateObject {
+			if winnerID == 0 {
+				winnerID = match.ID
+			}
+			continue
+		}
+		conflictingIDs = append(conflictingIDs, match.ID)
+	}
+
+	if winnerID != 0 {
+		for _, oldFactID := range conflictingIDs {
+			if oldFactID <= 0 || oldFactID == winnerID {
+				continue
+			}
+			if err := s.SupersedeFact(ctx, oldFactID, winnerID, "auto-supersede on extract: existing active fact matches imported object"); err != nil {
+				return winnerID, false, err
+			}
+		}
+		return winnerID, false, nil
+	}
+
+	factID, err = s.AddFact(ctx, fact)
+	if err != nil {
+		return 0, false, err
+	}
+
+	for _, oldFactID := range conflictingIDs {
+		if oldFactID <= 0 || oldFactID == factID {
+			continue
+		}
+		if err := s.SupersedeFact(ctx, oldFactID, factID, "auto-supersede on extract: updated object for same subject+predicate"); err != nil {
+			return factID, true, err
+		}
+	}
+
+	return factID, true, nil
+}

--- a/internal/ingest/extracted_facts_test.go
+++ b/internal/ingest/extracted_facts_test.go
@@ -1,0 +1,144 @@
+package ingest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+func TestStoreExtractedFact_AutoSupersedesChangedObject(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	memoryA, err := s.AddMemory(ctx, &store.Memory{Content: "status: running", SourceFile: "a.md"})
+	if err != nil {
+		t.Fatalf("AddMemory A: %v", err)
+	}
+	oldFactID, err := s.AddFact(ctx, &store.Fact{
+		MemoryID:   memoryA,
+		Subject:    "service-status",
+		Predicate:  "status",
+		Object:     "running",
+		FactType:   "state",
+		Confidence: 0.8,
+	})
+	if err != nil {
+		t.Fatalf("AddFact old: %v", err)
+	}
+
+	memoryB, err := s.AddMemory(ctx, &store.Memory{Content: "status: stopped", SourceFile: "b.md"})
+	if err != nil {
+		t.Fatalf("AddMemory B: %v", err)
+	}
+	newFactID, stored, err := StoreExtractedFact(ctx, s, &store.Fact{
+		MemoryID:   memoryB,
+		Subject:    "service-status",
+		Predicate:  "status",
+		Object:     "stopped",
+		FactType:   "state",
+		Confidence: 0.9,
+	})
+	if err != nil {
+		t.Fatalf("StoreExtractedFact: %v", err)
+	}
+	if !stored {
+		t.Fatalf("expected changed object to store a new fact")
+	}
+	if newFactID <= 0 {
+		t.Fatalf("expected new fact id, got %d", newFactID)
+	}
+
+	oldFact, err := s.GetFact(ctx, oldFactID)
+	if err != nil {
+		t.Fatalf("GetFact old: %v", err)
+	}
+	if oldFact == nil || oldFact.SupersededBy == nil || *oldFact.SupersededBy != newFactID {
+		t.Fatalf("expected old fact to be superseded by %d, got %+v", newFactID, oldFact)
+	}
+	if !strings.EqualFold(oldFact.State, store.FactStateSuperseded) {
+		t.Fatalf("expected old fact state=%q, got %q", store.FactStateSuperseded, oldFact.State)
+	}
+}
+
+func TestStoreExtractedFact_SkipsDuplicateObjectAndSupersedesConflicts(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	memoryA, err := s.AddMemory(ctx, &store.Memory{Content: "status: running", SourceFile: "a.md"})
+	if err != nil {
+		t.Fatalf("AddMemory A: %v", err)
+	}
+	winnerID, err := s.AddFact(ctx, &store.Fact{
+		MemoryID:   memoryA,
+		Subject:    "service-status",
+		Predicate:  "status",
+		Object:     "running",
+		FactType:   "state",
+		Confidence: 0.95,
+	})
+	if err != nil {
+		t.Fatalf("AddFact winner: %v", err)
+	}
+
+	memoryB, err := s.AddMemory(ctx, &store.Memory{Content: "status: stopped", SourceFile: "b.md"})
+	if err != nil {
+		t.Fatalf("AddMemory B: %v", err)
+	}
+	loserID, err := s.AddFact(ctx, &store.Fact{
+		MemoryID:   memoryB,
+		Subject:    "service-status",
+		Predicate:  "status",
+		Object:     "stopped",
+		FactType:   "state",
+		Confidence: 0.7,
+	})
+	if err != nil {
+		t.Fatalf("AddFact loser: %v", err)
+	}
+
+	memoryC, err := s.AddMemory(ctx, &store.Memory{Content: "status: running updated import", SourceFile: "c.md"})
+	if err != nil {
+		t.Fatalf("AddMemory C: %v", err)
+	}
+	factID, stored, err := StoreExtractedFact(ctx, s, &store.Fact{
+		MemoryID:   memoryC,
+		Subject:    "service-status",
+		Predicate:  "status",
+		Object:     "running",
+		FactType:   "state",
+		Confidence: 0.92,
+	})
+	if err != nil {
+		t.Fatalf("StoreExtractedFact: %v", err)
+	}
+	if stored {
+		t.Fatalf("expected identical object to skip insert")
+	}
+	if factID != winnerID {
+		t.Fatalf("expected existing matching fact %d to remain winner, got %d", winnerID, factID)
+	}
+
+	loserFact, err := s.GetFact(ctx, loserID)
+	if err != nil {
+		t.Fatalf("GetFact loser: %v", err)
+	}
+	if loserFact == nil || loserFact.SupersededBy == nil || *loserFact.SupersededBy != winnerID {
+		t.Fatalf("expected conflicting loser to be superseded by %d, got %+v", winnerID, loserFact)
+	}
+
+	allFacts, err := s.ListFacts(ctx, store.ListOpts{Limit: 50, IncludeSuperseded: true})
+	if err != nil {
+		t.Fatalf("ListFacts: %v", err)
+	}
+	activeRunning := 0
+	for _, f := range allFacts {
+		if f.SupersededBy == nil && strings.EqualFold(strings.TrimSpace(f.Object), "running") {
+			activeRunning++
+		}
+	}
+	if activeRunning != 1 {
+		t.Fatalf("expected exactly one active 'running' fact, got %d", activeRunning)
+	}
+}


### PR DESCRIPTION
## What this does
Implements proactive conflict prevention during extraction: when a newly extracted fact has the same `subject+predicate` as an existing active fact but a different `object`, the old fact is automatically superseded at write time instead of surviving as a conflict.

This turns #343 from reactive maintenance into immediate ingestion-time lifecycle correctness.

## Problem / Context
Issue #343 is the follow-up to #342 content-hash dedup.

#342 stops identical content from creating duplicate memories, but it does **not** handle the common “slightly changed file” case:
- import creates a new memory (correct)
- extraction emits a new fact with the same `subject+predicate`
- old and new objects coexist as active facts
- conflicts/lifecycle cleanup have to repair it later

The acceptance target here is to prevent that at extraction time.

## How it works
### Ingest-layer write helper
Moved the policy into the ingest layer with a new helper:
- `internal/ingest/extracted_facts.go`
- `StoreExtractedFact(ctx, store, fact)`

Behavior:
1. Query active/core facts with the same normalized `subject+predicate` and same `agent_id` namespace.
2. If an active fact already has the same trimmed `object`:
   - skip inserting a duplicate
   - if conflicting old-object facts still exist, supersede them to that existing winner
3. If no active fact has the same object:
   - insert the new fact
   - supersede all active same-subject+predicate facts with different objects

### Wiring
The CLI now delegates extracted-fact persistence to the ingest helper in two extracted-fact write paths:
- `runExtractionOnImportedMemories(...)`
- `runUpdate(... --extract)` re-extraction path

This keeps the policy out of ad hoc CLI-only logic and makes the ingest/extraction layer own the lifecycle behavior.

## Testing done
### Targeted ingest-layer tests
- `go test ./internal/ingest -run "TestStoreExtractedFact_(AutoSupersedesChangedObject|SkipsDuplicateObjectAndSupersedesConflicts)"`

### Targeted extraction regression tests
- `go test ./cmd/cortex -run "TestRunExtractionOnImportedMemories_(AutoSupersedesChangedObject|SkipsDuplicateObjectForSameSubjectPredicate)"`

### Package suites
- `go test ./cmd/cortex ./internal/ingest`

### Full repo
- `go test ./...`

### New tests
#### `internal/ingest/extracted_facts_test.go`
1. **`TestStoreExtractedFact_AutoSupersedesChangedObject`**
   - changed object inserts a new fact
   - old fact becomes superseded by the new fact
2. **`TestStoreExtractedFact_SkipsDuplicateObjectAndSupersedesConflicts`**
   - identical object reuses existing active fact
   - conflicting older-object fact is superseded to that winner

#### `cmd/cortex/extraction_auto_supersede_test.go`
1. **`TestRunExtractionOnImportedMemories_AutoSupersedesChangedObject`**
   - import same file twice with `running -> stopped`
   - verifies no active conflict remains
2. **`TestRunExtractionOnImportedMemories_SkipsDuplicateObjectForSameSubjectPredicate`**
   - changed content but unchanged value
   - verifies duplicate insert is skipped

## Screenshots / before-after
### Before
- Re-import with updated value produced parallel active facts that had to be cleaned up later by lifecycle/dedup.

### After
- Re-import with updated value supersedes the old fact immediately.
- Re-import with unchanged value skips duplicate insert.

(Backend behavior change; test evidence above.)

## Breaking changes / risks
- **No breaking API or schema changes.**
- Behavior change is intentional: extracted facts now proactively enforce same-subject update supersession.
- Scope is bounded to extracted-fact persistence paths; no new telemetry stack, no migration, no unrelated lifecycle widening.

## Merge notes
- Closes #343 on merge.