### PR TITLE
fix(extract): tighten auto-capture governor noise filters (#346)

### DIFF
--- a/internal/extract/extract_test.go
+++ b/internal/extract/extract_test.go
@@ -304,6 +304,37 @@ Current time: Saturday, February 14th, 2026 — 9:04 PM
 	}
 }
 
+func TestPipelineExtract_AutoCaptureUsesStricterGovernor(t *testing.T) {
+	pipeline := NewPipeline()
+	text := "**Status:** false\n**Decision:** ship the governor tightening today"
+
+	facts, err := pipeline.Extract(context.Background(), text, map[string]string{"source_file": "/tmp/cortex-capture-abc/auto-capture.md"})
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+
+	if len(facts) != 1 {
+		t.Fatalf("expected auto-capture strict governor to keep only one fact, got %d: %+v", len(facts), facts)
+	}
+	if facts[0].Predicate != "decision" {
+		t.Fatalf("expected decision fact to survive strict governor, got %+v", facts[0])
+	}
+}
+
+func TestPipelineExtract_NonAutoCaptureKeepsBooleanState(t *testing.T) {
+	pipeline := NewPipeline()
+	text := "**Status:** false\n**Decision:** ship the governor tightening today"
+
+	facts, err := pipeline.Extract(context.Background(), text, map[string]string{"source_file": "/tmp/status-notes.md"})
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+
+	if len(facts) != 2 {
+		t.Fatalf("expected non-auto-capture path to keep both facts, got %d: %+v", len(facts), facts)
+	}
+}
+
 func TestNormalizeSubject_PreservesStructuredHierarchy(t *testing.T) {
 	subj := normalizeSubject("COMPLETED TODAY > Trading Systems", false)
 	if subj != "COMPLETED TODAY > Trading Systems" {

--- a/internal/extract/governor.go
+++ b/internal/extract/governor.go
@@ -28,6 +28,17 @@ type GovernorConfig struct {
 	// DropGenericSubjects removes facts with subjects that carry no signal
 	// (e.g., "Conversation Summary", empty subjects). Default: true.
 	DropGenericSubjects bool
+
+	// DropTransientFacts enables stricter subject/predicate filtering for
+	// conversation auto-capture noise (timestamps, message metadata, trivial state echoes).
+	DropTransientFacts bool
+
+	// DropBooleanObjects removes trivial yes/no style object values for noisy sources.
+	DropBooleanObjects bool
+
+	// DropInstructionParroting removes facts that appear to mirror prompt/rules language
+	// instead of durable knowledge.
+	DropInstructionParroting bool
 }
 
 // DefaultGovernorConfig returns the recommended default governor settings.
@@ -48,11 +59,14 @@ func DefaultGovernorConfig() GovernorConfig {
 // Auto-capture text is noisy by nature — only high-signal facts survive.
 func AutoCaptureGovernorConfig() GovernorConfig {
 	return GovernorConfig{
-		MaxFactsPerMemory:   5,
-		MinObjectLength:     4,
-		MinPredicateLength:  5,
-		DropMarkdownJunk:    true,
-		DropGenericSubjects: true,
+		MaxFactsPerMemory:        3,
+		MinObjectLength:          6,
+		MinPredicateLength:       5,
+		DropMarkdownJunk:         true,
+		DropGenericSubjects:      true,
+		DropTransientFacts:       true,
+		DropBooleanObjects:       true,
+		DropInstructionParroting: true,
 	}
 }
 
@@ -153,6 +167,31 @@ func (g *Governor) isNoise(f ExtractedFact) bool {
 		return true
 	}
 
+	predLower := strings.ToLower(pred)
+	objLower := strings.ToLower(obj)
+	subjLower := strings.ToLower(subj)
+
+	if g.config.DropTransientFacts {
+		if autoCaptureNoisePredicates[predLower] {
+			return true
+		}
+		for _, prefix := range autoCaptureNoiseSubjectPrefixes {
+			if strings.HasPrefix(subjLower, prefix) {
+				return true
+			}
+		}
+	}
+
+	if g.config.DropBooleanObjects {
+		if autoCaptureNoiseObjects[normalizeGovernorToken(objLower)] {
+			return true
+		}
+	}
+
+	if g.config.DropInstructionParroting && isInstructionParroting(subj, pred, obj) {
+		return true
+	}
+
 	// Object is just a repetition of the predicate (circular fact)
 	if strings.EqualFold(obj, pred) {
 		return true
@@ -169,10 +208,6 @@ func (g *Governor) isNoise(f ExtractedFact) bool {
 	}
 
 	// --- v0.9.0 noise filters (Feb 2026) ---
-
-	predLower := strings.ToLower(pred)
-	objLower := strings.ToLower(obj)
-	subjLower := strings.ToLower(subj)
 
 	// Generic regex-extracted predicates that aren't real facts.
 	// Note: "email" and "phone" are kept — they're valid in KV pairs like "Email: test@example.com"
@@ -293,6 +328,44 @@ func isMarkdownJunk(s string) bool {
 
 // gitHashRE matches predicates that are git commit hashes (6+ hex chars).
 var gitHashRE = regexp.MustCompile(`^[0-9a-f]{6,}\b`)
+
+var autoCaptureNoisePredicates = map[string]bool{
+	"is":    true,
+	"is on": true,
+	"is at": true,
+	"has":   true,
+	"was":   true,
+	"are":   true,
+}
+
+var autoCaptureNoiseSubjectPrefixes = []string{
+	"current",
+	"timestamp",
+	"message ",
+}
+
+var autoCaptureNoiseObjects = map[string]bool{
+	"true":    true,
+	"false":   true,
+	"yes":     true,
+	"no":      true,
+	"none":    true,
+	"n/a":     true,
+	"active":  true,
+	"enabled": true,
+}
+
+var instructionSignals = []string{
+	"must",
+	"should",
+	"never",
+	"always",
+	"do not",
+	"read-only",
+	"append only",
+	"flush",
+	"overwrite",
+}
 
 // timestampSubjectRE matches subjects that are primarily timestamps or
 // timestamp-prefixed section headers — strong signal of auto-capture noise.
@@ -419,6 +492,26 @@ func isOnlyFormatting(s string) bool {
 		}
 	}
 	return true
+}
+
+func normalizeGovernorToken(s string) string {
+	normalized := strings.ToLower(strings.TrimSpace(s))
+	normalized = strings.Trim(normalized, "\"'`.,;:!?()[]{}")
+	return normalized
+}
+
+func isInstructionParroting(subj, pred, obj string) bool {
+	combined := strings.ToLower(strings.Join([]string{subj, pred, obj}, " "))
+	count := 0
+	for _, signal := range instructionSignals {
+		if strings.Contains(combined, signal) {
+			count++
+			if count >= 2 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // deduplicateByTriple removes facts with the same (subject, predicate, object) triple,

--- a/internal/extract/governor_test.go
+++ b/internal/extract/governor_test.go
@@ -332,11 +332,69 @@ func TestGovernor_TighterDefaults(t *testing.T) {
 	}
 
 	acfg := AutoCaptureGovernorConfig()
-	if acfg.MaxFactsPerMemory != 5 {
-		t.Errorf("expected AutoCapture MaxFactsPerMemory=5, got %d", acfg.MaxFactsPerMemory)
+	if acfg.MaxFactsPerMemory != 3 {
+		t.Errorf("expected AutoCapture MaxFactsPerMemory=3, got %d", acfg.MaxFactsPerMemory)
 	}
-	if acfg.MinObjectLength != 4 {
-		t.Errorf("expected AutoCapture MinObjectLength=4, got %d", acfg.MinObjectLength)
+	if acfg.MinObjectLength != 6 {
+		t.Errorf("expected AutoCapture MinObjectLength=6, got %d", acfg.MinObjectLength)
+	}
+	if !acfg.DropTransientFacts {
+		t.Error("expected AutoCapture DropTransientFacts=true")
+	}
+	if !acfg.DropBooleanObjects {
+		t.Error("expected AutoCapture DropBooleanObjects=true")
+	}
+	if !acfg.DropInstructionParroting {
+		t.Error("expected AutoCapture DropInstructionParroting=true")
+	}
+}
+
+func TestGovernor_AutoCaptureDropsTransientAndBooleanNoise(t *testing.T) {
+	gov := NewGovernor(AutoCaptureGovernorConfig())
+
+	facts := []ExtractedFact{
+		{Subject: "Current UTC time", Predicate: "status", Object: "2026-03-15 17:52", FactType: "temporal", Confidence: 0.9},
+		{Subject: "Repository HEAD", Predicate: "is on", Object: "origin/main", FactType: "state", Confidence: 0.9},
+		{Subject: "Feature flag", Predicate: "status", Object: "active", FactType: "state", Confidence: 0.9},
+		{Subject: "Cortex", Predicate: "decision", Object: "ship governor tightening now", FactType: "decision", Confidence: 0.92},
+	}
+
+	result := gov.Apply(facts)
+	if len(result) != 1 {
+		t.Fatalf("expected only one durable fact to remain, got %d: %+v", len(result), result)
+	}
+	if result[0].Subject != "Cortex" {
+		t.Fatalf("expected Cortex decision fact to survive, got %+v", result[0])
+	}
+}
+
+func TestGovernor_AutoCaptureDropsInstructionParroting(t *testing.T) {
+	gov := NewGovernor(AutoCaptureGovernorConfig())
+
+	facts := []ExtractedFact{
+		{Subject: "workspace policy", Predicate: "governor note", Object: "read-only during flush and never overwrite memory files", FactType: "kv", Confidence: 0.9},
+		{Subject: "Cortex", Predicate: "decision", Object: "ship the bounded governor patch", FactType: "decision", Confidence: 0.9},
+	}
+
+	result := gov.Apply(facts)
+	if len(result) != 1 {
+		t.Fatalf("expected instruction parroting to drop, got %d: %+v", len(result), result)
+	}
+	if result[0].Subject != "Cortex" {
+		t.Fatalf("expected durable decision fact to survive, got %+v", result[0])
+	}
+}
+
+func TestGovernor_DefaultConfigKeepsNonAutoCaptureBooleanState(t *testing.T) {
+	gov := NewGovernor(DefaultGovernorConfig())
+
+	facts := []ExtractedFact{
+		{Subject: "Feature flag", Predicate: "status", Object: "false", FactType: "state", Confidence: 0.9},
+	}
+
+	result := gov.Apply(facts)
+	if len(result) != 1 {
+		t.Fatalf("expected default governor to keep non-auto-capture boolean state, got %d: %+v", len(result), result)
 	}
 }
 


### PR DESCRIPTION
## What this does
Tightens the **auto-capture** extraction governor so conversation/plugin captures emit far fewer low-value facts without changing normal document import behavior.

This is the bounded fix for #346: stricter caps + stricter auto-capture-only noise filters + instruction parroting detection + proof that non-auto-capture paths still behave the same.

## Problem / Context
Auto-capture currently lets too many conversation artifacts through:
- transient time/state facts
- trivial `is`/`has` narrative predicates
- boolean-only/state-echo objects like `true`, `false`, `active`
- prompt/rules parroting (`read-only during flush`, `never overwrite`, etc.)

That creates a large stream of low-value active facts which #342 and #345 cannot fully clean up because most of them are unique noise, not true duplicates.

## How it works
### Phase 1 — tighter auto-capture governor defaults
Updated `AutoCaptureGovernorConfig()` in `internal/extract/governor.go`:
- `MaxFactsPerMemory: 3` (was 5)
- `MinObjectLength: 6` (was 4)
- added auto-capture-only toggles:
  - `DropTransientFacts`
  - `DropBooleanObjects`
  - `DropInstructionParroting`

Default governor config is unchanged.

### Phase 2 — transient fact detection
Added auto-capture-only filters in `isNoise()` for:
- trivial predicates: `is`, `is on`, `is at`, `has`, `was`, `are`
- transient/noisy subject prefixes: `current*`, `timestamp*`, `message *`

These are gated by `DropTransientFacts`, so they only affect the stricter auto-capture governor.

### Phase 3 — boolean/state-echo object blocklist
Added auto-capture-only object blocklist for:
- `true`, `false`, `yes`, `no`, `none`, `n/a`, `active`, `enabled`

This is gated by `DropBooleanObjects`, so normal imports are unaffected.

### Phase 4 — instruction parroting detection
Added `isInstructionParroting()` which drops facts when the combined subject/predicate/object contains 2+ instruction signals such as:
- `must`, `should`, `never`, `always`, `do not`
- `read-only`, `append only`, `flush`, `overwrite`

This is gated by `DropInstructionParroting`, so again it only applies to auto-capture strict mode.

### Routing proof
`extract.go` already switches to `AutoCaptureGovernorConfig()` when `isAutoCaptureSource(metadata)` is true.
I added pipeline tests that verify:
- auto-capture source uses the stricter governor and drops boolean noise
- non-auto-capture source keeps the same fact pattern

## Testing done
### Focused tests
- `go test ./internal/extract -run "TestGovernor_(TighterDefaults|AutoCaptureDropsTransientAndBooleanNoise|AutoCaptureDropsInstructionParroting|DefaultConfigKeepsNonAutoCaptureBooleanState)|TestPipelineExtract_(AutoCaptureUsesStricterGovernor|NonAutoCaptureKeepsBooleanState)"`

### Package suite
- `go test ./internal/extract`

### Full repo
- `go test ./...`

## Screenshots / before-after
Before:
- auto-capture could retain facts like time/state echoes, generic `is on` facts, boolean-only values, and prompt-rule paraphrases

After:
- auto-capture keeps only the higher-signal survivors under a 3-fact cap
- non-auto-capture path remains unchanged

(Backend behavior change; test evidence above.)

## Breaking changes / risks
- No schema/API changes.
- Intentional behavior change only for auto-capture strict mode.
- Normal non-auto-capture imports are explicitly regression-tested.

## Merge notes
- Closes #346 on merge.
