### PR TITLE
fix(governor): suppress phone regex in auto-capture mode

### DIFF
--- a/internal/extract/governor.go
+++ b/internal/extract/governor.go
@@ -336,6 +336,7 @@ var autoCaptureNoisePredicates = map[string]bool{
 	"has":   true,
 	"was":   true,
 	"are":   true,
+	"phone": true, // 10-digit sender IDs get regex-extracted as phone numbers
 }
 
 var autoCaptureNoiseSubjectPrefixes = []string{

--- a/internal/extract/governor_test.go
+++ b/internal/extract/governor_test.go
@@ -356,6 +356,7 @@ func TestGovernor_AutoCaptureDropsTransientAndBooleanNoise(t *testing.T) {
 		{Subject: "Current UTC time", Predicate: "status", Object: "2026-03-15 17:52", FactType: "temporal", Confidence: 0.9},
 		{Subject: "Repository HEAD", Predicate: "is on", Object: "origin/main", FactType: "state", Confidence: 0.9},
 		{Subject: "Feature flag", Predicate: "status", Object: "active", FactType: "state", Confidence: 0.9},
+		{Subject: "auto-capture", Predicate: "phone", Object: "7930762102", FactType: "identity", Confidence: 0.7},
 		{Subject: "Cortex", Predicate: "decision", Object: "ship governor tightening now", FactType: "decision", Confidence: 0.92},
 	}
 


### PR DESCRIPTION
Sender IDs (10-digit numbers like `7930762102`) get regex-extracted as phone facts in auto-capture mode. Adds `phone` to auto-capture noise predicates.

Normal imports via `cortex import` are unaffected — default governor doesn't drop phone predicates.

All 18 test suites pass. Closes the edge case found in #347 audit.