### PR TITLE
fix: wire hybrid answer embedder and harden FTS queries

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -1016,57 +1016,9 @@ func runSearch(args []string) error {
 	}
 	defer s.Close()
 
-	// Create search engine with optional embedder.
-	// For hybrid/rrf/semantic modes, auto-resolve embedder from config/env when
-	// --embed is not explicitly provided so the smartest mode works by default.
-	var engine *search.Engine
-	embedExplicit := embedFlag != ""
-	if !embedExplicit && (searchMode == search.ModeHybrid || searchMode == search.ModeRRF || searchMode == search.ModeSemantic) {
-		// Attempt auto-resolution from config/env; errors here are non-fatal.
-		if autoConfig, autoErr := embed.ResolveEmbedConfig(""); autoErr == nil && autoConfig != nil {
-			if autoConfig.Validate() == nil {
-				if embedder, clientErr := embed.NewClient(autoConfig); clientErr == nil {
-					engine = search.NewEngineWithEmbedder(s, embedder)
-					hnswPath := getHNSWPath()
-					if count, err := engine.LoadOrBuildHNSW(context.Background(), hnswPath, 3600); err == nil && count > 0 {
-						if globalVerbose {
-							fmt.Fprintf(os.Stderr, "  HNSW index: %d vectors loaded (auto-resolved from config)\n", count)
-						}
-					}
-				}
-			}
-		}
-	}
-	if engine == nil && embedExplicit {
-		// --embed was explicitly provided: use it and surface errors.
-		embedConfig, err := embed.ResolveEmbedConfig(embedFlag)
-		if err != nil {
-			return fmt.Errorf("configuring embedder: %w", err)
-		}
-		if embedConfig == nil {
-			return fmt.Errorf("no embedding configuration found")
-		}
-		if err := embedConfig.Validate(); err != nil {
-			return fmt.Errorf("invalid embedding configuration: %w", err)
-		}
-
-		embedder, err := embed.NewClient(embedConfig)
-		if err != nil {
-			return fmt.Errorf("creating embedder: %w", err)
-		}
-
-		engine = search.NewEngineWithEmbedder(s, embedder)
-
-		// Load or build HNSW index for fast semantic search
-		hnswPath := getHNSWPath()
-		if count, err := engine.LoadOrBuildHNSW(context.Background(), hnswPath, 3600); err == nil && count > 0 {
-			if globalVerbose {
-				fmt.Fprintf(os.Stderr, "  HNSW index: %d vectors loaded\n", count)
-			}
-		}
-	}
-	if engine == nil {
-		engine = search.NewEngine(s)
+	engine, err := newSearchEngineForMode(s, searchMode, embedFlag)
+	if err != nil {
+		return err
 	}
 
 	ctx := context.Background()
@@ -1298,6 +1250,7 @@ func runAnswer(args []string) error {
 	mode := "hybrid"
 	limit := 5
 	modelFlag := ""
+	embedFlag := ""
 	projectFlag := ""
 	agentFlag := ""
 	sourceFlag := ""
@@ -1333,6 +1286,11 @@ func runAnswer(args []string) error {
 			modelFlag = args[i]
 		case strings.HasPrefix(args[i], "--model="):
 			modelFlag = strings.TrimPrefix(args[i], "--model=")
+		case args[i] == "--embed" && i+1 < len(args):
+			i++
+			embedFlag = args[i]
+		case strings.HasPrefix(args[i], "--embed="):
+			embedFlag = strings.TrimPrefix(args[i], "--embed=")
 		case args[i] == "--project" && i+1 < len(args):
 			i++
 			projectFlag = args[i]
@@ -1397,7 +1355,7 @@ func runAnswer(args []string) error {
 		case args[i] == "--verbose" || args[i] == "-v":
 			verbose = true
 		case strings.HasPrefix(args[i], "-"):
-			return fmt.Errorf("unknown flag: %s\nusage: cortex answer <query> [--mode hybrid] [--limit 5] [--model provider/model] [--max-sentences 6] [--json]", args[i])
+			return fmt.Errorf("unknown flag: %s\nusage: cortex answer <query> [--mode hybrid] [--limit 5] [--model provider/model] [--embed <provider/model>] [--max-sentences 6] [--json]", args[i])
 		default:
 			queryParts = append(queryParts, args[i])
 		}
@@ -1405,7 +1363,7 @@ func runAnswer(args []string) error {
 
 	query := strings.TrimSpace(strings.Join(queryParts, " "))
 	if query == "" {
-		return fmt.Errorf("usage: cortex answer <query> [--mode hybrid] [--limit 5] [--model provider/model] [--max-sentences 6] [--json]")
+		return fmt.Errorf("usage: cortex answer <query> [--mode hybrid] [--limit 5] [--model provider/model] [--embed <provider/model>] [--max-sentences 6] [--json]")
 	}
 
 	modeParsed, err := search.ParseMode(mode)
@@ -1428,7 +1386,10 @@ func runAnswer(args []string) error {
 	}
 	defer s.Close()
 
-	searchEngine := search.NewEngine(s)
+	searchEngine, err := newSearchEngineForMode(s, modeParsed, embedFlag)
+	if err != nil {
+		return err
+	}
 	provider, resolvedModel, degradeReason, err := answer.ResolveProvider(modelFlag)
 	if err != nil {
 		return err
@@ -1473,6 +1434,62 @@ func runAnswer(args []string) error {
 		fmt.Printf("\n(degraded: %s)\n", res.Reason)
 	}
 	return nil
+}
+
+func newSearchEngineForMode(s store.Store, mode search.Mode, embedFlag string) (*search.Engine, error) {
+	needsEmbedder := mode == search.ModeHybrid || mode == search.ModeRRF || mode == search.ModeSemantic
+	embedExplicit := strings.TrimSpace(embedFlag) != ""
+
+	if !needsEmbedder {
+		return search.NewEngine(s), nil
+	}
+
+	if !embedExplicit {
+		if autoConfig, autoErr := embed.ResolveEmbedConfig(""); autoErr == nil && autoConfig != nil {
+			if autoConfig.Validate() == nil {
+				if embedder, clientErr := newEmbedClient(autoConfig); clientErr == nil {
+					engine := search.NewEngineWithEmbedder(s, embedder)
+					loadSearchHNSW(engine, "auto-resolved from config")
+					return engine, nil
+				}
+			}
+		}
+		return search.NewEngine(s), nil
+	}
+
+	embedConfig, err := embed.ResolveEmbedConfig(embedFlag)
+	if err != nil {
+		return nil, fmt.Errorf("configuring embedder: %w", err)
+	}
+	if embedConfig == nil {
+		return nil, fmt.Errorf("no embedding configuration found")
+	}
+	if err := embedConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid embedding configuration: %w", err)
+	}
+
+	embedder, err := newEmbedClient(embedConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating embedder: %w", err)
+	}
+
+	engine := search.NewEngineWithEmbedder(s, embedder)
+	loadSearchHNSW(engine, "")
+	return engine, nil
+}
+
+func loadSearchHNSW(engine *search.Engine, detail string) {
+	if engine == nil {
+		return
+	}
+	hnswPath := getHNSWPath()
+	if count, err := engine.LoadOrBuildHNSW(context.Background(), hnswPath, 3600); err == nil && count > 0 && globalVerbose {
+		if detail != "" {
+			fmt.Fprintf(os.Stderr, "  HNSW index: %d vectors loaded (%s)\n", count, detail)
+		} else {
+			fmt.Fprintf(os.Stderr, "  HNSW index: %d vectors loaded\n", count)
+		}
+	}
 }
 
 func runLifecycle(args []string) error {

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -247,6 +247,21 @@ func captureStdout(fn func()) string {
 	return buf.String()
 }
 
+func captureStderr(fn func()) string {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	fn()
+
+	w.Close()
+	os.Stderr = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
 func TestOutputStaleTTY_NoFacts(t *testing.T) {
 	opts := observe.StaleOpts{MaxConfidence: 0.5, MaxDays: 30, Limit: 50}
 	out := captureStdout(func() {
@@ -2804,6 +2819,125 @@ func TestRunSearch_FactsJSON(t *testing.T) {
 	}
 	if !strings.Contains(out, "\"predicate\": \"prefers\"") {
 		t.Fatalf("expected fact payload in JSON output, got %q", out)
+	}
+}
+
+func TestRunAnswer_AutoResolvesEmbedderForHybrid(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "cortex.db")
+
+	oldDBPath := globalDBPath
+	oldReadOnly := globalReadOnly
+	oldFactory := newEmbedClient
+	globalDBPath = dbPath
+	globalReadOnly = false
+	t.Cleanup(func() {
+		globalDBPath = oldDBPath
+		globalReadOnly = oldReadOnly
+		newEmbedClient = oldFactory
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CORTEX_EMBED", "ollama/nomic-embed-text")
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	newEmbedClient = func(cfg *embed.EmbedConfig) (embed.Embedder, error) {
+		return &mockCommandEmbedder{dims: 8}, nil
+	}
+
+	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := s.AddMemory(ctx, &store.Memory{
+		Content:    "Caroline went to the support group on 7 May 2023.",
+		SourceFile: "locomo.md",
+	}); err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close store: %v", err)
+	}
+
+	var (
+		runErr error
+		stdout string
+		stderr string
+	)
+	stderr = captureStderr(func() {
+		stdout = captureStdout(func() {
+			runErr = runAnswer([]string{"support group", "--mode", "hybrid", "--json"})
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("runAnswer: %v\nstdout=%s\nstderr=%s", runErr, stdout, stderr)
+	}
+	if strings.Contains(stderr, "hybrid mode requires an embedder") {
+		t.Fatalf("expected auto-resolved embedder, got fallback stderr: %q", stderr)
+	}
+	if !strings.Contains(stdout, "\"answer\"") {
+		t.Fatalf("expected JSON answer payload, got %q", stdout)
+	}
+}
+
+func TestRunAnswer_EmbedFlagAccepted(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "cortex.db")
+
+	oldDBPath := globalDBPath
+	oldReadOnly := globalReadOnly
+	oldFactory := newEmbedClient
+	globalDBPath = dbPath
+	globalReadOnly = false
+	t.Cleanup(func() {
+		globalDBPath = oldDBPath
+		globalReadOnly = oldReadOnly
+		newEmbedClient = oldFactory
+	})
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	newEmbedClient = func(cfg *embed.EmbedConfig) (embed.Embedder, error) {
+		return &mockCommandEmbedder{dims: 8}, nil
+	}
+
+	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := s.AddMemory(ctx, &store.Memory{
+		Content:    "Validator yield data is in this note.",
+		SourceFile: "staking.md",
+	}); err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close store: %v", err)
+	}
+
+	var (
+		runErr error
+		stdout string
+		stderr string
+	)
+	stderr = captureStderr(func() {
+		stdout = captureStdout(func() {
+			runErr = runAnswer([]string{"validator yield", "--mode", "hybrid", "--embed", "ollama/nomic-embed-text", "--json"})
+		})
+	})
+	if runErr != nil {
+		t.Fatalf("runAnswer with --embed: %v\nstdout=%s\nstderr=%s", runErr, stdout, stderr)
+	}
+	if strings.Contains(stderr, "hybrid mode requires an embedder") {
+		t.Fatalf("expected explicit embedder, got fallback stderr: %q", stderr)
+	}
+	if !strings.Contains(stdout, "\"answer\"") {
+		t.Fatalf("expected JSON answer payload, got %q", stdout)
 	}
 }
 

--- a/docs/archive/locomo-conv30-quickwins-baseline-2026-03-22.md
+++ b/docs/archive/locomo-conv30-quickwins-baseline-2026-03-22.md
@@ -1,0 +1,81 @@
+# LoCoMo conv-30 Quick Wins Baseline — 2026-03-22
+
+## Scope
+
+This note records the baseline after landing the two retrieval foundations on branch `feat/locomo-quick-wins`:
+
+1. `cortex answer` hybrid embedder wiring
+2. FTS query sanitization
+
+This is the clean baseline to use before any temporal normalization or multi-hop planner work.
+
+## What Changed
+
+### Quick Win B
+
+`cortex answer` now accepts `--embed <provider/model>` and uses the same embedder auto-resolution path as `cortex search` for `semantic`, `hybrid`, and `rrf` modes.
+
+That unblocks real product-path evaluation of hybrid answer mode.
+
+### Quick Win A
+
+FTS sanitization now strips natural-language punctuation and handles quoted questions more safely before sending the query to SQLite FTS5.
+
+This is primarily a correctness/stability fix. On the `conv-30` slice it had little visible score impact, which is expected because the worst quoted-query failures were outside this slice.
+
+## Method
+
+- Branch under test: `feat/locomo-quick-wins`
+- Binary under test: `/tmp/cortex-locomo-quickwins-clean`
+- Corpus imported: full public LoCoMo corpus, all 10 conversations
+- Slice scored: `conv-30`, categories 1/2/4 only, 81 questions
+- Import settings:
+
+```bash
+cortex --db /tmp/cortex-locomo-conv30-quickwins-full-clean/cortex.db \
+  import /tmp/cortex-locomo-run-fast/corpus \
+  --recursive \
+  --extract \
+  --no-enrich \
+  --no-classify
+```
+
+- Hybrid embedder:
+
+```bash
+openrouter/text-embedding-3-small
+```
+
+- Reader model for `cortex answer`:
+
+```bash
+openrouter/google/gemini-2.0-flash-001
+```
+
+## Results
+
+| Mode | Questions | Top-1 hit | Top-5 hit | Evidence recall | Answer hit | F1 | Exact match | Avg latency |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| BM25 retrieval | 81 | 54.32% | 70.37% | 66.83% | 33.33% | — | — | 64 ms |
+| Hybrid retrieval | 81 | 28.40% | 61.73% | 57.96% | 27.16% | — | — | 2.15 s |
+| `cortex answer --mode hybrid --embed ...` | 81 | — | — | — | — | 7.61% | 0.00% | 5.52 s |
+
+Degraded responses from the answer path: `1`
+
+## Interpretation
+
+- Quick Win B succeeded technically: hybrid answer mode now runs through the real `cortex answer` path instead of silently requiring a custom harness.
+- That real answer path benchmarks much worse than the earlier custom reader harness. This is useful because it gives us the true product baseline before temporal or planner work.
+- Quick Win A is still worth keeping because it removes parser failures, even though the score impact on this specific 81-question slice is negligible.
+- Hybrid retrieval still does not beat BM25 on this slice.
+
+## Conclusion
+
+Before starting temporal normalization or multi-hop planning, the numbers to beat are:
+
+- BM25 top-5 evidence hit: `70.37%`
+- Hybrid top-5 evidence hit: `61.73%`
+- Hybrid evidence recall: `57.96%`
+- Hybrid answer F1: `7.61%`
+
+This is the clean post-quick-wins baseline.

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/hurttlocker/cortex/internal/ann"
 	"github.com/hurttlocker/cortex/internal/embed"
@@ -2288,7 +2289,117 @@ func normalizeBM25Score(rank float64) float64 {
 // sanitizeFTSQuery performs basic sanitization of an FTS5 query.
 // It trims whitespace and returns empty string for empty/whitespace-only queries.
 func sanitizeFTSQuery(query string) string {
-	return strings.TrimSpace(query)
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return ""
+	}
+
+	normalized := normalizeFTSFreeText(query)
+	if normalized == "" {
+		return ""
+	}
+
+	type ftsToken struct {
+		text   string
+		quoted bool
+	}
+
+	var (
+		tokens  []ftsToken
+		buf     strings.Builder
+		inQuote bool
+	)
+
+	flushPlain := func() {
+		for _, field := range strings.Fields(buf.String()) {
+			tokens = append(tokens, ftsToken{text: field})
+		}
+		buf.Reset()
+	}
+
+	flushQuoted := func() {
+		text := strings.Join(strings.Fields(buf.String()), " ")
+		if text != "" {
+			tokens = append(tokens, ftsToken{text: text, quoted: true})
+		}
+		buf.Reset()
+	}
+
+	for _, r := range normalized {
+		switch r {
+		case '"':
+			if inQuote {
+				flushQuoted()
+				inQuote = false
+				continue
+			}
+			flushPlain()
+			inQuote = true
+		default:
+			buf.WriteRune(r)
+		}
+	}
+
+	if inQuote {
+		flushPlain()
+	} else {
+		flushPlain()
+	}
+
+	sanitized := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		if tok.quoted {
+			if tok.text != "" {
+				sanitized = append(sanitized, `"`+tok.text+`"`)
+			}
+			continue
+		}
+		term := sanitizeFTSTerm(tok.text)
+		if term != "" {
+			sanitized = append(sanitized, term)
+		}
+	}
+
+	return strings.Join(sanitized, " ")
+}
+
+func normalizeFTSFreeText(query string) string {
+	var b strings.Builder
+	for _, r := range query {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r), unicode.IsSpace(r), r == '"', r == '*':
+			b.WriteRune(r)
+		default:
+			b.WriteRune(' ')
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+func sanitizeFTSTerm(term string) string {
+	term = strings.TrimSpace(term)
+	if term == "" {
+		return ""
+	}
+	upper := strings.ToUpper(term)
+	if upper == "AND" || upper == "OR" || upper == "NOT" {
+		return upper
+	}
+
+	hasPrefixWildcard := strings.HasSuffix(term, "*")
+	if hasPrefixWildcard {
+		term = strings.TrimSuffix(term, "*")
+	}
+	term = strings.TrimSpace(term)
+	term = strings.Trim(term, `"'`)
+	term = strings.Join(strings.Fields(term), " ")
+	if term == "" {
+		return ""
+	}
+	if hasPrefixWildcard {
+		return term + "*"
+	}
+	return term
 }
 
 // hasMultipleSearchTerms checks if a query has more than one searchable word.
@@ -2318,9 +2429,8 @@ func buildORQuery(query string) string {
 
 	terms := make([]string, 0, len(words))
 	for _, w := range words {
-		w = strings.Trim(w, `"`)
-		w = strings.TrimSpace(w)
-		if w == "" || strings.EqualFold(w, "AND") || strings.EqualFold(w, "OR") || strings.EqualFold(w, "NOT") {
+		w = sanitizeFTSTerm(w)
+		if w == "" || w == "AND" || w == "OR" || w == "NOT" {
 			continue
 		}
 		terms = append(terms, `"`+w+`"`)
@@ -2341,10 +2451,8 @@ func escapeFTSQuery(query string) string {
 
 	escaped := make([]string, 0, len(words))
 	for _, w := range words {
-		// Strip any existing quotes and FTS5 operators
-		w = strings.Trim(w, `"`)
-		w = strings.TrimSpace(w)
-		if w == "" || strings.EqualFold(w, "AND") || strings.EqualFold(w, "OR") || strings.EqualFold(w, "NOT") {
+		w = sanitizeFTSTerm(w)
+		if w == "" || w == "AND" || w == "OR" || w == "NOT" {
 			continue
 		}
 		escaped = append(escaped, `"`+w+`"`)

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -495,6 +495,30 @@ func TestSearchBM25_InvalidSyntaxFallback(t *testing.T) {
 	}
 }
 
+func TestSanitizeFTSQuery_StripsNaturalLanguagePunctuation(t *testing.T) {
+	got := sanitizeFTSQuery(`When did Melanie read the book "nothing is impossible"?`)
+	want := `When did Melanie read the book "nothing is impossible"`
+	if got != want {
+		t.Fatalf("sanitizeFTSQuery() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeFTSQuery_UnbalancedQuoteBecomesPlainTerms(t *testing.T) {
+	got := sanitizeFTSQuery(`"unclosed quote?`)
+	want := `unclosed quote`
+	if got != want {
+		t.Fatalf("sanitizeFTSQuery() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeFTSQuery_PreservesOperatorsAndPrefix(t *testing.T) {
+	got := sanitizeFTSQuery(`deployment NOT Docker deploy*`)
+	want := `deployment NOT Docker deploy*`
+	if got != want {
+		t.Fatalf("sanitizeFTSQuery() = %q, want %q", got, want)
+	}
+}
+
 // --- Semantic Search (Stub) ---
 
 func TestSearchSemantic_FallbackToBM25(t *testing.T) {


### PR DESCRIPTION
What shipped:
- Hybrid embedder fix for `cortex answer`, including `--embed <provider/model>` support and the same embedder auto-resolution path used by `cortex search`
- FTS query sanitization hardening for natural-language and quoted queries before handing them to SQLite FTS5

Benchmark:
- Established the honest product-path baseline at `7.61%` F1 on the LoCoMo `conv-30` slice through the real `cortex answer --mode hybrid` path
- Baseline note: [docs/archive/locomo-conv30-quickwins-baseline-2026-03-22.md](docs/archive/locomo-conv30-quickwins-baseline-2026-03-22.md)

Tests:
- Added targeted CLI/search tests for the hybrid answer embedder path and FTS sanitization
- `go test ./...` passing
