### PR TITLE
feat: temporal anchor normalization and fact-level temporal_norm

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -4037,7 +4037,7 @@ func runExtract(args []string) error {
 		if provider, err := tryCreateProvider(enrichLLM); err != nil {
 			fmt.Fprintf(os.Stderr, "  Skipping enrichment: %v. Set OPENROUTER_API_KEY or pass --no-enrich.\n", err)
 		} else {
-			result, err := extract.EnrichFacts(ctx, provider, string(content), facts)
+			result, err := extract.EnrichFacts(ctx, provider, string(content), facts, "")
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Enrichment warning: %v (showing rule-only results)\n", err)
 			} else if len(result.NewFacts) > 0 {
@@ -4713,6 +4713,9 @@ func runExtractionOnImportedMemories(ctx context.Context, s store.Store, llmFlag
 		if memory.SourceSection != "" {
 			metadata["source_section"] = memory.SourceSection
 		}
+		if memory.Metadata != nil && strings.TrimSpace(memory.Metadata.TimestampStart) != "" {
+			metadata["timestamp_start"] = memory.Metadata.TimestampStart
+		}
 
 		// Extract facts
 		facts, err := pipeline.Extract(ctx, memory.Content, metadata)
@@ -4723,14 +4726,15 @@ func runExtractionOnImportedMemories(ctx context.Context, s store.Store, llmFlag
 		// Store facts and track extraction method
 		for _, extractedFact := range facts {
 			fact := &store.Fact{
-				MemoryID:    memory.ID,
-				Subject:     extractedFact.Subject,
-				Predicate:   extractedFact.Predicate,
-				Object:      extractedFact.Object,
-				FactType:    extractedFact.FactType,
-				Confidence:  extractedFact.Confidence,
-				DecayRate:   extractedFact.DecayRate,
-				SourceQuote: extractedFact.SourceQuote,
+				MemoryID:     memory.ID,
+				Subject:      extractedFact.Subject,
+				Predicate:    extractedFact.Predicate,
+				Object:       extractedFact.Object,
+				FactType:     extractedFact.FactType,
+				Confidence:   extractedFact.Confidence,
+				DecayRate:    extractedFact.DecayRate,
+				SourceQuote:  extractedFact.SourceQuote,
+				TemporalNorm: extractedFact.TemporalNorm,
 			}
 
 			factID, stored, err := ingest.StoreExtractedFact(ctx, s, fact)
@@ -4816,6 +4820,9 @@ func runEnrichmentOnImportedMemories(ctx context.Context, s store.Store, llmFlag
 		if memory.SourceSection != "" {
 			metadata["source_section"] = memory.SourceSection
 		}
+		if memory.Metadata != nil && strings.TrimSpace(memory.Metadata.TimestampStart) != "" {
+			metadata["timestamp_start"] = memory.Metadata.TimestampStart
+		}
 
 		ruleFacts, err := pipeline.Extract(ctx, memory.Content, metadata)
 		if err != nil {
@@ -4823,7 +4830,11 @@ func runEnrichmentOnImportedMemories(ctx context.Context, s store.Store, llmFlag
 		}
 
 		// Ask LLM to enrich
-		result, err := extract.EnrichFacts(ctx, provider, memory.Content, ruleFacts)
+		anchor := ""
+		if memory.Metadata != nil {
+			anchor = memory.Metadata.TimestampStart
+		}
+		result, err := extract.EnrichFacts(ctx, provider, memory.Content, ruleFacts, anchor)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "  Enrichment warning (memory %d): %v\n", memory.ID, err)
 			continue
@@ -6063,6 +6074,9 @@ func runUpdate(args []string) error {
 		if memory.SourceSection != "" {
 			metadata["source_section"] = memory.SourceSection
 		}
+		if memory.Metadata != nil && strings.TrimSpace(memory.Metadata.TimestampStart) != "" {
+			metadata["timestamp_start"] = memory.Metadata.TimestampStart
+		}
 
 		extractedFacts, err := pipeline.Extract(ctx, content, metadata)
 		if err != nil {
@@ -6071,14 +6085,15 @@ func runUpdate(args []string) error {
 
 		for _, extractedFact := range extractedFacts {
 			_, stored, err := ingest.StoreExtractedFact(ctx, s, &store.Fact{
-				MemoryID:    memoryID,
-				Subject:     extractedFact.Subject,
-				Predicate:   extractedFact.Predicate,
-				Object:      extractedFact.Object,
-				FactType:    extractedFact.FactType,
-				Confidence:  extractedFact.Confidence,
-				DecayRate:   extractedFact.DecayRate,
-				SourceQuote: extractedFact.SourceQuote,
+				MemoryID:     memoryID,
+				Subject:      extractedFact.Subject,
+				Predicate:    extractedFact.Predicate,
+				Object:       extractedFact.Object,
+				FactType:     extractedFact.FactType,
+				Confidence:   extractedFact.Confidence,
+				DecayRate:    extractedFact.DecayRate,
+				SourceQuote:  extractedFact.SourceQuote,
+				TemporalNorm: extractedFact.TemporalNorm,
 			})
 			if err != nil {
 				continue

--- a/docs/archive/locomo-conv30-temporal-phaseab-2026-03-22.md
+++ b/docs/archive/locomo-conv30-temporal-phaseab-2026-03-22.md
@@ -1,0 +1,66 @@
+# LoCoMo conv-30 Temporal Phase A+B — 2026-03-22
+
+## Scope
+
+This note captures the `conv-30` 81-question LoCoMo slice after landing:
+
+- Phase A: session anchor propagation
+- Phase B: fact-level temporal normalization, extraction/enrichment schema updates, query-time temporal parsing/boost, and answer-context temporal rendering
+
+This run was executed on top of the quick-win foundation so it is directly comparable to the earlier `7.61%` product-path baseline.
+
+## Branch
+
+- branch: `feat/temporal-normalization`
+- binary under test: `/tmp/cortex-temporal-phaseb`
+
+## Method
+
+- imported the full public 10-conversation corpus
+- scored only the `conv-30` answerable slice, 81 questions
+- kept the same reader model and embedder as the quick-wins baseline:
+  - embedder: `openrouter/text-embedding-3-small`
+  - answer model: `openrouter/google/gemini-2.0-flash-001`
+
+## Results
+
+| Mode | Questions | Top-1 hit | Top-5 hit | Evidence recall | Answer hit | F1 | Exact match | Avg latency |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| BM25 retrieval | 81 | 50.62% | 69.14% | 65.60% | 30.86% | — | — | 61 ms |
+| Hybrid retrieval | 81 | 28.40% | 60.49% | 56.73% | 27.16% | — | — | 2.17 s |
+| `cortex answer --mode hybrid --embed ...` | 81 | — | — | — | — | 8.93% | 0.00% | 3.28 s |
+
+Degraded responses from the answer path: `0`
+
+## Delta vs Quick Wins Baseline
+
+Quick-wins baseline:
+
+- hybrid answer F1: `7.61%`
+- hybrid answer exact match: `0.00%`
+- degraded responses: `1`
+
+Temporal Phase A+B:
+
+- hybrid answer F1: `8.93%`
+- hybrid answer exact match: `0.00%`
+- degraded responses: `0`
+
+Absolute change:
+
+- F1: `+1.32`
+- exact match: `+0.00`
+- degraded responses: `-1`
+
+## Interpretation
+
+- The temporal work helped, but only modestly on the real `cortex answer` path.
+- The main visible product gain in this slice is that hybrid answer no longer degraded at all.
+- The answer-context temporal anchors and normalized temporal facts were not enough by themselves to close the benchmark gap.
+- This is consistent with the benchmark diagnosis: temporal normalization matters, but the answer path is still constrained by one-shot retrieval and weak composition.
+
+## Conclusion
+
+Phase A+B moved the honest product-path baseline from `7.61%` F1 to `8.93%` F1 on the `conv-30` slice.
+
+That is real progress, but it is not enough on its own. The next material step should be the multi-hop planner and a stronger answer-path composition strategy.

--- a/internal/answer/engine.go
+++ b/internal/answer/engine.go
@@ -11,6 +11,7 @@ import (
 	cfgresolver "github.com/hurttlocker/cortex/internal/config"
 	"github.com/hurttlocker/cortex/internal/llm"
 	"github.com/hurttlocker/cortex/internal/search"
+	"github.com/hurttlocker/cortex/internal/temporal"
 )
 
 var citationRefRE = regexp.MustCompile(`\[(\d+)\]`)
@@ -133,6 +134,12 @@ func (e *Engine) Answer(ctx context.Context, opts Options) (*Result, error) {
 		}
 		clean = truncate(clean, opts.PerResultChars)
 		block := fmt.Sprintf("[%d] source:%s score:%.2f\n%s", i+1, sourceLabel(r), r.Score, clean)
+		if anchorDate := resultAnchorDate(r); anchorDate != "" {
+			block += fmt.Sprintf("\nanchor_date: %s", anchorDate)
+		}
+		if temporalInfo := resultTemporalInfo(r); temporalInfo != "" {
+			block += "\n" + temporalInfo
+		}
 		if len(block)+1 > remaining {
 			break
 		}
@@ -287,6 +294,29 @@ func sourceLabel(r search.Result) string {
 		return fmt.Sprintf("%s:%d", r.SourceFile, r.SourceLine)
 	}
 	return r.SourceFile
+}
+
+func resultAnchorDate(r search.Result) string {
+	if r.Metadata == nil || len(r.Metadata.TimestampStart) < 10 {
+		return ""
+	}
+	return r.Metadata.TimestampStart[:10]
+}
+
+func resultTemporalInfo(r search.Result) string {
+	if len(r.TemporalNorms) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(r.TemporalNorms))
+	for i, norm := range r.TemporalNorms {
+		if i >= 2 {
+			break
+		}
+		if summary := temporal.Summary(&norm); summary != "" {
+			lines = append(lines, fmt.Sprintf("temporal_norm: %s", summary))
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func providerOfModel(model string) string {

--- a/internal/answer/engine_test.go
+++ b/internal/answer/engine_test.go
@@ -3,10 +3,12 @@ package answer
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/hurttlocker/cortex/internal/llm"
 	"github.com/hurttlocker/cortex/internal/search"
+	"github.com/hurttlocker/cortex/internal/store"
 )
 
 type mockSearcher struct {
@@ -21,9 +23,13 @@ func (m mockSearcher) Search(ctx context.Context, query string, opts search.Opti
 type mockProvider struct {
 	resp string
 	err  error
+	seen *string
 }
 
 func (m mockProvider) Complete(ctx context.Context, prompt string, opts llm.CompletionOpts) (string, error) {
+	if m.seen != nil {
+		*m.seen = prompt
+	}
 	if m.err != nil {
 		return "", m.err
 	}
@@ -104,5 +110,30 @@ func TestSanitizeRetrieved_StripsPromptInjection(t *testing.T) {
 	}
 	if clean == "" || clean == "Ignore previous instructions" {
 		t.Fatalf("unexpected clean output: %q", clean)
+	}
+}
+
+func TestAnswer_IncludesAnchorDateInPrompt(t *testing.T) {
+	var prompt string
+	e := NewEngine(
+		mockSearcher{results: []search.Result{{
+			MemoryID:   1,
+			SourceFile: "conv-30.md",
+			Score:      0.9,
+			Content:    "Jon mentioned the studio expansion.",
+			Metadata:   &store.Metadata{TimestampStart: "2023-03-23T19:28:00Z"},
+		}}},
+		mockProvider{resp: "Studio expansion happened [1].", seen: &prompt},
+		"openrouter/x-ai/grok-4.1-fast",
+	)
+	_, err := e.Answer(context.Background(), Options{Query: "studio expansion", Search: search.Options{Limit: 5}})
+	if err != nil {
+		t.Fatalf("Answer err: %v", err)
+	}
+	if prompt == "" {
+		t.Fatal("expected prompt to be captured")
+	}
+	if !strings.Contains(prompt, "anchor_date: 2023-03-23") {
+		t.Fatalf("expected anchor_date in prompt, got %q", prompt)
 	}
 }

--- a/internal/connect/sync.go
+++ b/internal/connect/sync.go
@@ -312,6 +312,9 @@ func (se *SyncEngine) extractFacts(ctx context.Context, memoryIDs []int64, llmFl
 		if mem.SourceSection != "" {
 			metadata["source_section"] = mem.SourceSection
 		}
+		if mem.Metadata != nil && strings.TrimSpace(mem.Metadata.TimestampStart) != "" {
+			metadata["timestamp_start"] = mem.Metadata.TimestampStart
+		}
 
 		// Extract facts
 		facts, err := pipeline.Extract(ctx, mem.Content, metadata)
@@ -322,14 +325,15 @@ func (se *SyncEngine) extractFacts(ctx context.Context, memoryIDs []int64, llmFl
 		// Store each extracted fact
 		for _, ef := range facts {
 			fact := &store.Fact{
-				MemoryID:    mem.ID,
-				Subject:     ef.Subject,
-				Predicate:   ef.Predicate,
-				Object:      ef.Object,
-				FactType:    ef.FactType,
-				Confidence:  ef.Confidence,
-				DecayRate:   ef.DecayRate,
-				SourceQuote: ef.SourceQuote,
+				MemoryID:     mem.ID,
+				Subject:      ef.Subject,
+				Predicate:    ef.Predicate,
+				Object:       ef.Object,
+				FactType:     ef.FactType,
+				Confidence:   ef.Confidence,
+				DecayRate:    ef.DecayRate,
+				SourceQuote:  ef.SourceQuote,
+				TemporalNorm: ef.TemporalNorm,
 			}
 			if !ingest.ShouldStoreExtractedFact(fact) {
 				continue

--- a/internal/extract/enrich.go
+++ b/internal/extract/enrich.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/hurttlocker/cortex/internal/llm"
+	"github.com/hurttlocker/cortex/internal/temporal"
 )
 
 const (
@@ -61,7 +62,16 @@ Return ONLY a JSON object matching this schema:
       "object": "value or related entity",
       "type": "one of the valid types",
       "confidence": 0.85,
-      "source_quote": "exact text from the chunk"
+      "source_quote": "exact text from the chunk",
+      "temporal_norm": {
+        "kind": "date|date_range|duration",
+        "literal": "exact temporal phrase",
+        "value": "YYYY-MM-DD if exact",
+        "start": "YYYY-MM-DD if range",
+        "end": "YYYY-MM-DD if range",
+        "precision": "day|week|month|year",
+        "resolution": "absolute|resolved_from_anchor|unresolved"
+      }
     }
   ],
   "reasoning": "brief explanation of what you found that rules missed"
@@ -82,19 +92,20 @@ type enrichResponse struct {
 }
 
 type enrichFact struct {
-	Subject     string          `json:"subject"`
-	Predicate   string          `json:"predicate"`
-	ObjectRaw   json.RawMessage `json:"object"`
-	Object      string          `json:"-"` // populated by coerceEnrichFacts
-	FactType    string          `json:"type"`
-	Confidence  float64         `json:"confidence"`
-	SourceQuote string          `json:"source_quote"`
+	Subject      string          `json:"subject"`
+	Predicate    string          `json:"predicate"`
+	ObjectRaw    json.RawMessage `json:"object"`
+	Object       string          `json:"-"` // populated by coerceEnrichFacts
+	FactType     string          `json:"type"`
+	Confidence   float64         `json:"confidence"`
+	SourceQuote  string          `json:"source_quote"`
+	TemporalNorm *temporal.Norm  `json:"temporal_norm,omitempty"`
 }
 
 // EnrichFacts uses an LLM to find facts that rule-based extraction missed.
 // It is additive-only: ruleFacts are never modified or removed.
 // On LLM error, returns nil (graceful fallback to rule-only).
-func EnrichFacts(ctx context.Context, provider llm.Provider, chunk string, ruleFacts []ExtractedFact) (*EnrichResult, error) {
+func EnrichFacts(ctx context.Context, provider llm.Provider, chunk string, ruleFacts []ExtractedFact, anchor string) (*EnrichResult, error) {
 	if provider == nil {
 		return nil, fmt.Errorf("LLM provider is nil")
 	}
@@ -108,7 +119,7 @@ func EnrichFacts(ctx context.Context, provider llm.Provider, chunk string, ruleF
 	}
 
 	// Build the user prompt with existing facts context
-	prompt := buildEnrichPrompt(truncatedChunk, ruleFacts)
+	prompt := buildEnrichPrompt(truncatedChunk, ruleFacts, anchor)
 
 	// Call LLM with timeout
 	enrichCtx, cancel := context.WithTimeout(ctx, enrichTimeout)
@@ -140,6 +151,7 @@ func EnrichFacts(ctx context.Context, provider llm.Provider, chunk string, ruleF
 			Confidence:       f.Confidence,
 			SourceQuote:      f.SourceQuote,
 			ExtractionMethod: "llm-enrich",
+			TemporalNorm:     f.TemporalNorm,
 		}
 
 		// Validate
@@ -151,6 +163,9 @@ func EnrichFacts(ctx context.Context, provider llm.Provider, chunk string, ruleF
 		}
 		if ef.Confidence <= 0 || ef.Confidence > 1.0 {
 			ef.Confidence = 0.7 // reasonable default
+		}
+		if strings.EqualFold(ef.FactType, "temporal") && ef.TemporalNorm == nil {
+			ef.TemporalNorm = temporal.NormalizeLiteral(ef.Object, anchor)
 		}
 
 		// Assign decay rate
@@ -182,9 +197,12 @@ func EnrichFacts(ctx context.Context, provider llm.Provider, chunk string, ruleF
 }
 
 // buildEnrichPrompt constructs the user message with chunk + existing facts.
-func buildEnrichPrompt(chunk string, ruleFacts []ExtractedFact) string {
+func buildEnrichPrompt(chunk string, ruleFacts []ExtractedFact, anchor string) string {
 	var sb strings.Builder
 
+	sb.WriteString("SESSION ANCHOR DATE:\n")
+	sb.WriteString(anchor)
+	sb.WriteString("\n\n")
 	sb.WriteString("TEXT CHUNK:\n---\n")
 	sb.WriteString(chunk)
 	sb.WriteString("\n---\n\n")

--- a/internal/extract/enrich_test.go
+++ b/internal/extract/enrich_test.go
@@ -55,7 +55,7 @@ func TestEnrichFacts_BasicEnrichment(t *testing.T) {
 		{Subject: "Q", Predicate: "locked", Object: "ORB config", FactType: "decision", Confidence: 0.8},
 	}
 
-	result, err := EnrichFacts(context.Background(), provider, chunk, ruleFacts)
+	result, err := EnrichFacts(context.Background(), provider, chunk, ruleFacts, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestEnrichFacts_DeduplicatesAgainstRules(t *testing.T) {
 		{Subject: "Q", Predicate: "locked", Object: "ORB config", FactType: "decision", Confidence: 0.8},
 	}
 
-	result, err := EnrichFacts(context.Background(), provider, chunk, ruleFacts)
+	result, err := EnrichFacts(context.Background(), provider, chunk, ruleFacts, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestEnrichFacts_EmptyResponse(t *testing.T) {
 		{Subject: "", Predicate: "meeting time", Object: "3pm", FactType: "temporal", Confidence: 0.9},
 	}
 
-	result, err := EnrichFacts(context.Background(), provider, chunk, ruleFacts)
+	result, err := EnrichFacts(context.Background(), provider, chunk, ruleFacts, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestEnrichFacts_LLMError_GracefulFallback(t *testing.T) {
 	provider := &mockEnrichProvider{err: fmt.Errorf("API rate limit exceeded")}
 
 	chunk := "some text"
-	result, err := EnrichFacts(context.Background(), provider, chunk, nil)
+	result, err := EnrichFacts(context.Background(), provider, chunk, nil, "")
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -175,7 +175,7 @@ func TestEnrichFacts_LLMError_GracefulFallback(t *testing.T) {
 }
 
 func TestEnrichFacts_NilProvider(t *testing.T) {
-	_, err := EnrichFacts(context.Background(), nil, "text", nil)
+	_, err := EnrichFacts(context.Background(), nil, "text", nil, "")
 	if err == nil {
 		t.Fatal("expected error for nil provider")
 	}
@@ -199,7 +199,7 @@ func TestEnrichFacts_InvalidFactType_Fallback(t *testing.T) {
 
 	provider := &mockEnrichProvider{response: response}
 
-	result, err := EnrichFacts(context.Background(), provider, "The system uses SQLite for storage.", nil)
+	result, err := EnrichFacts(context.Background(), provider, "The system uses SQLite for storage.", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestEnrichFacts_InvalidConfidence_Defaults(t *testing.T) {
 
 	provider := &mockEnrichProvider{response: response}
 
-	result, err := EnrichFacts(context.Background(), provider, "test has value. test2 has value2.", nil)
+	result, err := EnrichFacts(context.Background(), provider, "test has value. test2 has value2.", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestEnrichFacts_SkipsEmptyPredicateOrObject(t *testing.T) {
 
 	provider := &mockEnrichProvider{response: response}
 
-	result, err := EnrichFacts(context.Background(), provider, "good has value", nil)
+	result, err := EnrichFacts(context.Background(), provider, "good has value", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -313,7 +313,7 @@ func TestEnrichFacts_MarkdownFencedResponse(t *testing.T) {
 
 	provider := &mockEnrichProvider{response: response}
 
-	result, err := EnrichFacts(context.Background(), provider, "Cortex is written in Go", nil)
+	result, err := EnrichFacts(context.Background(), provider, "Cortex is written in Go", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -341,7 +341,7 @@ func TestEnrichFacts_LongSubjectTruncated(t *testing.T) {
 
 	provider := &mockEnrichProvider{response: response}
 
-	result, err := EnrichFacts(context.Background(), provider, "long subject has property", nil)
+	result, err := EnrichFacts(context.Background(), provider, "long subject has property", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -358,7 +358,7 @@ func TestEnrichFacts_TracksLatency(t *testing.T) {
 	response := `{"facts": [], "reasoning": "nothing"}`
 	provider := &mockEnrichProvider{response: response}
 
-	result, err := EnrichFacts(context.Background(), provider, "text", nil)
+	result, err := EnrichFacts(context.Background(), provider, "text", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -375,7 +375,7 @@ func TestEnrichFacts_SetsSystemPrompt(t *testing.T) {
 	response := `{"facts": [], "reasoning": "n/a"}`
 	provider := &mockEnrichProvider{response: response}
 
-	_, err := EnrichFacts(context.Background(), provider, "text", nil)
+	_, err := EnrichFacts(context.Background(), provider, "text", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -405,7 +405,7 @@ func TestEnrichFacts_NoRuleFacts(t *testing.T) {
 
 	provider := &mockEnrichProvider{response: response}
 
-	result, err := EnrichFacts(context.Background(), provider, "Alice (alice@test.com) is here.", nil)
+	result, err := EnrichFacts(context.Background(), provider, "Alice (alice@test.com) is here.", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -421,7 +421,7 @@ func TestBuildEnrichPrompt_WithFacts(t *testing.T) {
 		{Subject: "SB", Predicate: "role", Object: "co-founder", FactType: "relationship"},
 	}
 
-	prompt := buildEnrichPrompt("Q and SB founded Spear in Philadelphia.", facts)
+	prompt := buildEnrichPrompt("Q and SB founded Spear in Philadelphia.", facts, "")
 
 	if !strings.Contains(prompt, "TEXT CHUNK:") {
 		t.Error("prompt should contain TEXT CHUNK header")
@@ -438,7 +438,7 @@ func TestBuildEnrichPrompt_WithFacts(t *testing.T) {
 }
 
 func TestBuildEnrichPrompt_NoFacts(t *testing.T) {
-	prompt := buildEnrichPrompt("Some text.", nil)
+	prompt := buildEnrichPrompt("Some text.", nil, "")
 
 	if !strings.Contains(prompt, "none") {
 		t.Error("prompt should indicate no existing facts")
@@ -453,7 +453,7 @@ func TestBuildEnrichPrompt_ManyFacts_Truncates(t *testing.T) {
 		}
 	}
 
-	prompt := buildEnrichPrompt("text", facts)
+	prompt := buildEnrichPrompt("text", facts, "")
 
 	if !strings.Contains(prompt, "and 20 more facts") {
 		t.Error("prompt should indicate truncated facts")
@@ -598,7 +598,7 @@ func TestEnrichFacts_MultipleRelationships(t *testing.T) {
 		{Subject: "Eyes Web", Predicate: "is", Object: "health companion", FactType: "kv"},
 	}
 
-	result, err := EnrichFacts(context.Background(), provider, chunk, ruleFacts)
+	result, err := EnrichFacts(context.Background(), provider, chunk, ruleFacts, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -18,18 +18,21 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/hurttlocker/cortex/internal/temporal"
 )
 
 // ExtractedFact represents a single structured fact extracted from text.
 type ExtractedFact struct {
-	Subject          string  `json:"subject"`           // Who/what this is about
-	Predicate        string  `json:"predicate"`         // The relationship or attribute
-	Object           string  `json:"object"`            // The value or related entity
-	FactType         string  `json:"type"`              // kv, relationship, preference, temporal, identity, location, decision, state
-	Confidence       float64 `json:"confidence"`        // 0.0–1.0
-	SourceQuote      string  `json:"source_quote"`      // Exact text this was extracted from
-	ExtractionMethod string  `json:"extraction_method"` // always "rules" for Tier 1
-	DecayRate        float64 `json:"decay_rate"`        // Assigned based on fact type
+	Subject          string         `json:"subject"`           // Who/what this is about
+	Predicate        string         `json:"predicate"`         // The relationship or attribute
+	Object           string         `json:"object"`            // The value or related entity
+	FactType         string         `json:"type"`              // kv, relationship, preference, temporal, identity, location, decision, state
+	Confidence       float64        `json:"confidence"`        // 0.0–1.0
+	SourceQuote      string         `json:"source_quote"`      // Exact text this was extracted from
+	ExtractionMethod string         `json:"extraction_method"` // always "rules" for Tier 1
+	DecayRate        float64        `json:"decay_rate"`        // Assigned based on fact type
+	TemporalNorm     *temporal.Norm `json:"temporal_norm,omitempty"`
 }
 
 // BaseDecayRates holds the built-in default decay rates by fact type.
@@ -360,13 +363,14 @@ func (p *Pipeline) Extract(ctx context.Context, text string, metadata map[string
 		} else {
 			facts[i].DecayRate = DecayRates["kv"] // default
 		}
+		normalizeTemporalFact(&facts[i], metadata)
 	}
 
 	// Tier 2: LLM-assisted extraction (optional)
 	var llmFacts []ExtractedFact
 	if p.llmClient != nil {
 		var err error
-		llmFacts, err = p.extractWithLLM(ctx, text)
+		llmFacts, err = p.extractWithLLM(ctx, text, metadata)
 		if err != nil {
 			// Log warning but don't fail - fall back to Tier 1 only
 			fmt.Fprintf(os.Stderr, "Warning: LLM extraction failed, using rule-based extraction only: %v\n", err)
@@ -920,7 +924,7 @@ func parseInteger(s string) (int, bool) {
 }
 
 // extractWithLLM runs LLM-assisted extraction on the input text.
-func (p *Pipeline) extractWithLLM(ctx context.Context, text string) ([]ExtractedFact, error) {
+func (p *Pipeline) extractWithLLM(ctx context.Context, text string, metadata map[string]string) ([]ExtractedFact, error) {
 	if p.llmClient == nil || p.llmConfig == nil {
 		return nil, fmt.Errorf("LLM client not configured")
 	}
@@ -936,7 +940,7 @@ func (p *Pipeline) extractWithLLM(ctx context.Context, text string) ([]Extracted
 			continue
 		}
 
-		facts, err := p.llmClient.Extract(ctx, chunk)
+		facts, err := p.llmClient.Extract(ctx, chunk, metadata)
 		if err != nil {
 			return nil, fmt.Errorf("extracting from chunk: %w", err)
 		}
@@ -948,4 +952,18 @@ func (p *Pipeline) extractWithLLM(ctx context.Context, text string) ([]Extracted
 	allFacts = deduplicateFacts(allFacts)
 
 	return allFacts, nil
+}
+
+func normalizeTemporalFact(fact *ExtractedFact, metadata map[string]string) {
+	if fact == nil || !strings.EqualFold(strings.TrimSpace(fact.FactType), "temporal") || fact.TemporalNorm != nil {
+		return
+	}
+	anchor := strings.TrimSpace(metadata["timestamp_start"])
+	if anchor == "" {
+		anchor = temporal.TimestampStartFromSection(strings.TrimSpace(metadata["source_section"]))
+	}
+	fact.TemporalNorm = temporal.NormalizeLiteral(fact.Object, anchor)
+	if fact.TemporalNorm == nil && fact.SourceQuote != "" {
+		fact.TemporalNorm = temporal.NormalizeLiteral(fact.SourceQuote, anchor)
+	}
 }

--- a/internal/extract/llm_client.go
+++ b/internal/extract/llm_client.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hurttlocker/cortex/internal/temporal"
 )
 
 // System prompt for LLM extraction (v1)
@@ -40,7 +42,16 @@ JSON SCHEMA:
       "object": "value/related entity",
       "type": "one of the valid fact types above",
       "confidence": 0.85,
-      "source_quote": "exact text from input this was extracted from"
+      "source_quote": "exact text from input this was extracted from",
+      "temporal_norm": {
+        "kind": "date|date_range|duration",
+        "literal": "exact temporal phrase",
+        "value": "YYYY-MM-DD if exact",
+        "start": "YYYY-MM-DD if range",
+        "end": "YYYY-MM-DD if range",
+        "precision": "day|week|month|year",
+        "resolution": "absolute|resolved_from_anchor|unresolved"
+      }
     }
   ]
 }
@@ -138,7 +149,12 @@ func NewLLMClient(config *LLMConfig) *LLMClient {
 }
 
 // Extract extracts facts from text using the configured LLM.
-func (c *LLMClient) Extract(ctx context.Context, text string) ([]ExtractedFact, error) {
+func (c *LLMClient) Extract(ctx context.Context, text string, metadata map[string]string) ([]ExtractedFact, error) {
+	anchor := strings.TrimSpace(metadata["timestamp_start"])
+	if anchor == "" {
+		anchor = temporal.TimestampStartFromSection(strings.TrimSpace(metadata["source_section"]))
+	}
+
 	// Build the chat messages
 	messages := []ChatMessage{
 		{
@@ -147,7 +163,7 @@ func (c *LLMClient) Extract(ctx context.Context, text string) ([]ExtractedFact, 
 		},
 		{
 			Role:    "user",
-			Content: fmt.Sprintf("Extract facts from this text:\n\n---\n%s\n---\n\nReturn JSON matching the schema.", text),
+			Content: fmt.Sprintf("Session anchor date: %s\n\nExtract facts from this text:\n\n---\n%s\n---\n\nFor temporal facts, preserve the literal phrase in object and fill temporal_norm using the session anchor date when possible. Return JSON matching the schema.", anchor, text),
 		},
 	}
 
@@ -166,6 +182,11 @@ func (c *LLMClient) Extract(ctx context.Context, text string) ([]ExtractedFact, 
 	for attempt := 0; attempt <= c.config.MaxRetries; attempt++ {
 		facts, err := c.attemptExtraction(ctx, req)
 		if err == nil {
+			for i := range facts {
+				if strings.EqualFold(facts[i].FactType, "temporal") && facts[i].TemporalNorm == nil {
+					facts[i].TemporalNorm = temporal.NormalizeLiteral(facts[i].Object, anchor)
+				}
+			}
 			return facts, nil
 		}
 
@@ -246,7 +267,6 @@ func (c *LLMClient) attemptExtraction(ctx context.Context, req ChatRequest) ([]E
 		} else {
 			fact.DecayRate = DecayRates["kv"] // default
 		}
-
 		validFacts = append(validFacts, fact)
 	}
 

--- a/internal/extract/llm_test.go
+++ b/internal/extract/llm_test.go
@@ -341,7 +341,7 @@ func TestLLMClient_ValidResponse(t *testing.T) {
 	client := NewLLMClient(config)
 	ctx := context.Background()
 
-	facts, err := client.Extract(ctx, "Alice (alice@company.com) is the project manager")
+	facts, err := client.Extract(ctx, "Alice (alice@company.com) is the project manager", nil)
 	if err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestLLMClient_InvalidJSON(t *testing.T) {
 	client := NewLLMClient(config)
 	ctx := context.Background()
 
-	_, err := client.Extract(ctx, "test text")
+	_, err := client.Extract(ctx, "test text", nil)
 	if err == nil {
 		t.Error("Expected error for invalid JSON")
 	}
@@ -429,7 +429,7 @@ func TestLLMClient_RetrySuccess(t *testing.T) {
 	client := NewLLMClient(config)
 	ctx := context.Background()
 
-	facts, err := client.Extract(ctx, "test text")
+	facts, err := client.Extract(ctx, "test text", nil)
 	if err != nil {
 		t.Fatalf("Expected retry to succeed, got error: %v", err)
 	}
@@ -457,7 +457,7 @@ func TestLLMClient_AllRetriesFail(t *testing.T) {
 	client := NewLLMClient(config)
 	ctx := context.Background()
 
-	_, err := client.Extract(ctx, "test text")
+	_, err := client.Extract(ctx, "test text", nil)
 	if err == nil {
 		t.Error("Expected error after all retries exhausted")
 	}
@@ -479,7 +479,7 @@ func TestLLMClient_NetworkError(t *testing.T) {
 	client := NewLLMClient(config)
 	ctx := context.Background()
 
-	_, err := client.Extract(ctx, "test text")
+	_, err := client.Extract(ctx, "test text", nil)
 	if err == nil {
 		t.Error("Expected network error")
 	}
@@ -502,7 +502,7 @@ func TestLLMClient_RateLimit(t *testing.T) {
 	ctx := context.Background()
 
 	start := time.Now()
-	facts, err := client.Extract(ctx, "test text")
+	facts, err := client.Extract(ctx, "test text", nil)
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -542,7 +542,7 @@ func TestLLMClient_EmptyResponse(t *testing.T) {
 	client := NewLLMClient(config)
 	ctx := context.Background()
 
-	_, err := client.Extract(ctx, "test text")
+	_, err := client.Extract(ctx, "test text", nil)
 	if err == nil {
 		t.Error("Expected error for empty response")
 	}
@@ -575,7 +575,7 @@ func TestLLMClient_NoChoices(t *testing.T) {
 	client := NewLLMClient(config)
 	ctx := context.Background()
 
-	_, err := client.Extract(ctx, "test text")
+	_, err := client.Extract(ctx, "test text", nil)
 	if err == nil {
 		t.Error("Expected error for no choices")
 	}
@@ -613,7 +613,7 @@ func TestLLMClient_OpenRouterHeaders(t *testing.T) {
 	client := NewLLMClient(config)
 	ctx := context.Background()
 
-	_, err := client.Extract(ctx, "test text")
+	_, err := client.Extract(ctx, "test text", nil)
 	if err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}

--- a/internal/ingest/extracted_facts.go
+++ b/internal/ingest/extracted_facts.go
@@ -9,6 +9,7 @@ import (
 
 	cfgresolver "github.com/hurttlocker/cortex/internal/config"
 	"github.com/hurttlocker/cortex/internal/store"
+	"github.com/hurttlocker/cortex/internal/temporal"
 )
 
 var (
@@ -83,9 +84,6 @@ func ShouldStoreExtractedFact(fact *store.Fact) bool {
 		return false
 	}
 	if heartbeatFactSubjectRE.MatchString(subject) {
-		return false
-	}
-	if strings.EqualFold(strings.TrimSpace(fact.FactType), "temporal") && hasSpecificDatetime(object) {
 		return false
 	}
 	if isBareNumberObject(object) {
@@ -185,6 +183,7 @@ func StoreExtractedFact(ctx context.Context, s store.Store, fact *store.Fact) (f
 	if fact == nil {
 		return 0, false, fmt.Errorf("fact is nil")
 	}
+	populateTemporalNorm(ctx, s, fact)
 	if !ShouldStoreExtractedFact(fact) {
 		return 0, false, nil
 	}
@@ -230,4 +229,25 @@ func StoreExtractedFact(ctx context.Context, s store.Store, fact *store.Fact) (f
 	}
 
 	return factID, true, nil
+}
+
+func populateTemporalNorm(ctx context.Context, s store.Store, fact *store.Fact) {
+	if fact == nil || !strings.EqualFold(strings.TrimSpace(fact.FactType), "temporal") || fact.TemporalNorm != nil {
+		return
+	}
+	mem, err := s.GetMemory(ctx, fact.MemoryID)
+	if err != nil || mem == nil {
+		return
+	}
+	anchor := ""
+	if mem.Metadata != nil {
+		anchor = strings.TrimSpace(mem.Metadata.TimestampStart)
+	}
+	if anchor == "" {
+		anchor = temporal.TimestampStartFromSection(mem.SourceSection)
+	}
+	fact.TemporalNorm = temporal.NormalizeLiteral(fact.Object, anchor)
+	if fact.TemporalNorm == nil && fact.SourceQuote != "" {
+		fact.TemporalNorm = temporal.NormalizeLiteral(fact.SourceQuote, anchor)
+	}
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -411,6 +411,14 @@ func (e *Engine) processMemory(ctx context.Context, raw RawMemory, opts ImportOp
 			mem.Metadata = meta
 		}
 	}
+	if ts := timestampStartFromSourceSection(raw.SourceSection); ts != "" {
+		if mem.Metadata == nil {
+			mem.Metadata = &store.Metadata{}
+		}
+		if strings.TrimSpace(mem.Metadata.TimestampStart) == "" {
+			mem.Metadata.TimestampStart = ts
+		}
+	}
 
 	newID, err := e.store.AddMemory(ctx, mem)
 	if err != nil {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -114,6 +114,38 @@ func TestMarkdownImport_WithoutHeaders(t *testing.T) {
 	}
 }
 
+func TestImportFile_PopulatesTimestampStartFromSourceSection(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	engine := NewEngine(s)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "locomo.md")
+	content := "# Conv 30\n\n## Session 7 - 7:28 pm on 23 March, 2023\nJon said the studio expansion is finally moving forward and the new floor plan looks solid.\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write markdown: %v", err)
+	}
+
+	result, err := engine.ImportFile(ctx, path, ImportOptions{})
+	if err != nil {
+		t.Fatalf("ImportFile: %v", err)
+	}
+	if result.MemoriesNew == 0 || len(result.NewMemoryIDs) == 0 {
+		t.Fatalf("expected imported memories, got %+v", result)
+	}
+
+	mem, err := s.GetMemory(ctx, result.NewMemoryIDs[0])
+	if err != nil {
+		t.Fatalf("GetMemory: %v", err)
+	}
+	if mem == nil || mem.Metadata == nil {
+		t.Fatalf("expected metadata on imported memory, got %+v", mem)
+	}
+	if got := mem.Metadata.TimestampStart; got != "2023-03-23T19:28:00Z" {
+		t.Fatalf("TimestampStart = %q, want %q", got, "2023-03-23T19:28:00Z")
+	}
+}
+
 func TestMarkdownImport_FrontMatter(t *testing.T) {
 	ctx := context.Background()
 	imp := &MarkdownImporter{}

--- a/internal/ingest/source_section_time.go
+++ b/internal/ingest/source_section_time.go
@@ -1,0 +1,7 @@
+package ingest
+
+import "github.com/hurttlocker/cortex/internal/temporal"
+
+func timestampStartFromSourceSection(section string) string {
+	return temporal.TimestampStartFromSection(section)
+}

--- a/internal/ingest/source_section_time_test.go
+++ b/internal/ingest/source_section_time_test.go
@@ -1,0 +1,35 @@
+package ingest
+
+import "testing"
+
+func TestTimestampStartFromSourceSection(t *testing.T) {
+	tests := []struct {
+		name    string
+		section string
+		want    string
+	}{
+		{
+			name:    "session with time and date",
+			section: "Session 7 - 7:28 pm on 23 March, 2023",
+			want:    "2023-03-23T19:28:00Z",
+		},
+		{
+			name:    "date only iso",
+			section: "Session 1 - 2023-05-07",
+			want:    "2023-05-07T00:00:00Z",
+		},
+		{
+			name:    "unparseable",
+			section: "Trading Systems",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := timestampStartFromSourceSection(tt.section); got != tt.want {
+				t.Fatalf("timestampStartFromSourceSection(%q) = %q, want %q", tt.section, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hurttlocker/cortex/internal/ann"
 	"github.com/hurttlocker/cortex/internal/embed"
 	"github.com/hurttlocker/cortex/internal/store"
+	"github.com/hurttlocker/cortex/internal/temporal"
 )
 
 // ConfidenceWeight controls how much effective confidence affects search ranking.
@@ -190,6 +191,7 @@ type Options struct {
 	IncludeSuperseded bool          // Include memories backed only by superseded facts
 	Explain           bool          // Attach explainability/provenance payloads to results
 	DisableDedupe     bool          // Keep overlapping same-source results instead of collapsing them
+	TemporalQuery     *temporal.Query
 }
 
 // Default minimum score thresholds by mode.
@@ -227,21 +229,23 @@ func effectiveMinScore(mode Mode, configured float64) float64 {
 
 // Result represents a single search result.
 type Result struct {
-	Content       string          `json:"content"`
-	SourceFile    string          `json:"source_file"`
-	SourceTier    string          `json:"source_tier,omitempty"`
-	SourceLine    int             `json:"source_line"`
-	SourceSection string          `json:"source_section,omitempty"`
-	Project       string          `json:"project,omitempty"`
-	MemoryClass   string          `json:"class,omitempty"`
-	Metadata      *store.Metadata `json:"metadata,omitempty"` // Structured metadata (Issue #30)
-	Score         float64         `json:"score"`
-	Snippet       string          `json:"snippet,omitempty"`
-	MatchType     string          `json:"match_type"` // "bm25", "semantic", "hybrid", "rrf"
-	MemoryID      int64           `json:"memory_id"`
-	FactIDs       []int64         `json:"fact_ids"`              // Facts linked to memory_id (for mutate-after-search workflows)
-	ImportedAt    time.Time       `json:"imported_at,omitempty"` // For metadata date filtering
-	Explain       *ExplainDetails `json:"explain,omitempty"`
+	Content        string          `json:"content"`
+	SourceFile     string          `json:"source_file"`
+	SourceTier     string          `json:"source_tier,omitempty"`
+	SourceLine     int             `json:"source_line"`
+	SourceSection  string          `json:"source_section,omitempty"`
+	Project        string          `json:"project,omitempty"`
+	MemoryClass    string          `json:"class,omitempty"`
+	Metadata       *store.Metadata `json:"metadata,omitempty"` // Structured metadata (Issue #30)
+	Score          float64         `json:"score"`
+	Snippet        string          `json:"snippet,omitempty"`
+	MatchType      string          `json:"match_type"` // "bm25", "semantic", "hybrid", "rrf"
+	MemoryID       int64           `json:"memory_id"`
+	FactIDs        []int64         `json:"fact_ids"`              // Facts linked to memory_id (for mutate-after-search workflows)
+	ImportedAt     time.Time       `json:"imported_at,omitempty"` // For metadata date filtering
+	TemporalAnchor string          `json:"temporal_anchor,omitempty"`
+	TemporalNorms  []temporal.Norm `json:"temporal_norms,omitempty"`
+	Explain        *ExplainDetails `json:"explain,omitempty"`
 }
 
 // FactResult is a direct fact-level search hit.
@@ -571,6 +575,7 @@ func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Resu
 	results = applyMetadataBoosts(results, opts)
 	results = applyRecencyBoost(results, opts.Explain)
 	results = applySourceWeight(results, opts.SourceBoosts, opts.Explain)
+	results = e.applyTemporalBoost(ctx, retrievalQuery, results, opts)
 
 	if !opts.IncludeSuperseded {
 		results = e.filterSupersededMemories(ctx, results)
@@ -1810,6 +1815,92 @@ func applySourceWeight(results []Result, boosts []SourceBoost, explain bool) []R
 		return results[i].Score > results[j].Score
 	})
 
+	return results
+}
+
+func (e *Engine) applyTemporalBoost(ctx context.Context, query string, results []Result, opts Options) []Result {
+	if len(results) == 0 {
+		return results
+	}
+
+	tq := opts.TemporalQuery
+	if tq == nil {
+		tq = temporal.ParseQuery(query)
+	}
+	if tq == nil || !tq.TemporalIntent {
+		return attachTemporalContext(ctx, e.store, results)
+	}
+
+	results = attachTemporalContext(ctx, e.store, results)
+	for i := range results {
+		multiplier := 1.0
+		reasons := make([]string, 0, 2)
+		hasTemporalEvidence := len(results[i].TemporalNorms) > 0
+		hasAnchor := results[i].TemporalAnchor != ""
+
+		if hasTemporalEvidence {
+			multiplier *= 1.08
+			reasons = append(reasons, "temporal-evidence")
+		}
+		if hasAnchor {
+			multiplier *= 1.05
+			reasons = append(reasons, "anchor-date")
+		}
+		if tq.Resolved {
+			for _, norm := range results[i].TemporalNorms {
+				if temporal.MatchesQuery(tq, &norm) {
+					multiplier *= 1.20
+					reasons = append(reasons, "temporal-match")
+					break
+				}
+			}
+		}
+		if multiplier != 1.0 {
+			results[i].Score *= multiplier
+			if opts.Explain {
+				ensureExplain(&results[i])
+				if results[i].Explain.Why == "" {
+					results[i].Explain.Why = "temporal boost: " + strings.Join(reasons, ", ")
+				} else {
+					results[i].Explain.Why += "; temporal boost: " + strings.Join(reasons, ", ")
+				}
+			}
+		}
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].Score > results[j].Score })
+	return results
+}
+
+func attachTemporalContext(ctx context.Context, st store.Store, results []Result) []Result {
+	if len(results) == 0 {
+		return results
+	}
+	memoryIDs := make([]int64, 0, len(results))
+	for _, r := range results {
+		if r.MemoryID > 0 {
+			memoryIDs = append(memoryIDs, r.MemoryID)
+		}
+	}
+	facts, err := st.ListFactsByMemoryIDs(ctx, memoryIDs, "temporal", 200)
+	if err != nil {
+		return results
+	}
+	byMemory := map[int64][]temporal.Norm{}
+	for _, f := range facts {
+		if f == nil || f.TemporalNorm == nil {
+			continue
+		}
+		if len(byMemory[f.MemoryID]) >= 3 {
+			continue
+		}
+		byMemory[f.MemoryID] = append(byMemory[f.MemoryID], *f.TemporalNorm)
+	}
+	for i := range results {
+		if results[i].Metadata != nil && len(results[i].Metadata.TimestampStart) >= 10 {
+			results[i].TemporalAnchor = results[i].Metadata.TimestampStart[:10]
+		}
+		results[i].TemporalNorms = byMemory[results[i].MemoryID]
+	}
 	return results
 }
 

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hurttlocker/cortex/internal/ann"
 	"github.com/hurttlocker/cortex/internal/store"
+	"github.com/hurttlocker/cortex/internal/temporal"
 )
 
 // newTestStore creates an in-memory store for testing.
@@ -492,6 +493,58 @@ func TestSearchBM25_InvalidSyntaxFallback(t *testing.T) {
 		t.Logf("Got error (acceptable): %v", err)
 	} else {
 		t.Logf("Got %d results with fallback", len(results))
+	}
+}
+
+func TestSearch_AttachesTemporalContext(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	memID, err := s.AddMemory(ctx, &store.Memory{
+		Content:       "Jon went to the fair to get more exposure for his dance studio.",
+		SourceFile:    "locomo.md",
+		SourceSection: "Session 7 - 7:28 pm on 23 March, 2023",
+		Metadata:      &store.Metadata{TimestampStart: "2023-03-23T19:28:00Z"},
+	})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if _, err := s.AddFact(ctx, &store.Fact{
+		MemoryID:   memID,
+		Subject:    "Jon",
+		Predicate:  "date",
+		Object:     "last week",
+		FactType:   "temporal",
+		Confidence: 0.9,
+		TemporalNorm: &temporal.Norm{
+			Kind:       "date_range",
+			Literal:    "last week",
+			Start:      "2023-03-16",
+			End:        "2023-03-22",
+			Anchor:     "2023-03-23",
+			Precision:  "day",
+			Resolution: "resolved_from_anchor",
+		},
+	}); err != nil {
+		t.Fatalf("AddFact: %v", err)
+	}
+
+	engine := NewEngine(s)
+	results, err := engine.Search(ctx, "When did Jon go to the fair", Options{Mode: ModeKeyword, Limit: 5})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results")
+	}
+	if results[0].TemporalAnchor != "2023-03-23" {
+		t.Fatalf("TemporalAnchor = %q, want 2023-03-23", results[0].TemporalAnchor)
+	}
+	if len(results[0].TemporalNorms) == 0 {
+		t.Fatal("expected temporal norms on result")
+	}
+	if results[0].TemporalNorms[0].Start != "2023-03-16" {
+		t.Fatalf("unexpected temporal norm %+v", results[0].TemporalNorms[0])
 	}
 }
 

--- a/internal/store/facts.go
+++ b/internal/store/facts.go
@@ -3,11 +3,36 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
 	"time"
+
+	"github.com/hurttlocker/cortex/internal/temporal"
 )
+
+func marshalTemporalNorm(n *temporal.Norm) sql.NullString {
+	if n == nil {
+		return sql.NullString{}
+	}
+	b, err := json.Marshal(n)
+	if err != nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: string(b), Valid: true}
+}
+
+func unmarshalTemporalNorm(raw sql.NullString) *temporal.Norm {
+	if !raw.Valid || strings.TrimSpace(raw.String) == "" {
+		return nil
+	}
+	var out temporal.Norm
+	if err := json.Unmarshal([]byte(raw.String), &out); err != nil {
+		return nil
+	}
+	return &out
+}
 
 func normalizeFactStateForWrite(state string) (string, error) {
 	s := strings.ToLower(strings.TrimSpace(state))
@@ -53,10 +78,10 @@ func (s *SQLiteStore) AddFact(ctx context.Context, f *Fact) (int64, error) {
 	}
 
 	result, err := s.db.ExecContext(ctx,
-		`INSERT INTO facts (memory_id, subject, predicate, object, fact_type, confidence, decay_rate, last_reinforced, source_quote, created_at, state, agent_id)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO facts (memory_id, subject, predicate, object, fact_type, confidence, decay_rate, last_reinforced, source_quote, temporal_norm, created_at, state, agent_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		f.MemoryID, f.Subject, f.Predicate, f.Object, f.FactType,
-		f.Confidence, f.DecayRate, now, f.SourceQuote, now, state, f.AgentID,
+		f.Confidence, f.DecayRate, now, f.SourceQuote, marshalTemporalNorm(f.TemporalNorm), now, state, f.AgentID,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("inserting fact: %w", err)
@@ -78,12 +103,13 @@ func (s *SQLiteStore) AddFact(ctx context.Context, f *Fact) (int64, error) {
 func (s *SQLiteStore) GetFact(ctx context.Context, id int64) (*Fact, error) {
 	f := &Fact{}
 	var supersededBy sql.NullInt64
+	var temporalNorm sql.NullString
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, memory_id, subject, predicate, object, fact_type, confidence, decay_rate, last_reinforced, source_quote, created_at, state, superseded_by, agent_id
+		`SELECT id, memory_id, subject, predicate, object, fact_type, confidence, decay_rate, last_reinforced, source_quote, temporal_norm, created_at, state, superseded_by, agent_id
 		 FROM facts WHERE id = ?`, id,
 	).Scan(&f.ID, &f.MemoryID, &f.Subject, &f.Predicate, &f.Object,
 		&f.FactType, &f.Confidence, &f.DecayRate, &f.LastReinforced,
-		&f.SourceQuote, &f.CreatedAt, &f.State, &supersededBy, &f.AgentID)
+		&f.SourceQuote, &temporalNorm, &f.CreatedAt, &f.State, &supersededBy, &f.AgentID)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -95,6 +121,7 @@ func (s *SQLiteStore) GetFact(ctx context.Context, id int64) (*Fact, error) {
 		v := supersededBy.Int64
 		f.SupersededBy = &v
 	}
+	f.TemporalNorm = unmarshalTemporalNorm(temporalNorm)
 	return f, nil
 }
 
@@ -110,7 +137,7 @@ func (s *SQLiteStore) ListFacts(ctx context.Context, opts ListOpts) ([]*Fact, er
 	}
 
 	query := `SELECT f.id, f.memory_id, f.subject, f.predicate, f.object, f.fact_type, 
-			         f.confidence, f.decay_rate, f.last_reinforced, f.source_quote, f.created_at, f.state, f.superseded_by, f.agent_id
+			         f.confidence, f.decay_rate, f.last_reinforced, f.source_quote, f.temporal_norm, f.created_at, f.state, f.superseded_by, f.agent_id
 		      FROM facts f`
 	args := []interface{}{}
 
@@ -162,15 +189,17 @@ func (s *SQLiteStore) ListFacts(ctx context.Context, opts ListOpts) ([]*Fact, er
 	for rows.Next() {
 		f := &Fact{}
 		var supersededBy sql.NullInt64
+		var temporalNorm sql.NullString
 		if err := rows.Scan(&f.ID, &f.MemoryID, &f.Subject, &f.Predicate, &f.Object,
 			&f.FactType, &f.Confidence, &f.DecayRate, &f.LastReinforced,
-			&f.SourceQuote, &f.CreatedAt, &f.State, &supersededBy, &f.AgentID); err != nil {
+			&f.SourceQuote, &temporalNorm, &f.CreatedAt, &f.State, &supersededBy, &f.AgentID); err != nil {
 			return nil, fmt.Errorf("scanning fact row: %w", err)
 		}
 		if supersededBy.Valid {
 			v := supersededBy.Int64
 			f.SupersededBy = &v
 		}
+		f.TemporalNorm = unmarshalTemporalNorm(temporalNorm)
 		facts = append(facts, f)
 	}
 	return facts, rows.Err()
@@ -193,7 +222,7 @@ func (s *SQLiteStore) ListFactsByMemoryIDs(ctx context.Context, memoryIDs []int6
 	}
 
 	query := fmt.Sprintf(`SELECT f.id, f.memory_id, f.subject, f.predicate, f.object, f.fact_type,
-		f.confidence, f.decay_rate, f.last_reinforced, f.source_quote, f.created_at, f.state, f.superseded_by, f.agent_id
+		f.confidence, f.decay_rate, f.last_reinforced, f.source_quote, f.temporal_norm, f.created_at, f.state, f.superseded_by, f.agent_id
 		FROM facts f
 		WHERE f.memory_id IN (%s) AND f.superseded_by IS NULL`,
 		strings.Join(placeholders, ","))
@@ -215,15 +244,17 @@ func (s *SQLiteStore) ListFactsByMemoryIDs(ctx context.Context, memoryIDs []int6
 	for rows.Next() {
 		f := &Fact{}
 		var supersededBy sql.NullInt64
+		var temporalNorm sql.NullString
 		if err := rows.Scan(&f.ID, &f.MemoryID, &f.Subject, &f.Predicate, &f.Object,
 			&f.FactType, &f.Confidence, &f.DecayRate, &f.LastReinforced,
-			&f.SourceQuote, &f.CreatedAt, &f.State, &supersededBy, &f.AgentID); err != nil {
+			&f.SourceQuote, &temporalNorm, &f.CreatedAt, &f.State, &supersededBy, &f.AgentID); err != nil {
 			return nil, fmt.Errorf("scanning fact row: %w", err)
 		}
 		if supersededBy.Valid {
 			v := supersededBy.Int64
 			f.SupersededBy = &v
 		}
+		f.TemporalNorm = unmarshalTemporalNorm(temporalNorm)
 		facts = append(facts, f)
 	}
 	return facts, rows.Err()
@@ -393,7 +424,7 @@ func (s *SQLiteStore) getFactsByMemoryIDs(ctx context.Context, memoryIDs []int64
 	}
 
 	query := fmt.Sprintf(
-		`SELECT id, memory_id, subject, predicate, object, fact_type, confidence, decay_rate, last_reinforced, source_quote, created_at, state, superseded_by, agent_id
+		`SELECT id, memory_id, subject, predicate, object, fact_type, confidence, decay_rate, last_reinforced, source_quote, temporal_norm, created_at, state, superseded_by, agent_id
 		 FROM facts WHERE memory_id IN (%s)`,
 		strings.Join(placeholders, ","),
 	)
@@ -411,15 +442,17 @@ func (s *SQLiteStore) getFactsByMemoryIDs(ctx context.Context, memoryIDs []int64
 	for rows.Next() {
 		f := &Fact{}
 		var supersededBy sql.NullInt64
+		var temporalNorm sql.NullString
 		if err := rows.Scan(&f.ID, &f.MemoryID, &f.Subject, &f.Predicate, &f.Object,
 			&f.FactType, &f.Confidence, &f.DecayRate, &f.LastReinforced,
-			&f.SourceQuote, &f.CreatedAt, &f.State, &supersededBy, &f.AgentID); err != nil {
+			&f.SourceQuote, &temporalNorm, &f.CreatedAt, &f.State, &supersededBy, &f.AgentID); err != nil {
 			return nil, fmt.Errorf("scanning fact: %w", err)
 		}
 		if supersededBy.Valid {
 			v := supersededBy.Int64
 			f.SupersededBy = &v
 		}
+		f.TemporalNorm = unmarshalTemporalNorm(temporalNorm)
 		facts = append(facts, f)
 	}
 	return facts, rows.Err()

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -94,6 +94,11 @@ func (s *SQLiteStore) migrate() error {
 		return fmt.Errorf("migrating fact agent_id: %w", err)
 	}
 
+	// Schema evolution: temporal_norm on facts (temporal normalization)
+	if err := s.migrateFactTemporalNorm(); err != nil {
+		return fmt.Errorf("migrating fact temporal_norm: %w", err)
+	}
+
 	// Schema evolution: fact accesses table (v1.0 — Issue #166)
 	if err := s.migrateFactAccessesTable(); err != nil {
 		return fmt.Errorf("migrating fact accesses table: %w", err)
@@ -179,6 +184,7 @@ func (s *SQLiteStore) runBootstrapDDL() error {
 			decay_rate      REAL DEFAULT 0.01,
 			last_reinforced DATETIME DEFAULT CURRENT_TIMESTAMP,
 			source_quote    TEXT,
+			temporal_norm   TEXT,
 			created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
 			state           TEXT NOT NULL DEFAULT 'active' CHECK(state IN ('active','core','retired','superseded')),
 			superseded_by   INTEGER REFERENCES facts(id)
@@ -1021,6 +1027,27 @@ func (s *SQLiteStore) migrateFactAgentID() error {
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("committing agent_id migration: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) migrateFactTemporalNorm() error {
+	var count int
+	err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM pragma_table_info('facts') WHERE name='temporal_norm'",
+	).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("checking for temporal_norm column: %w", err)
+	}
+	if count > 0 {
+		return nil
+	}
+
+	if _, err := s.db.Exec(`ALTER TABLE facts ADD COLUMN temporal_norm TEXT NULL`); err != nil {
+		if isDuplicateColumnError(err) {
+			return nil
+		}
+		return fmt.Errorf("adding temporal_norm column: %w", err)
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hurttlocker/cortex/internal/temporal"
 	_ "modernc.org/sqlite"
 )
 
@@ -82,6 +83,7 @@ type Fact struct {
 	DecayRate      float64
 	LastReinforced time.Time
 	SourceQuote    string
+	TemporalNorm   *temporal.Norm
 	CreatedAt      time.Time
 	State          string // active|core|retired|superseded
 	SupersededBy   *int64 // Fact ID that superseded this fact (nil = active)

--- a/internal/store/temporal_fact_test.go
+++ b/internal/store/temporal_fact_test.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hurttlocker/cortex/internal/temporal"
+)
+
+func TestAddFact_TemporalNormRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	memID, err := s.AddMemory(ctx, &Memory{Content: "Jon went to the fair", SourceFile: "locomo.md"})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+
+	factID, err := s.AddFact(ctx, &Fact{
+		MemoryID:   memID,
+		Subject:    "Jon",
+		Predicate:  "date",
+		Object:     "last week",
+		FactType:   "temporal",
+		Confidence: 0.9,
+		TemporalNorm: &temporal.Norm{
+			Kind:       "date_range",
+			Literal:    "last week",
+			Start:      "2023-03-16",
+			End:        "2023-03-22",
+			Anchor:     "2023-03-23",
+			Precision:  "day",
+			Resolution: "resolved_from_anchor",
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddFact: %v", err)
+	}
+
+	got, err := s.GetFact(ctx, factID)
+	if err != nil {
+		t.Fatalf("GetFact: %v", err)
+	}
+	if got == nil || got.TemporalNorm == nil {
+		t.Fatalf("expected temporal norm, got %+v", got)
+	}
+	if got.TemporalNorm.Start != "2023-03-16" || got.TemporalNorm.End != "2023-03-22" {
+		t.Fatalf("unexpected temporal norm: %+v", got.TemporalNorm)
+	}
+}

--- a/internal/temporal/temporal.go
+++ b/internal/temporal/temporal.go
@@ -1,0 +1,385 @@
+package temporal
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Norm struct {
+	Kind        string  `json:"kind"`
+	Literal     string  `json:"literal"`
+	Value       string  `json:"value,omitempty"`
+	Start       string  `json:"start,omitempty"`
+	End         string  `json:"end,omitempty"`
+	Anchor      string  `json:"anchor,omitempty"`
+	Precision   string  `json:"precision,omitempty"`
+	Resolution  string  `json:"resolution,omitempty"`
+	CalendarRef string  `json:"calendar_ref,omitempty"`
+	Confidence  float64 `json:"confidence,omitempty"`
+}
+
+type Query struct {
+	Raw            string `json:"raw"`
+	TemporalIntent bool   `json:"temporal_intent"`
+	Kind           string `json:"kind,omitempty"`
+	Value          string `json:"value,omitempty"`
+	Start          string `json:"start,omitempty"`
+	End            string `json:"end,omitempty"`
+	Precision      string `json:"precision,omitempty"`
+	Resolved       bool   `json:"resolved"`
+}
+
+var (
+	sessionPrefixRE = regexp.MustCompile(`(?i)^\s*session\s+\d+\s*[-—:]\s*`)
+	monthNames      = `(January|February|March|April|May|June|July|August|September|October|November|December)`
+	dateTimeRE      = regexp.MustCompile(`(?i)\b\d{1,2}:\d{2}\s*(?:am|pm)\s+on\s+\d{1,2}\s+` + monthNames + `\s*,\s*\d{4}\b`)
+	dayMonthYearRE  = regexp.MustCompile(`(?i)\b(\d{1,2})\s+` + monthNames + `\s*,?\s+(\d{4})\b`)
+	monthDayYearRE  = regexp.MustCompile(`(?i)\b` + monthNames + `\s+(\d{1,2}),\s*(\d{4})\b`)
+	dayMonthRE      = regexp.MustCompile(`(?i)\b(\d{1,2})\s+` + monthNames + `\b`)
+	monthDayRE      = regexp.MustCompile(`(?i)\b` + monthNames + `\s+(\d{1,2})\b`)
+	monthYearRE     = regexp.MustCompile(`(?i)\b` + monthNames + `\s+(\d{4})\b`)
+	isoDateRE       = regexp.MustCompile(`\b(\d{4}-\d{2}-\d{2})\b`)
+	yearRE          = regexp.MustCompile(`\b((?:19|20)\d{2})\b`)
+	weekBeforeRE    = regexp.MustCompile(`(?i)\b(?:the\s+)?week\s+before\s+(.+)$`)
+	weekAfterRE     = regexp.MustCompile(`(?i)\b(?:the\s+)?week\s+after\s+(.+)$`)
+	durationAgoRE   = regexp.MustCompile(`(?i)\b(\d+)\s+(day|week|month|year)s?\s+ago\b`)
+	whenIntentRE    = regexp.MustCompile(`(?i)\b(when|date|dated|day|week|month|year|yesterday|today|tomorrow|last week|next week|last month|next month)\b`)
+)
+
+var anchorLayouts = []string{
+	"3:04 pm on 2 January, 2006",
+	"3:04 PM on 2 January, 2006",
+	"3:04 pm on January 2, 2006",
+	"3:04 PM on January 2, 2006",
+	time.RFC3339,
+	"2 January, 2006",
+	"January 2, 2006",
+	"2006-01-02",
+}
+
+func TimestampStartFromSection(section string) string {
+	section = strings.TrimSpace(section)
+	if section == "" {
+		return ""
+	}
+
+	candidates := []string{section}
+	cleaned := strings.TrimSpace(sessionPrefixRE.ReplaceAllString(section, ""))
+	if cleaned != "" && cleaned != section {
+		candidates = append(candidates, cleaned)
+	}
+	if match := dateTimeRE.FindString(cleaned); match != "" {
+		candidates = append(candidates, match)
+	}
+	if match := dayMonthYearRE.FindString(cleaned); match != "" {
+		candidates = append(candidates, match)
+	}
+	if match := monthDayYearRE.FindString(cleaned); match != "" {
+		candidates = append(candidates, match)
+	}
+	if match := isoDateRE.FindString(cleaned); match != "" {
+		candidates = append(candidates, match)
+	}
+
+	seen := map[string]struct{}{}
+	for _, c := range candidates {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		if _, ok := seen[c]; ok {
+			continue
+		}
+		seen[c] = struct{}{}
+		if ts := parseAnchorTimestamp(c); ts != "" {
+			return ts
+		}
+	}
+	return ""
+}
+
+func ParseQuery(query string) *Query {
+	raw := strings.TrimSpace(query)
+	if raw == "" {
+		return nil
+	}
+	q := &Query{Raw: raw}
+	if whenIntentRE.MatchString(raw) {
+		q.TemporalIntent = true
+	}
+	if norm := NormalizeLiteral(raw, ""); norm != nil {
+		q.TemporalIntent = true
+		q.Kind = norm.Kind
+		q.Value = norm.Value
+		q.Start = norm.Start
+		q.End = norm.End
+		q.Precision = norm.Precision
+		q.Resolved = norm.Resolution != "unresolved"
+	}
+	if !q.TemporalIntent {
+		return nil
+	}
+	return q
+}
+
+func NormalizeLiteral(literal string, anchor string) *Norm {
+	literal = strings.TrimSpace(literal)
+	if literal == "" {
+		return nil
+	}
+
+	anchorTime, hasAnchor := parseAnchor(anchor)
+
+	if norm := normalizeRelativeRange(literal, anchorTime, hasAnchor); norm != nil {
+		return norm
+	}
+	if norm := normalizeRelativePoint(literal, anchorTime, hasAnchor); norm != nil {
+		return norm
+	}
+	if norm := normalizeDurationAgo(literal, anchorTime, hasAnchor); norm != nil {
+		return norm
+	}
+	if norm := normalizeAbsolute(literal, anchorTime, hasAnchor); norm != nil {
+		return norm
+	}
+
+	if whenIntentRE.MatchString(literal) {
+		return &Norm{
+			Kind:       "date_range",
+			Literal:    literal,
+			Precision:  "unknown",
+			Resolution: "unresolved",
+			Anchor:     anchorDate(anchorTime, hasAnchor),
+		}
+	}
+	return nil
+}
+
+func MatchesQuery(q *Query, n *Norm) bool {
+	if q == nil || n == nil {
+		return false
+	}
+	if q.Value != "" && n.Value != "" {
+		return q.Value == n.Value
+	}
+	qs, qe := q.Start, q.End
+	ns, ne := n.Start, n.End
+	if qs != "" && qe == "" {
+		qe = qs
+	}
+	if ns != "" && ne == "" {
+		ne = ns
+	}
+	if qs == "" || qe == "" || ns == "" || ne == "" {
+		return false
+	}
+	return !(qe < ns || ne < qs)
+}
+
+func Summary(n *Norm) string {
+	if n == nil {
+		return ""
+	}
+	switch {
+	case n.Value != "":
+		return n.Value
+	case n.Start != "" && n.End != "" && n.Start != n.End:
+		return n.Start + ".." + n.End
+	case n.Start != "":
+		return n.Start
+	default:
+		return ""
+	}
+}
+
+func parseAnchorTimestamp(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	for _, layout := range anchorLayouts {
+		if parsed, err := time.ParseInLocation(layout, raw, time.UTC); err == nil {
+			return parsed.UTC().Format(time.RFC3339)
+		}
+	}
+	return ""
+}
+
+func parseAnchor(anchor string) (time.Time, bool) {
+	anchor = strings.TrimSpace(anchor)
+	if anchor == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02"} {
+		if t, err := time.ParseInLocation(layout, anchor, time.UTC); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func normalizeAbsolute(literal string, anchor time.Time, hasAnchor bool) *Norm {
+	if match := isoDateRE.FindStringSubmatch(literal); len(match) == 2 {
+		return &Norm{Kind: "date", Literal: literal, Value: match[1], Precision: "day", Resolution: "absolute", Confidence: 0.95}
+	}
+	if match := dayMonthYearRE.FindStringSubmatch(literal); len(match) == 4 {
+		if t, err := time.ParseInLocation("2 January 2006", match[1]+" "+match[2]+" "+match[3], time.UTC); err == nil {
+			return &Norm{Kind: "date", Literal: literal, Value: t.Format("2006-01-02"), Precision: "day", Resolution: "absolute", Confidence: 0.95}
+		}
+	}
+	if match := monthDayYearRE.FindStringSubmatch(literal); len(match) == 4 {
+		if t, err := time.ParseInLocation("January 2 2006", match[1]+" "+match[2]+" "+match[3], time.UTC); err == nil {
+			return &Norm{Kind: "date", Literal: literal, Value: t.Format("2006-01-02"), Precision: "day", Resolution: "absolute", Confidence: 0.95}
+		}
+	}
+	if match := monthYearRE.FindStringSubmatch(literal); len(match) == 3 {
+		if t, err := time.ParseInLocation("January 2006", match[1]+" "+match[2], time.UTC); err == nil {
+			start := time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+			end := start.AddDate(0, 1, -1)
+			return &Norm{Kind: "date_range", Literal: literal, Start: start.Format("2006-01-02"), End: end.Format("2006-01-02"), Precision: "month", Resolution: "absolute", Confidence: 0.9}
+		}
+	}
+	if match := yearRE.FindStringSubmatch(literal); len(match) == 2 && !strings.Contains(strings.ToLower(literal), "ago") {
+		year, _ := strconv.Atoi(match[1])
+		start := time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(year, time.December, 31, 0, 0, 0, 0, time.UTC)
+		return &Norm{Kind: "date_range", Literal: literal, Start: start.Format("2006-01-02"), End: end.Format("2006-01-02"), Precision: "year", Resolution: "absolute", Confidence: 0.85}
+	}
+	if hasAnchor {
+		if match := dayMonthRE.FindStringSubmatch(literal); len(match) == 3 {
+			if t, err := time.ParseInLocation("2 January 2006", match[1]+" "+match[2]+" "+strconv.Itoa(anchor.Year()), time.UTC); err == nil {
+				return &Norm{Kind: "date", Literal: literal, Value: t.Format("2006-01-02"), Precision: "day", Resolution: "resolved_from_anchor", Anchor: anchor.Format("2006-01-02"), CalendarRef: "session_start", Confidence: 0.8}
+			}
+		}
+		if match := monthDayRE.FindStringSubmatch(literal); len(match) == 3 {
+			if t, err := time.ParseInLocation("January 2 2006", match[1]+" "+match[2]+" "+strconv.Itoa(anchor.Year()), time.UTC); err == nil {
+				return &Norm{Kind: "date", Literal: literal, Value: t.Format("2006-01-02"), Precision: "day", Resolution: "resolved_from_anchor", Anchor: anchor.Format("2006-01-02"), CalendarRef: "session_start", Confidence: 0.8}
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeRelativeRange(literal string, anchor time.Time, hasAnchor bool) *Norm {
+	raw := strings.TrimSpace(literal)
+	lower := strings.ToLower(raw)
+	if match := weekBeforeRE.FindStringSubmatch(raw); len(match) == 2 {
+		if base := NormalizeLiteral(match[1], anchorDate(anchor, hasAnchor)); base != nil {
+			baseDate := valueToTime(base)
+			if !baseDate.IsZero() {
+				start := baseDate.AddDate(0, 0, -7)
+				end := baseDate.AddDate(0, 0, -1)
+				return &Norm{Kind: "date_range", Literal: literal, Start: start.Format("2006-01-02"), End: end.Format("2006-01-02"), Anchor: anchorDate(anchor, hasAnchor), Precision: "day", Resolution: "resolved_from_anchor", CalendarRef: "session_start", Confidence: 0.9}
+			}
+		}
+	}
+	if match := weekAfterRE.FindStringSubmatch(raw); len(match) == 2 {
+		if base := NormalizeLiteral(match[1], anchorDate(anchor, hasAnchor)); base != nil {
+			baseDate := valueToTime(base)
+			if !baseDate.IsZero() {
+				start := baseDate.AddDate(0, 0, 1)
+				end := baseDate.AddDate(0, 0, 7)
+				return &Norm{Kind: "date_range", Literal: literal, Start: start.Format("2006-01-02"), End: end.Format("2006-01-02"), Anchor: anchorDate(anchor, hasAnchor), Precision: "day", Resolution: "resolved_from_anchor", CalendarRef: "session_start", Confidence: 0.9}
+			}
+		}
+	}
+	if !hasAnchor {
+		return nil
+	}
+	switch lower {
+	case "last week":
+		return rangeFromAnchor(literal, anchor, -7, -1)
+	case "next week":
+		return rangeFromAnchor(literal, anchor, 1, 7)
+	case "last month":
+		start := time.Date(anchor.Year(), anchor.Month()-1, 1, 0, 0, 0, 0, time.UTC)
+		end := start.AddDate(0, 1, -1)
+		return &Norm{Kind: "date_range", Literal: literal, Start: start.Format("2006-01-02"), End: end.Format("2006-01-02"), Anchor: anchor.Format("2006-01-02"), Precision: "month", Resolution: "resolved_from_anchor", CalendarRef: "session_start", Confidence: 0.85}
+	case "next month":
+		start := time.Date(anchor.Year(), anchor.Month()+1, 1, 0, 0, 0, 0, time.UTC)
+		end := start.AddDate(0, 1, -1)
+		return &Norm{Kind: "date_range", Literal: literal, Start: start.Format("2006-01-02"), End: end.Format("2006-01-02"), Anchor: anchor.Format("2006-01-02"), Precision: "month", Resolution: "resolved_from_anchor", CalendarRef: "session_start", Confidence: 0.85}
+	}
+	return nil
+}
+
+func normalizeRelativePoint(literal string, anchor time.Time, hasAnchor bool) *Norm {
+	if !hasAnchor {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(literal)) {
+	case "today":
+		return pointFromAnchor(literal, anchor, 0)
+	case "yesterday":
+		return pointFromAnchor(literal, anchor, -1)
+	case "tomorrow":
+		return pointFromAnchor(literal, anchor, 1)
+	}
+	return nil
+}
+
+func normalizeDurationAgo(literal string, anchor time.Time, hasAnchor bool) *Norm {
+	match := durationAgoRE.FindStringSubmatch(strings.ToLower(strings.TrimSpace(literal)))
+	if len(match) != 3 || !hasAnchor {
+		return nil
+	}
+	amount, _ := strconv.Atoi(match[1])
+	unit := match[2]
+	switch unit {
+	case "day":
+		target := anchor.AddDate(0, 0, -amount)
+		return &Norm{Kind: "date", Literal: literal, Value: target.Format("2006-01-02"), Anchor: anchor.Format("2006-01-02"), Precision: "day", Resolution: "resolved_from_anchor", CalendarRef: "session_start", Confidence: 0.8}
+	case "week":
+		start := anchor.AddDate(0, 0, -7*amount)
+		end := start.AddDate(0, 0, 6)
+		return &Norm{Kind: "date_range", Literal: literal, Start: start.Format("2006-01-02"), End: end.Format("2006-01-02"), Anchor: anchor.Format("2006-01-02"), Precision: "week", Resolution: "resolved_from_anchor", CalendarRef: "session_start", Confidence: 0.8}
+	case "month":
+		target := anchor.AddDate(0, -amount, 0)
+		start := time.Date(target.Year(), target.Month(), 1, 0, 0, 0, 0, time.UTC)
+		end := start.AddDate(0, 1, -1)
+		return &Norm{Kind: "date_range", Literal: literal, Start: start.Format("2006-01-02"), End: end.Format("2006-01-02"), Anchor: anchor.Format("2006-01-02"), Precision: "month", Resolution: "resolved_from_anchor", CalendarRef: "session_start", Confidence: 0.78}
+	case "year":
+		targetYear := anchor.Year() - amount
+		start := time.Date(targetYear, time.January, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(targetYear, time.December, 31, 0, 0, 0, 0, time.UTC)
+		return &Norm{Kind: "date_range", Literal: literal, Start: start.Format("2006-01-02"), End: end.Format("2006-01-02"), Anchor: anchor.Format("2006-01-02"), Precision: "year", Resolution: "resolved_from_anchor", CalendarRef: "session_start", Confidence: 0.75}
+	}
+	return nil
+}
+
+func pointFromAnchor(literal string, anchor time.Time, days int) *Norm {
+	target := anchor.AddDate(0, 0, days)
+	return &Norm{Kind: "date", Literal: literal, Value: target.Format("2006-01-02"), Anchor: anchor.Format("2006-01-02"), Precision: "day", Resolution: "resolved_from_anchor", CalendarRef: "session_start", Confidence: 0.9}
+}
+
+func rangeFromAnchor(literal string, anchor time.Time, startDays int, endDays int) *Norm {
+	start := anchor.AddDate(0, 0, startDays)
+	end := anchor.AddDate(0, 0, endDays)
+	return &Norm{Kind: "date_range", Literal: literal, Start: start.Format("2006-01-02"), End: end.Format("2006-01-02"), Anchor: anchor.Format("2006-01-02"), Precision: "day", Resolution: "resolved_from_anchor", CalendarRef: "session_start", Confidence: 0.9}
+}
+
+func valueToTime(n *Norm) time.Time {
+	if n == nil {
+		return time.Time{}
+	}
+	if n.Value != "" {
+		if t, err := time.ParseInLocation("2006-01-02", n.Value, time.UTC); err == nil {
+			return t
+		}
+	}
+	if n.Start != "" {
+		if t, err := time.ParseInLocation("2006-01-02", n.Start, time.UTC); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func anchorDate(anchor time.Time, ok bool) string {
+	if !ok {
+		return ""
+	}
+	return anchor.Format("2006-01-02")
+}

--- a/internal/temporal/temporal_test.go
+++ b/internal/temporal/temporal_test.go
@@ -1,0 +1,30 @@
+package temporal
+
+import "testing"
+
+func TestTimestampStartFromSection(t *testing.T) {
+	got := TimestampStartFromSection("Session 7 - 7:28 pm on 23 March, 2023")
+	if got != "2023-03-23T19:28:00Z" {
+		t.Fatalf("TimestampStartFromSection = %q, want %q", got, "2023-03-23T19:28:00Z")
+	}
+}
+
+func TestNormalizeLiteral_WeekBeforeAbsoluteDate(t *testing.T) {
+	n := NormalizeLiteral("the week before 9 June 2023", "")
+	if n == nil {
+		t.Fatal("expected norm")
+	}
+	if n.Start != "2023-06-02" || n.End != "2023-06-08" {
+		t.Fatalf("got %s..%s, want 2023-06-02..2023-06-08", n.Start, n.End)
+	}
+}
+
+func TestNormalizeLiteral_LastWeekUsesAnchor(t *testing.T) {
+	n := NormalizeLiteral("last week", "2023-03-23T19:28:00Z")
+	if n == nil {
+		t.Fatal("expected norm")
+	}
+	if n.Start != "2023-03-16" || n.End != "2023-03-22" {
+		t.Fatalf("got %s..%s, want 2023-03-16..2023-03-22", n.Start, n.End)
+	}
+}


### PR DESCRIPTION
Phase A:
- `TimestampStart` propagation from `SourceSection`
- `anchor_date` rendering in the real answer context

Phase B:
- `facts.temporal_norm` column
- `TemporalNorm` struct on facts
- extraction/enrichment prompt and schema updates for `temporal_norm`
- query-time temporal parsing and boost in search

Benchmark:
- Product-path LoCoMo `conv-30` slice improved from `7.61%` to `8.93%` F1 (`+1.32`)
- Benchmark note: [docs/archive/locomo-conv30-temporal-phaseab-2026-03-22.md](docs/archive/locomo-conv30-temporal-phaseab-2026-03-22.md)

Note:
- Depends on `feat/locomo-quick-wins` merging first because this branch builds on the hybrid answer embedder / FTS sanitization foundation

Tests:
- `go test ./...` passing
