### PR TITLE
feat: add retrieval parity foundation

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -9867,6 +9867,16 @@ func outputTTYSearch(query string, results []search.Result, showMetadata bool, e
 		if explain && r.Explain != nil {
 			e := r.Explain
 			fmt.Printf("     🔎 source=%s\n", e.Provenance.Source)
+			if e.QueryStrategy != nil {
+				fmt.Printf("     🧭 strategy=%s", e.QueryStrategy.Primary)
+				if len(e.QueryStrategy.Entities) > 0 {
+					fmt.Printf(" entities=%s", strings.Join(e.QueryStrategy.Entities, ","))
+				}
+				if e.QueryStrategy.TemporalIntent {
+					fmt.Print(" temporal=true")
+				}
+				fmt.Println()
+			}
 			if !e.Provenance.Timestamp.IsZero() {
 				fmt.Printf("     ⏱ imported=%s  age=%.1f days\n", e.Provenance.Timestamp.Format(time.RFC3339), e.Provenance.AgeDays)
 			}
@@ -9889,6 +9899,17 @@ func outputTTYSearch(query string, results []search.Result, showMetadata bool, e
 			}
 			if e.RankComponents.HybridBM25Contribution != nil && e.RankComponents.HybridSemanticContribution != nil {
 				fmt.Printf("     • hybrid: bm25=%.3f semantic=%.3f\n", *e.RankComponents.HybridBM25Contribution, *e.RankComponents.HybridSemanticContribution)
+			}
+			if e.RankComponents.EntityChannelScore != nil || e.RankComponents.TemporalChannelScore != nil {
+				entityScore := 0.0
+				temporalScore := 0.0
+				if e.RankComponents.EntityChannelScore != nil {
+					entityScore = *e.RankComponents.EntityChannelScore
+				}
+				if e.RankComponents.TemporalChannelScore != nil {
+					temporalScore = *e.RankComponents.TemporalChannelScore
+				}
+				fmt.Printf("     • rrf extras: entity=%.3f temporal=%.3f\n", entityScore, temporalScore)
 			}
 			if e.RankComponents.SourceWeight != 0 {
 				fmt.Printf("     • source_weight=%.3f\n", e.RankComponents.SourceWeight)

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -1706,7 +1706,7 @@ func newSearchEngineForModeStrict(s store.Store, mode search.Mode, embedFlag str
 
 func runAsk(args []string) error {
 	var queryParts []string
-	mode := "hybrid"
+	mode := "rrf"
 	limit := 8
 	limitExplicit := false
 	budget := 1500
@@ -1843,7 +1843,7 @@ func runAsk(args []string) error {
 		case args[i] == "--entity-graph":
 			entityGraph = true
 		case strings.HasPrefix(args[i], "-"):
-			return fmt.Errorf("unknown flag: %s\nusage: cortex ask <query> [--mode hybrid|bm25|semantic|rrf] [--limit 8] [--budget 1500] [--model provider/model] [--embed <provider/model>] [--rerank[=auto|on|off]] [--entity-graph] [--scope agent:<id>|entity:<id>|session:<id>|project:<id>] [--json]", args[i])
+			return fmt.Errorf("unknown flag: %s\nusage: cortex ask <query> [--mode rrf|hybrid|bm25|semantic] [--limit 8] [--budget 1500] [--model provider/model] [--embed <provider/model>] [--rerank[=auto|on|off]] [--entity-graph] [--scope agent:<id>|entity:<id>|session:<id>|project:<id>] [--json]", args[i])
 		default:
 			queryParts = append(queryParts, args[i])
 		}
@@ -1851,7 +1851,7 @@ func runAsk(args []string) error {
 
 	query := strings.TrimSpace(strings.Join(queryParts, " "))
 	if query == "" {
-		return fmt.Errorf("usage: cortex ask <query> [--mode hybrid|bm25|semantic|rrf] [--limit 8] [--budget 1500] [--model provider/model] [--embed <provider/model>] [--rerank[=auto|on|off]] [--entity-graph] [--scope agent:<id>|entity:<id>|session:<id>|project:<id>] [--json]")
+		return fmt.Errorf("usage: cortex ask <query> [--mode rrf|hybrid|bm25|semantic] [--limit 8] [--budget 1500] [--model provider/model] [--embed <provider/model>] [--rerank[=auto|on|off]] [--entity-graph] [--scope agent:<id>|entity:<id>|session:<id>|project:<id>] [--json]")
 	}
 
 	modeParsed, err := search.ParseMode(mode)
@@ -1996,7 +1996,7 @@ func providerName(provider llm.Provider, model string) string {
 
 func runAnswer(args []string) error {
 	var queryParts []string
-	mode := "hybrid"
+	mode := "rrf"
 	limit := 5
 	modelFlag := ""
 	embedFlag := ""
@@ -2120,7 +2120,7 @@ func runAnswer(args []string) error {
 		case args[i] == "--verbose" || args[i] == "-v":
 			verbose = true
 		case strings.HasPrefix(args[i], "-"):
-			return fmt.Errorf("unknown flag: %s\nusage: cortex answer <query> [--mode hybrid] [--limit 5] [--model provider/model] [--embed <provider/model>] [--rerank[=auto|on|off]] [--max-sentences 6] [--json]", args[i])
+			return fmt.Errorf("unknown flag: %s\nusage: cortex answer <query> [--mode rrf|hybrid|bm25|semantic] [--limit 5] [--model provider/model] [--embed <provider/model>] [--rerank[=auto|on|off]] [--max-sentences 6] [--json]", args[i])
 		default:
 			queryParts = append(queryParts, args[i])
 		}
@@ -2128,7 +2128,7 @@ func runAnswer(args []string) error {
 
 	query := strings.TrimSpace(strings.Join(queryParts, " "))
 	if query == "" {
-		return fmt.Errorf("usage: cortex answer <query> [--mode hybrid] [--limit 5] [--model provider/model] [--embed <provider/model>] [--rerank[=auto|on|off]] [--max-sentences 6] [--json]")
+		return fmt.Errorf("usage: cortex answer <query> [--mode rrf|hybrid|bm25|semantic] [--limit 5] [--model provider/model] [--embed <provider/model>] [--rerank[=auto|on|off]] [--max-sentences 6] [--json]")
 	}
 
 	modeParsed, err := search.ParseMode(mode)

--- a/docs/research/retrieval-parity-foundation-benchmark-2026-03-23.md
+++ b/docs/research/retrieval-parity-foundation-benchmark-2026-03-23.md
@@ -1,0 +1,156 @@
+# Retrieval Parity Foundation Benchmark — 2026-03-23
+
+## Scope
+
+This note benchmarks the `feat/retrieval-parity-foundation` branch against the same public LoCoMo `conv-30` answerable slice used in the `v1.4.0` note.
+
+This branch adds:
+
+- query strategy classification
+- strategy-aware RRF weights
+- a temporal retrieval channel in RRF
+- bounded scene expansion
+- grouped evidence rendering in `ask` / `answer`
+- `ask` and `answer` defaulting to `rrf`
+
+## Setup
+
+- repo branch: `feat/retrieval-parity-foundation`
+- binary: `/tmp/cortex-retrieval-parity-bench`
+- benchmark DB: `/tmp/cortex-v140-benchmark-2026-03-23/cortex.db`
+- corpus source: `/tmp/cortex-locomo-combined-2026-03-22/corpus`
+- question source: `/tmp/cortex-locomo-run-fast/checkpoints/hybrid.json`
+- raw artifact: `/tmp/retrieval-parity-results-2026-03-23.json`
+- reader model: `google/gemini-2.5-flash`
+- query embedder: `openrouter/text-embedding-3-small`
+
+The DB was the same fresh LoCoMo-only DB used for the existing `v1.4.0` benchmark. I did not re-import or re-embed it.
+
+## Modes
+
+I measured two product-path variants through `cortex ask`:
+
+- `rrf_default`
+  - `--mode rrf --rerank off`
+- `rrf_rerank_daemon`
+  - `--mode rrf --rerank on`
+  - warm local reranker daemon on `localhost:9720`
+
+## Results
+
+| Mode | F1 | Avg latency | Median latency | Degraded |
+| --- | ---: | ---: | ---: | ---: |
+| `rrf_default` | `11.90%` | `6461.61 ms` | `6328.81 ms` | `0` |
+| `rrf_rerank_daemon` | `15.03%` | `9706.82 ms` | `9910.43 ms` | `0` |
+
+Important note:
+
+- normalized exact accuracy on raw answer strings stayed `0.00%` in both modes
+- this is not a retrieval failure signal; it reflects that the current answer path still returns cited short-form sentences instead of exact normalized gold strings
+- the meaningful comparison metric here remains the same LoCoMo-style token F1 used in the prior Cortex notes
+
+## Comparison To v1.4.0
+
+Reference numbers from `docs/research/v140-benchmark-2026-03-23.md`:
+
+- `A` baseline: `11.81%` F1
+- `C` reranker daemon only: `13.26%` F1
+- prior historical best single-feature benchmark: `15.77%` F1
+
+Delta from `A` baseline:
+
+- `rrf_default`: `+0.09`
+- `rrf_rerank_daemon`: `+3.22`
+
+Delta from `C` reranker daemon only:
+
+- `rrf_rerank_daemon`: `+1.77`
+
+Delta from prior `15.77%` reference:
+
+- `rrf_rerank_daemon`: `-0.74`
+
+The key read:
+
+- the retrieval-parity foundation work is basically neutral on the non-reranked path
+- the same work is a real win on the daemon-backed best path
+- the branch closes most of the remaining gap to the previous `15.77%` best reference
+
+## Category Breakdown
+
+### `rrf_default`
+
+- category `1`: `18.70%` F1 on `11` questions
+- category `2`: `10.12%` F1 on `26` questions
+- category `4`: `11.26%` F1 on `44` questions
+
+### `rrf_rerank_daemon`
+
+- category `1`: `27.46%` F1 on `11` questions
+- category `2`: `11.22%` F1 on `26` questions
+- category `4`: `14.18%` F1 on `44` questions
+
+Interpretation:
+
+- the biggest gain is category `1`
+- category `2` is roughly flat relative to the prior reranker-backed path
+- category `4` stays roughly flat to slightly down relative to the prior reranker-backed path
+
+That profile is consistent with what this branch changed:
+
+- better routing
+- better evidence-set construction
+- better scene-level packing
+
+These help compositional / scene-sensitive questions more than pure date normalization.
+
+## 3-Question Diagnostic
+
+### `conv-30:27` `Did Jon and Gina both participate in dance competitions?`
+
+- `rrf_default` answer:
+  - `Jon participates in dance competitions [1]. There is no evidence that Gina participates in dance competitions.`
+  - F1: `0.00`
+- `rrf_rerank_daemon` answer:
+  - `Yes, both Jon and Gina participated in dance competitions...`
+  - F1: `1.00`
+
+This is the clearest branch win.
+
+### `conv-30:62` `How does Gina stay confident in her business?`
+
+- `rrf_default` F1: `0.6667`
+- `rrf_rerank_daemon` F1: `0.6977`
+
+Small improvement, same evidence family.
+
+### `conv-30:11` `When did Gina get her tattoo?`
+
+- `rrf_default` answer:
+  - `Gina got her tattoo a few years ago [4].`
+  - F1: `0.5455`
+- `rrf_rerank_daemon` answer:
+  - `Gina got her tattoo a few years ago [1]. This statement was made on February 8, 2023 [1].`
+  - F1: `0.3000`
+
+This is a useful warning:
+
+- grouped evidence and scene expansion help composition
+- but the reader still sometimes appends extra temporal framing that hurts strict F1
+
+## Bottom Line
+
+This branch is a real retrieval improvement when paired with the reranker daemon:
+
+- `13.26%` -> `15.03%` F1 on the best path
+- `0` degraded responses maintained
+
+Without the daemon, the branch is roughly flat:
+
+- `11.81%` -> `11.90%`
+
+So the honest conclusion is:
+
+1. the strategy classifier + temporal channel + scene expansion stack is directionally correct
+2. the gain shows up most clearly when the reranker is present
+3. answer-form discipline is now the main blocker to converting these retrieval wins into normalized exact-answer wins

--- a/docs/research/v140-benchmark-2026-03-23.md
+++ b/docs/research/v140-benchmark-2026-03-23.md
@@ -1,0 +1,235 @@
+# Cortex v1.4.0 Benchmark — 2026-03-23
+
+## Scope
+
+This note benchmarks Cortex `v1.4.0` on the public LoCoMo `conv-30` slice with the full query-time stack available:
+
+- temporal normalization
+- Honcho recall / ask-path fixes
+- entity resolution graph
+- cross-encoder reranker daemon
+
+The goal was to measure four product-path variants through `cortex ask`:
+
+- `A` baseline: no entity graph, no reranker
+- `B` entity graph only
+- `C` reranker daemon only
+- `D` full stack: entity graph + reranker daemon
+
+## Setup
+
+- repo: `main` at `46ee0ca`
+- binary: `/tmp/cortex-v140-bench`
+- benchmark DB: `/tmp/cortex-v140-benchmark-2026-03-23/cortex.db`
+- raw result artifact: `/tmp/cortex-v140-benchmark-2026-03-23/results.json`
+- corpus: `/tmp/cortex-locomo-combined-2026-03-22/corpus`
+- reader model: `google/gemini-2.5-flash`
+- embed model: `openrouter/text-embedding-3-small`
+
+Important note:
+
+- The user message mentioned the live DB at `~/.cortex/cortex.db`, but the benchmark instructions also explicitly required a fresh temp DB with just LoCoMo for A/B/C/D. I used the fresh LoCoMo-only DB for scoring so the comparison stayed honest and isolated. The live DB was left untouched.
+
+## Import / Embed Method
+
+For comparability with the earlier LoCoMo baselines and the entity-graph benchmark, I used:
+
+```bash
+/tmp/cortex-v140-bench \
+  --db /tmp/cortex-v140-benchmark-2026-03-23/cortex.db \
+  import /tmp/cortex-locomo-combined-2026-03-22/corpus \
+  --extract \
+  --no-enrich \
+  --no-classify
+```
+
+Then I generated embeddings explicitly:
+
+```bash
+/tmp/cortex-v140-bench \
+  --db /tmp/cortex-v140-benchmark-2026-03-23/cortex.db \
+  embed openrouter/text-embedding-3-small \
+  --batch-size 50
+```
+
+Prepared DB state:
+
+- memories: `764`
+- facts: `4458`
+- embeddings: `764`
+- pending embeddings: `0`
+
+## Slice
+
+To stay directly comparable with the historical `7.61%` and `15.77%` numbers, this benchmark uses the same public `conv-30` answerable slice:
+
+- questions: `81`
+- included categories: `1`, `2`, `4`
+
+Category `3` and `5` rows below are reported as `0` questions / `n/a` for completeness because the comparable slice does not include them.
+
+## Results
+
+| Mode | F1 | Avg latency | Median latency | Degraded |
+| --- | ---: | ---: | ---: | ---: |
+| `A` Baseline | `11.81%` | `5898.59 ms` | `5408.15 ms` | `2` |
+| `B` Entity graph only | `10.13%` | `8172.23 ms` | `5164.10 ms` | `1` |
+| `C` Reranker daemon only | `13.26%` | `7112.25 ms` | `7196.98 ms` | `0` |
+| `D` Full stack | `11.68%` | `6926.86 ms` | `6933.31 ms` | `1` |
+
+Direct takeaways:
+
+- Best overall result on this slice: `C` reranker daemon only
+- `D` full stack did not beat `C`
+- `B` entity graph alone regressed on this broad slice
+
+## Comparison To Historical Baselines
+
+Historical references:
+
+- pre-temporal product baseline: `7.61%`
+- best previous single-feature benchmark: `15.77%`
+
+Compared to `7.61%`:
+
+- `A`: `+4.20`
+- `B`: `+2.52`
+- `C`: `+5.65`
+- `D`: `+4.07`
+
+Compared to `15.77%`:
+
+- `A`: `-3.96`
+- `B`: `-5.64`
+- `C`: `-2.51`
+- `D`: `-4.09`
+
+So `v1.4.0` clearly clears the old pre-temporal product baseline, but the best path on this run still trails the prior `15.77%` benchmark.
+
+## Category Breakdown
+
+### A. Baseline
+
+- category `1`: `14.30%` F1 on `11` questions
+- category `2`: `12.51%` F1 on `26` questions
+- category `3`: `n/a` on `0` questions
+- category `4`: `10.77%` F1 on `44` questions
+- category `5`: `n/a` on `0` questions
+
+### B. Entity Graph Only
+
+- category `1`: `14.84%` F1 on `11` questions
+- category `2`: `5.62%` F1 on `26` questions
+- category `3`: `n/a` on `0` questions
+- category `4`: `11.61%` F1 on `44` questions
+- category `5`: `n/a` on `0` questions
+
+### C. Reranker Daemon Only
+
+- category `1`: `14.17%` F1 on `11` questions
+- category `2`: `11.16%` F1 on `26` questions
+- category `3`: `n/a` on `0` questions
+- category `4`: `14.26%` F1 on `44` questions
+- category `5`: `n/a` on `0` questions
+
+### D. Full Stack
+
+- category `1`: `10.88%` F1 on `11` questions
+- category `2`: `5.93%` F1 on `26` questions
+- category `3`: `n/a` on `0` questions
+- category `4`: `15.29%` F1 on `44` questions
+- category `5`: `n/a` on `0` questions
+
+Interpretation:
+
+- The entity graph helps category `1` and category `4` a bit, but it hurts category `2` badly on this slice.
+- The reranker daemon is the cleanest improvement path: it raises category `4` a lot without collapsing category `2`.
+- The full stack inherits the entity-graph drag on category `2`, so it ends up below reranker-only.
+
+## 3-Question Diagnostic
+
+### `conv-30:27` `Did Jon and Gina both participate in dance competitions?`
+
+Gold answer: `Yes`
+
+- `A`: top-1 memory `83`, correct answer
+- `B`: top-1 memory `104`, incorrect answer path: “not enough evidence to determine if Gina participates”
+- `C`: top-1 memory `83`, correct answer
+- `D`: top-1 memory `83`, correct answer
+
+What this says:
+
+- entity graph alone is capable of surfacing the wrong high-scoring graph-linked memories
+- reranking fixes that when it is present
+
+### `conv-30:62` `How does Gina stay confident in her business?`
+
+Gold answer:
+
+- `By reminding herself of her successes and progress, having a support system, and focusing on why she started`
+
+- `A`: top-1 memory `85`, correct answer
+- `B`: top-1 memory `85`, correct answer
+- `C`: top-1 memory `85`, correct answer
+- `D`: top-1 memory `85`, correct answer
+
+What this says:
+
+- all four modes can answer the straightforward single-evidence question
+- reranking mostly changes confidence/order, not outcome
+
+### `conv-30:11` `When did Gina get her tattoo?`
+
+Gold answer: `A few years ago`
+
+- `A`: top-1 memory `71`, answer still correct from lower-ranked evidence
+- `B`: top-1 memory `71`, answer still correct
+- `C`: top-1 memory `72`, answer correct
+- `D`: top-1 memory `72`, answer correct
+
+What this says:
+
+- reranking improves evidence ordering on temporal questions even when the final answer was already recoverable
+- entity graph alone does not fix the lexical trap ordering
+
+## Interpretation
+
+The v1.4.0 stack does not behave as a single monotonic upgrade on this benchmark.
+
+What worked:
+
+- the clean baseline path `A` is materially better than the old `7.61%` product baseline
+- the reranker daemon path `C` is the best result in this benchmark
+- `C` also reduced degraded responses to `0`
+
+What did not work:
+
+- entity graph alone `B` regressed on the broad 81-question slice
+- full stack `D` did not beat reranker-only `C`
+- the main loss mechanism is category `2` temporal performance when entity graph is enabled
+
+The practical read:
+
+- If the goal is best measured LoCoMo performance on this comparable slice, use `--rerank on` with the daemon and leave `--entity-graph` off.
+- The entity graph remains useful for some specific commonality-style questions, but it is not a free win on the broad `conv-30` answerable slice.
+
+## Bottom Line
+
+Best measured v1.4.0 path on this benchmark:
+
+- `C_reranker_daemon`
+- F1: `13.26%`
+- Avg latency: `7112.25 ms`
+- Degraded: `0`
+
+That is:
+
+- clearly above the old `7.61%` product baseline
+- below the earlier `15.77%` best-single-feature benchmark
+- better than the full-stack `D` configuration on this slice
+
+So the truthful conclusion for this run is:
+
+- v1.4.0 is better than the old baseline
+- reranker daemon is the best single improvement in the current stack
+- entity graph should not be assumed to help this benchmark unless it is more selectively applied

--- a/internal/answer/engine.go
+++ b/internal/answer/engine.go
@@ -126,28 +126,8 @@ func (e *Engine) Answer(ctx context.Context, opts Options) (*Result, error) {
 		return fallbackResult(results, "no_llm_configured"), nil
 	}
 
-	ctxLines := make([]string, 0, len(results)*3)
-	remaining := opts.MaxContextChars
-	for i, r := range results {
-		clean, stripped := sanitizeRetrieved(r.Content)
-		if stripped != "" && opts.Verbose {
-			fmt.Fprintf(os.Stderr, "[answer] stripped prompt-injection-like content from %s: %q\n", r.SourceFile, truncate(stripped, 220))
-		}
-		clean = truncate(clean, opts.PerResultChars)
-		block := fmt.Sprintf("[%d] source:%s score:%.2f\n%s", i+1, sourceLabel(r), r.Score, clean)
-		if anchorDate := resultAnchorDate(r); anchorDate != "" {
-			block += fmt.Sprintf("\nanchor_date: %s", anchorDate)
-		}
-		if temporalInfo := resultTemporalInfo(r); temporalInfo != "" {
-			block += "\n" + temporalInfo
-		}
-		if len(block)+1 > remaining {
-			break
-		}
-		ctxLines = append(ctxLines, block)
-		remaining -= len(block) + 1
-	}
-	if len(ctxLines) == 0 {
+	ctxText := buildGroupedSourceContext(results, opts.MaxContextChars, opts.PerResultChars, opts.Verbose)
+	if ctxText == "" {
 		return fallbackResult(results, "empty_context_after_sanitize"), nil
 	}
 
@@ -161,8 +141,9 @@ Rules:
 - For names, titles, places, and numbers, give the exact value from the sources.
 - Do not elaborate, summarize, or add narrative filler.
 - Prefer one short sentence unless the question clearly needs more.
+- Read grouped evidence blocks as scene-level context when present.
 - Every factual claim must include citation markers like [1] or [2][4].`)
-	userPrompt := fmt.Sprintf("Question: %s\n\nSources:\n%s\n\nReturn the shortest exact answer possible with citations. For dates, give the exact date. For names, give the exact name. Do not elaborate.", opts.Query, strings.Join(ctxLines, "\n\n"))
+	userPrompt := fmt.Sprintf("Question: %s\n\nSources:\n%s\n\nReturn the shortest exact answer possible with citations. For dates, give the exact date. For names, give the exact name. Do not elaborate.", opts.Query, ctxText)
 
 	resp, err := e.llm.Complete(ctx, userPrompt, llm.CompletionOpts{
 		System:      systemPrompt,
@@ -190,6 +171,64 @@ Rules:
 		Model:     e.model,
 		Provider:  providerOfModel(e.model),
 	}, nil
+}
+
+func buildGroupedSourceContext(results []search.Result, maxContextChars int, perResultChars int, verbose bool) string {
+	type sourceGroup struct {
+		label  string
+		blocks []string
+	}
+
+	groupOrder := make([]string, 0, len(results))
+	groupMap := make(map[string]*sourceGroup, len(results))
+	for i, r := range results {
+		clean, stripped := sanitizeRetrieved(r.Content)
+		if stripped != "" && verbose {
+			fmt.Fprintf(os.Stderr, "[answer] stripped prompt-injection-like content from %s: %q\n", r.SourceFile, truncate(stripped, 220))
+		}
+		clean = truncate(clean, perResultChars)
+		block := fmt.Sprintf("[%d] source:%s score:%.2f\n%s", i+1, sourceLabel(r), r.Score, clean)
+		if anchorDate := resultAnchorDate(r); anchorDate != "" {
+			block += fmt.Sprintf("\nanchor_date: %s", anchorDate)
+		}
+		if temporalInfo := resultTemporalInfo(r); temporalInfo != "" {
+			block += "\n" + temporalInfo
+		}
+		key := search.SceneLabelForResult(r)
+		group, ok := groupMap[key]
+		if !ok {
+			group = &sourceGroup{label: key}
+			groupMap[key] = group
+			groupOrder = append(groupOrder, key)
+		}
+		group.blocks = append(group.blocks, block)
+	}
+
+	remaining := maxContextChars
+	lines := make([]string, 0, len(results)*3)
+	for i, key := range groupOrder {
+		group := groupMap[key]
+		header := fmt.Sprintf("Source group %d — %s", i+1, group.label)
+		groupLines := []string{header}
+		for _, block := range group.blocks {
+			candidate := strings.Join(append(groupLines, block), "\n\n")
+			if len(candidate)+1 > remaining {
+				break
+			}
+			groupLines = append(groupLines, block)
+		}
+		if len(groupLines) == 1 {
+			continue
+		}
+		groupText := strings.Join(groupLines, "\n\n")
+		if len(groupText)+2 > remaining {
+			break
+		}
+		lines = append(lines, groupText)
+		remaining -= len(groupText) + 2
+	}
+
+	return strings.Join(lines, "\n\n")
 }
 
 func fallbackResult(results []search.Result, reason string) *Result {

--- a/internal/answer/engine_test.go
+++ b/internal/answer/engine_test.go
@@ -189,3 +189,39 @@ func TestAnswer_UsesShortestExactPromptGuidance(t *testing.T) {
 		}
 	}
 }
+
+func TestAnswer_GroupsSourcesBySceneLabel(t *testing.T) {
+	var prompt string
+	e := NewEngine(
+		mockSearcher{results: []search.Result{
+			{
+				MemoryID:      1,
+				SourceFile:    "conv-30.md",
+				SourceSection: "Session 9",
+				Score:         0.95,
+				Content:       "Jon started a dance studio after leaving banking.",
+				Metadata:      &store.Metadata{SessionKey: "conv-30:session-9"},
+			},
+			{
+				MemoryID:      2,
+				SourceFile:    "conv-30.md",
+				SourceSection: "Session 9",
+				Score:         0.91,
+				Content:       "The official opening night is June 20, 2023.",
+				Metadata:      &store.Metadata{SessionKey: "conv-30:session-9"},
+			},
+		}},
+		mockProvider{resp: "June 20, 2023 [2].", seenPrompt: &prompt},
+		"openrouter/x-ai/grok-4.1-fast",
+	)
+	_, err := e.Answer(context.Background(), Options{Query: "When is Jon's opening night?", Search: search.Options{Limit: 5}})
+	if err != nil {
+		t.Fatalf("Answer err: %v", err)
+	}
+	if !strings.Contains(prompt, "Source group 1") {
+		t.Fatalf("expected grouped source header, got %q", prompt)
+	}
+	if !strings.Contains(prompt, "session:conv-30:session-9") {
+		t.Fatalf("expected session label in grouped prompt, got %q", prompt)
+	}
+}

--- a/internal/ask/engine.go
+++ b/internal/ask/engine.go
@@ -96,30 +96,8 @@ func (e *Engine) Ask(ctx context.Context, opts Options) (*Result, error) {
 		return fallbackResult(question, results, opts, "no_llm_configured", ""), nil
 	}
 
-	ctxLines := make([]string, 0, len(results)*4)
-	remaining := opts.MaxContextChars
-	for i, r := range results {
-		clean, stripped := sanitizeRetrieved(r.Content)
-		if stripped != "" {
-			// ignore stripped content silently; the retrieval layer already surfaced clean evidence
-		}
-		clean = truncate(clean, opts.PerResultChars)
-		block := fmt.Sprintf(
-			"[%d] source:%s section:%s score:%.2f fact_ids:%s\n%s",
-			i+1,
-			sourceLabel(r),
-			strings.TrimSpace(r.SourceSection),
-			r.Score,
-			formatFactIDs(r.FactIDs),
-			clean,
-		)
-		if len(block)+1 > remaining {
-			break
-		}
-		ctxLines = append(ctxLines, block)
-		remaining -= len(block) + 1
-	}
-	if len(ctxLines) == 0 {
+	ctxText := buildGroupedEvidenceContext(results, opts.MaxContextChars, opts.PerResultChars)
+	if ctxText == "" {
 		return &Result{
 			Question:     question,
 			Answer:       "not enough evidence",
@@ -153,7 +131,7 @@ Rules:
 	userPrompt := fmt.Sprintf(
 		"Question:\n%s\n\nAvailable evidence:\n%s\n\nWrite the shortest direct answer possible with inline citations after each sentence or clause. If the evidence is insufficient, reply exactly: not enough evidence.",
 		question,
-		strings.Join(ctxLines, "\n\n"),
+		ctxText,
 	)
 
 	resp, err := e.llm.Complete(ctx, userPrompt, llm.CompletionOpts{
@@ -213,6 +191,63 @@ Rules:
 		Budget:       opts.Budget,
 		PackedTokens: opts.PackedTokens,
 	}, nil
+}
+
+func buildGroupedEvidenceContext(results []search.Result, maxContextChars int, perResultChars int) string {
+	type evidenceGroup struct {
+		label  string
+		blocks []string
+	}
+
+	groupOrder := make([]string, 0, len(results))
+	groupMap := make(map[string]*evidenceGroup, len(results))
+	for i, r := range results {
+		clean, _ := sanitizeRetrieved(r.Content)
+		clean = truncate(clean, perResultChars)
+		key := search.SceneLabelForResult(r)
+		group, ok := groupMap[key]
+		if !ok {
+			group = &evidenceGroup{label: key}
+			groupMap[key] = group
+			groupOrder = append(groupOrder, key)
+		}
+		block := fmt.Sprintf(
+			"[%d] source:%s section:%s score:%.2f fact_ids:%s\n%s",
+			i+1,
+			sourceLabel(r),
+			strings.TrimSpace(r.SourceSection),
+			r.Score,
+			formatFactIDs(r.FactIDs),
+			clean,
+		)
+		group.blocks = append(group.blocks, block)
+	}
+
+	remaining := maxContextChars
+	lines := make([]string, 0, len(results)*3)
+	for i, key := range groupOrder {
+		group := groupMap[key]
+		header := fmt.Sprintf("Evidence group %d — %s", i+1, group.label)
+		groupLines := []string{header}
+		for _, block := range group.blocks {
+			candidate := strings.Join(append(groupLines, block), "\n\n")
+			if len(candidate)+1 > remaining {
+				break
+			}
+			groupLines = append(groupLines, block)
+		}
+		if len(groupLines) == 1 {
+			continue
+		}
+		groupText := strings.Join(groupLines, "\n\n")
+		if len(groupText)+2 > remaining {
+			break
+		}
+		lines = append(lines, groupText)
+		remaining -= len(groupText) + 2
+	}
+
+	return strings.Join(lines, "\n\n")
 }
 
 func fallbackResult(question string, results []search.Result, opts Options, reason, errorDetail string) *Result {

--- a/internal/ask/engine_test.go
+++ b/internal/ask/engine_test.go
@@ -3,18 +3,24 @@ package ask
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/hurttlocker/cortex/internal/llm"
 	"github.com/hurttlocker/cortex/internal/search"
+	"github.com/hurttlocker/cortex/internal/store"
 )
 
 type mockProvider struct {
-	resp string
-	err  error
+	resp       string
+	err        error
+	seenPrompt *string
 }
 
 func (m mockProvider) Complete(ctx context.Context, prompt string, opts llm.CompletionOpts) (string, error) {
+	if m.seenPrompt != nil {
+		*m.seenPrompt = prompt
+	}
 	if m.err != nil {
 		return "", m.err
 	}
@@ -185,6 +191,44 @@ func TestAsk_HandlesProviderError(t *testing.T) {
 	}
 	if res.Error == "" {
 		t.Fatal("expected underlying error detail to be populated")
+	}
+}
+
+func TestAsk_GroupsEvidenceBlocksByScene(t *testing.T) {
+	var prompt string
+	e := NewEngine(mockProvider{
+		resp:       "June 20, 2023 [1].",
+		seenPrompt: &prompt,
+	}, "google/gemini-2.5-flash-lite")
+	_, err := e.Ask(context.Background(), Options{
+		Question: "When is Jon's opening night?",
+		Results: []search.Result{
+			{
+				MemoryID:      1,
+				SourceFile:    "conv-30.md",
+				SourceSection: "Session 9",
+				Score:         0.95,
+				Content:       "Jon started a dance studio after leaving banking.",
+				Metadata:      &store.Metadata{SessionKey: "conv-30:session-9"},
+			},
+			{
+				MemoryID:      2,
+				SourceFile:    "conv-30.md",
+				SourceSection: "Session 9",
+				Score:         0.91,
+				Content:       "The official opening night is June 20, 2023.",
+				Metadata:      &store.Metadata{SessionKey: "conv-30:session-9"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Ask err: %v", err)
+	}
+	if !strings.Contains(prompt, "Evidence group 1") {
+		t.Fatalf("expected grouped evidence header, got %q", prompt)
+	}
+	if !strings.Contains(prompt, "session:conv-30:session-9") {
+		t.Fatalf("expected session label in grouped prompt, got %q", prompt)
 	}
 }
 

--- a/internal/benchscore/score.go
+++ b/internal/benchscore/score.go
@@ -1,0 +1,102 @@
+package benchscore
+
+import (
+	"regexp"
+	"strings"
+)
+
+var answerTokenRE = regexp.MustCompile(`[a-z0-9]+`)
+
+// NormalizeAnswer mirrors the lightweight normalization used in the local
+// LoCoMo comparison harness: lowercase, remove punctuation, drop articles,
+// and collapse whitespace.
+func NormalizeAnswer(text string) string {
+	text = strings.ReplaceAll(text, ",", "")
+	text = strings.ToLower(text)
+	text = stripPunctuation(text)
+	text = removeArticles(text)
+	return strings.Join(strings.Fields(text), " ")
+}
+
+// NormalizedExactMatch returns true when the normalized prediction matches any
+// normalized gold alias exactly.
+func NormalizedExactMatch(prediction string, goldAliases ...string) bool {
+	prediction = NormalizeAnswer(prediction)
+	if prediction == "" {
+		return false
+	}
+	for _, gold := range goldAliases {
+		if prediction == NormalizeAnswer(gold) {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsNormalizedPhrase returns true when the normalized gold phrase appears
+// as a contiguous token span inside the normalized haystack.
+func ContainsNormalizedPhrase(haystack string, phrase string) bool {
+	haystackTokens := answerTokenRE.FindAllString(strings.ToLower(NormalizeAnswer(haystack)), -1)
+	phraseTokens := answerTokenRE.FindAllString(strings.ToLower(NormalizeAnswer(phrase)), -1)
+	if len(haystackTokens) == 0 || len(phraseTokens) == 0 || len(phraseTokens) > len(haystackTokens) {
+		return false
+	}
+	width := len(phraseTokens)
+	for idx := 0; idx <= len(haystackTokens)-width; idx++ {
+		match := true
+		for offset := 0; offset < width; offset++ {
+			if haystackTokens[idx+offset] != phraseTokens[offset] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizedAccuracy returns 1 when the normalized prediction matches any gold
+// alias exactly, otherwise 0.
+func NormalizedAccuracy(prediction string, goldAliases ...string) float64 {
+	if NormalizedExactMatch(prediction, goldAliases...) {
+		return 1.0
+	}
+	return 0.0
+}
+
+func stripPunctuation(text string) string {
+	var b strings.Builder
+	b.Grow(len(text))
+	for _, r := range text {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == ' ' || r == '\n' || r == '\t':
+			b.WriteRune(' ')
+		default:
+			// drop punctuation/symbols
+		}
+	}
+	return b.String()
+}
+
+func removeArticles(text string) string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return ""
+	}
+	filtered := make([]string, 0, len(words))
+	for _, word := range words {
+		switch word {
+		case "a", "an", "the", "and":
+			continue
+		default:
+			filtered = append(filtered, word)
+		}
+	}
+	return strings.Join(filtered, " ")
+}

--- a/internal/benchscore/score_test.go
+++ b/internal/benchscore/score_test.go
@@ -1,0 +1,38 @@
+package benchscore
+
+import "testing"
+
+func TestNormalizeAnswer(t *testing.T) {
+	got := NormalizeAnswer("The June 20, 2023 answer.")
+	if got != "june 20 2023 answer" {
+		t.Fatalf("NormalizeAnswer = %q", got)
+	}
+}
+
+func TestNormalizedExactMatch(t *testing.T) {
+	if !NormalizedExactMatch("June 20, 2023", "the June 20 2023", "June 21, 2023") {
+		t.Fatal("expected normalized exact match")
+	}
+	if NormalizedExactMatch("June 22, 2023", "the June 20 2023") {
+		t.Fatal("did not expect normalized exact match")
+	}
+}
+
+func TestContainsNormalizedPhrase(t *testing.T) {
+	haystack := "Jon said the official opening night is June 20, 2023 in Session 9."
+	if !ContainsNormalizedPhrase(haystack, "June 20 2023") {
+		t.Fatal("expected normalized phrase containment")
+	}
+	if ContainsNormalizedPhrase(haystack, "June 21 2023") {
+		t.Fatal("did not expect wrong phrase containment")
+	}
+}
+
+func TestNormalizedAccuracy(t *testing.T) {
+	if score := NormalizedAccuracy("Gina", "gina", "jon"); score != 1.0 {
+		t.Fatalf("NormalizedAccuracy = %.1f, want 1.0", score)
+	}
+	if score := NormalizedAccuracy("Jon", "gina"); score != 0.0 {
+		t.Fatalf("NormalizedAccuracy = %.1f, want 0.0", score)
+	}
+}

--- a/internal/search/entity_channel.go
+++ b/internal/search/entity_channel.go
@@ -125,11 +125,14 @@ func (e *Engine) searchEntityProfiles(ctx context.Context, query string, opts Op
 	return results, nil
 }
 
-func (e *Engine) shouldUseEntityGraph(ctx context.Context, opts Options) bool {
+func (e *Engine) shouldUseEntityGraph(ctx context.Context, query string, opts Options, strategy queryStrategyDecision) bool {
 	if opts.EntityGraph {
 		return true
 	}
 	if opts.Mode != ModeRRF {
+		return false
+	}
+	if len(strategy.Entities) == 0 && strategy.Primary != StrategyEntity && strategy.Primary != StrategyComparison && strategy.Primary != StrategyBridge {
 		return false
 	}
 	if e == nil || e.store == nil {

--- a/internal/search/rrf.go
+++ b/internal/search/rrf.go
@@ -14,6 +14,7 @@ type RRFConfig struct {
 	BM25Weight     float64
 	SemanticWeight float64
 	EntityWeight   float64
+	TemporalWeight float64
 }
 
 // DefaultRRFConfig returns the default RRF configuration.
@@ -23,6 +24,7 @@ func DefaultRRFConfig() RRFConfig {
 		BM25Weight:     1.0,
 		SemanticWeight: 1.0,
 		EntityWeight:   1.0,
+		TemporalWeight: 1.0,
 	}
 }
 
@@ -94,6 +96,7 @@ func fuseRRFChannelsWithOptions(channels []rrfChannel, limit int, explain bool, 
 		bm25Contribution := 0.0
 		semanticContribution := 0.0
 		entityContribution := 0.0
+		temporalContribution := 0.0
 		for _, channel := range channels {
 			reciprocal := 1.0 / float64(cfg.K+entry.ranks[channel.name])
 			contribution := channel.weight * reciprocal
@@ -107,6 +110,8 @@ func fuseRRFChannelsWithOptions(channels []rrfChannel, limit int, explain bool, 
 				semanticContribution = contribution
 			case "entity":
 				entityContribution = contribution
+			case "temporal":
+				temporalContribution = contribution
 			}
 		}
 		prior, priorReason := hybridMetadataPrior(entry.result)
@@ -132,6 +137,9 @@ func fuseRRFChannelsWithOptions(channels []rrfChannel, limit int, explain bool, 
 			}
 			if entityContribution > 0 {
 				entry.result.Explain.RankComponents.EntityChannelScore = floatPtr(entityContribution)
+			}
+			if temporalContribution > 0 {
+				entry.result.Explain.RankComponents.TemporalChannelScore = floatPtr(temporalContribution)
 			}
 			if priorReason != "" {
 				if entry.result.Explain.Why == "" {
@@ -172,6 +180,9 @@ func normalizeRRFConfig(cfg RRFConfig) RRFConfig {
 	}
 	if cfg.EntityWeight == 0 {
 		cfg.EntityWeight = 1.0
+	}
+	if cfg.TemporalWeight == 0 {
+		cfg.TemporalWeight = 1.0
 	}
 	return cfg
 }

--- a/internal/search/scene.go
+++ b/internal/search/scene.go
@@ -1,0 +1,233 @@
+package search
+
+import (
+	"context"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/hurttlocker/cortex/internal/store"
+	"github.com/hurttlocker/cortex/internal/temporal"
+)
+
+const (
+	sceneSeedLimit              = 4
+	sceneSourceFetchLimit       = 200
+	sceneLineWindow             = 120
+	sceneMinAffinity            = 0.45
+	sceneMaxNeighborsPerSeed    = 2
+	sceneTemporalSignalBoost    = 0.10
+	sceneSessionAffinityBoost   = 0.15
+	sceneSectionAffinityBoost   = 0.10
+	sceneMinimumNeighborOverlap = 0.01
+)
+
+// SceneLabelForResult returns a stable grouping label for prompt rendering and
+// scene-aware retrieval expansion.
+func SceneLabelForResult(r Result) string {
+	if r.Metadata != nil && strings.TrimSpace(r.Metadata.SessionKey) != "" {
+		return "session:" + strings.TrimSpace(r.Metadata.SessionKey)
+	}
+	if strings.TrimSpace(r.SourceSection) != "" {
+		return "source:" + strings.TrimSpace(r.SourceFile) + "#" + strings.TrimSpace(r.SourceSection)
+	}
+	if strings.TrimSpace(r.SourceFile) != "" {
+		return "source:" + strings.TrimSpace(r.SourceFile)
+	}
+	return "memory"
+}
+
+func (e *Engine) searchSceneExpansion(ctx context.Context, query string, fused []Result, opts Options, strategy queryStrategyDecision) ([]Result, error) {
+	if len(fused) == 0 || !strategy.EnableSceneExpand {
+		return nil, nil
+	}
+
+	queryTokens := queryTokenSet(query)
+	entitySet := make(map[string]struct{}, len(strategy.Entities))
+	for _, entity := range strategy.Entities {
+		entitySet[strings.ToLower(strings.TrimSpace(entity))] = struct{}{}
+	}
+
+	limit := sceneSeedLimit
+	if len(fused) < limit {
+		limit = len(fused)
+	}
+
+	injected := make(map[int64]Result)
+	for _, seed := range fused[:limit] {
+		if strings.TrimSpace(seed.SourceFile) == "" {
+			continue
+		}
+		memories, err := e.store.ListMemories(ctx, store.ListOpts{
+			Limit:      sceneSourceFetchLimit,
+			SourceFile: seed.SourceFile,
+			Agent:      opts.Agent,
+		})
+		if err != nil || len(memories) == 0 {
+			continue
+		}
+
+		candidates := make([]Result, 0, len(memories))
+		for _, memory := range memories {
+			if memory == nil || memory.ID == seed.MemoryID {
+				continue
+			}
+			candidate := Result{
+				Content:       memory.Content,
+				SourceFile:    memory.SourceFile,
+				SourceTier:    SourceTierForFile(memory.SourceFile),
+				SourceLine:    memory.SourceLine,
+				SourceSection: memory.SourceSection,
+				Project:       memory.Project,
+				MemoryClass:   memory.MemoryClass,
+				Metadata:      memory.Metadata,
+				ImportedAt:    memory.ImportedAt,
+				MemoryID:      memory.ID,
+				MatchType:     "scene",
+			}
+			affinity, ok := sceneAffinity(seed, candidate, queryTokens, entitySet, strategy.TemporalQuery)
+			if !ok {
+				continue
+			}
+			candidate.Score = seed.Score * affinity
+			candidate.Snippet = truncateSceneSnippet(candidate.Content)
+			candidates = append(candidates, candidate)
+		}
+
+		sort.Slice(candidates, func(i, j int) bool {
+			if candidates[i].Score == candidates[j].Score {
+				return candidates[i].MemoryID < candidates[j].MemoryID
+			}
+			return candidates[i].Score > candidates[j].Score
+		})
+		if len(candidates) > sceneMaxNeighborsPerSeed {
+			candidates = candidates[:sceneMaxNeighborsPerSeed]
+		}
+		for _, candidate := range candidates {
+			current, ok := injected[candidate.MemoryID]
+			if !ok || candidate.Score > current.Score {
+				injected[candidate.MemoryID] = candidate
+			}
+		}
+	}
+
+	if len(injected) == 0 {
+		return nil, nil
+	}
+	results := make([]Result, 0, len(injected))
+	for _, result := range injected {
+		results = append(results, result)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score == results[j].Score {
+			return results[i].MemoryID < results[j].MemoryID
+		}
+		return results[i].Score > results[j].Score
+	})
+	return results, nil
+}
+
+func sceneAffinity(seed Result, candidate Result, queryTokens map[string]struct{}, entitySet map[string]struct{}, tq *temporal.Query) (float64, bool) {
+	if strings.TrimSpace(seed.SourceFile) == "" || !strings.EqualFold(strings.TrimSpace(seed.SourceFile), strings.TrimSpace(candidate.SourceFile)) {
+		return 0, false
+	}
+
+	proximity := lineProximity(seed.SourceLine, candidate.SourceLine)
+	sameSession := sameSession(seed, candidate)
+	sameSection := sameSection(seed, candidate)
+	lexical := overlapCoverage(queryTokens, queryTokenSet(candidate.Content+" "+candidate.SourceSection))
+	entityCoverage := sceneEntityCoverage(candidate, entitySet)
+	temporalSupport := sceneTemporalSupport(candidate, tq)
+
+	if lexical < sceneMinimumNeighborOverlap && entityCoverage == 0 && temporalSupport == 0 && !sameSession && !sameSection {
+		return 0, false
+	}
+
+	affinity := 0.20 + 0.25*proximity + 0.25*lexical + 0.20*entityCoverage
+	if temporalSupport > 0 {
+		affinity += sceneTemporalSignalBoost * temporalSupport
+	}
+	if sameSession {
+		affinity += sceneSessionAffinityBoost
+	}
+	if sameSection {
+		affinity += sceneSectionAffinityBoost
+	}
+	if affinity < sceneMinAffinity {
+		return 0, false
+	}
+	if affinity > 0.95 {
+		affinity = 0.95
+	}
+	return affinity, true
+}
+
+func lineProximity(seedLine, candidateLine int) float64 {
+	if seedLine <= 0 || candidateLine <= 0 {
+		return 0
+	}
+	delta := math.Abs(float64(seedLine - candidateLine))
+	if delta > sceneLineWindow {
+		return 0
+	}
+	return 1.0 - (delta / sceneLineWindow)
+}
+
+func sameSession(left, right Result) bool {
+	if left.Metadata == nil || right.Metadata == nil {
+		return false
+	}
+	return strings.TrimSpace(left.Metadata.SessionKey) != "" &&
+		strings.EqualFold(strings.TrimSpace(left.Metadata.SessionKey), strings.TrimSpace(right.Metadata.SessionKey))
+}
+
+func sameSection(left, right Result) bool {
+	return strings.TrimSpace(left.SourceSection) != "" &&
+		strings.EqualFold(strings.TrimSpace(left.SourceSection), strings.TrimSpace(right.SourceSection))
+}
+
+func sceneEntityCoverage(candidate Result, entitySet map[string]struct{}) float64 {
+	if len(entitySet) == 0 {
+		return 0
+	}
+	text := strings.ToLower(strings.TrimSpace(candidate.Content + " " + candidate.SourceSection))
+	if text == "" {
+		return 0
+	}
+	hits := 0
+	for entity := range entitySet {
+		if entity != "" && strings.Contains(text, entity) {
+			hits++
+		}
+	}
+	if hits == 0 {
+		return 0
+	}
+	return float64(hits) / float64(len(entitySet))
+}
+
+func sceneTemporalSupport(candidate Result, tq *temporal.Query) float64 {
+	if tq == nil || !tq.TemporalIntent {
+		return 0
+	}
+	if candidate.Metadata != nil && len(candidate.Metadata.TimestampStart) >= 10 {
+		if norm := temporal.NormalizeLiteral(candidate.Metadata.TimestampStart[:10], ""); norm != nil && temporal.MatchesQuery(tq, norm) {
+			return 1.0
+		}
+	}
+	if rerankTemporalCueRE.MatchString(candidate.Content + " " + candidate.SourceSection) {
+		return 0.5
+	}
+	return 0
+}
+
+func truncateSceneSnippet(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+	if len(content) <= 160 {
+		return content
+	}
+	return content[:157] + "..."
+}

--- a/internal/search/scene_test.go
+++ b/internal/search/scene_test.go
@@ -1,0 +1,71 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hurttlocker/cortex/internal/store"
+)
+
+func TestSearchRRFSceneExpansionAddsNearbySessionNeighbor(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	seedID, err := s.AddMemory(ctx, &store.Memory{
+		Content:       "Jon talked about opening a dance studio after losing his banking job.",
+		SourceFile:    "conv-30.md",
+		SourceLine:    10,
+		SourceSection: "Session 9",
+		Metadata:      &store.Metadata{SessionKey: "conv-30:session-9"},
+	})
+	if err != nil {
+		t.Fatalf("add seed memory: %v", err)
+	}
+	neighborID, err := s.AddMemory(ctx, &store.Memory{
+		Content:       "He said the official opening night is June 20, 2023.",
+		SourceFile:    "conv-30.md",
+		SourceLine:    18,
+		SourceSection: "Session 9",
+		Metadata:      &store.Metadata{SessionKey: "conv-30:session-9"},
+	})
+	if err != nil {
+		t.Fatalf("add neighbor memory: %v", err)
+	}
+
+	engine := NewEngineWithEmbedder(s, newMockEmbedder())
+	results, err := engine.Search(ctx, "How did Jon's studio come together after banking?", Options{
+		Mode:  ModeRRF,
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(results))
+	}
+
+	foundSeed := false
+	foundNeighbor := false
+	for _, result := range results {
+		if result.MemoryID == seedID {
+			foundSeed = true
+		}
+		if result.MemoryID == neighborID {
+			foundNeighbor = true
+		}
+	}
+	if !foundSeed || !foundNeighbor {
+		t.Fatalf("expected scene expansion to keep seed and add neighbor, foundSeed=%v foundNeighbor=%v", foundSeed, foundNeighbor)
+	}
+}
+
+func TestSceneLabelForResultPrefersSessionKey(t *testing.T) {
+	result := Result{
+		SourceFile:    "conv-30.md",
+		SourceSection: "Session 9",
+		Metadata:      &store.Metadata{SessionKey: "conv-30:session-9"},
+	}
+	if got := SceneLabelForResult(result); got != "session:conv-30:session-9" {
+		t.Fatalf("scene label = %q", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -329,11 +329,12 @@ type FactResult struct {
 
 // ExplainDetails surfaces provenance and ranking factors for operator trust/debugging.
 type ExplainDetails struct {
-	Provenance     ExplainProvenance  `json:"provenance"`
-	Confidence     ExplainConfidence  `json:"confidence"`
-	RankComponents RankComponents     `json:"rank_components"`
-	QueryShape     *ExplainQueryShape `json:"query_shape,omitempty"`
-	Why            string             `json:"why,omitempty"`
+	Provenance     ExplainProvenance     `json:"provenance"`
+	Confidence     ExplainConfidence     `json:"confidence"`
+	RankComponents RankComponents        `json:"rank_components"`
+	QueryShape     *ExplainQueryShape    `json:"query_shape,omitempty"`
+	QueryStrategy  *ExplainQueryStrategy `json:"query_strategy,omitempty"`
+	Why            string                `json:"why,omitempty"`
 }
 
 // ExplainQueryShape captures raw-vs-shaped retrieval query context when query shaping is applied.
@@ -343,6 +344,17 @@ type ExplainQueryShape struct {
 	Applied       bool   `json:"applied"`
 	RemovedTokens int    `json:"removed_tokens,omitempty"`
 	Reason        string `json:"reason,omitempty"`
+}
+
+// ExplainQueryStrategy captures the retrieval routing decision for the query.
+type ExplainQueryStrategy struct {
+	Primary        QueryStrategy `json:"primary"`
+	Entities       []string      `json:"entities,omitempty"`
+	TemporalIntent bool          `json:"temporal_intent,omitempty"`
+	TemporalKind   string        `json:"temporal_kind,omitempty"`
+	SceneExpand    bool          `json:"scene_expand,omitempty"`
+	BridgeDiscover bool          `json:"bridge_discover,omitempty"`
+	Reason         string        `json:"reason,omitempty"`
 }
 
 type ExplainProvenance struct {
@@ -370,6 +382,7 @@ type RankComponents struct {
 	HybridBM25Contribution     *float64 `json:"hybrid_bm25_contribution,omitempty"`
 	HybridSemanticContribution *float64 `json:"hybrid_semantic_contribution,omitempty"`
 	EntityChannelScore         *float64 `json:"entity_channel_score,omitempty"`
+	TemporalChannelScore       *float64 `json:"temporal_channel_score,omitempty"`
 	RerankBaseScore            *float64 `json:"rerank_base_score,omitempty"`
 	RerankScore                *float64 `json:"rerank_score,omitempty"`
 
@@ -547,6 +560,7 @@ func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Resu
 	if queryShape.Applied {
 		retrievalQuery = queryShape.Shaped
 	}
+	strategy := e.classifyQueryStrategy(ctx, retrievalQuery)
 
 	requestedLimit := opts.Limit
 	if requestedLimit <= 0 {
@@ -590,7 +604,10 @@ func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Resu
 	if intentErr != nil {
 		return nil, intentErr
 	}
-	opts.EntityGraph = e.shouldUseEntityGraph(ctx, opts)
+	if opts.TemporalQuery == nil {
+		opts.TemporalQuery = strategy.TemporalQuery
+	}
+	opts.EntityGraph = e.shouldUseEntityGraph(ctx, retrievalQuery, opts, strategy)
 
 	var results []Result
 	var err error
@@ -603,7 +620,7 @@ func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Resu
 	case ModeHybrid:
 		results, err = e.searchHybrid(ctx, retrievalQuery, opts)
 	case ModeRRF:
-		results, err = e.searchRRF(ctx, retrievalQuery, opts)
+		results, err = e.searchRRF(ctx, retrievalQuery, opts, strategy)
 	default:
 		return nil, fmt.Errorf("unknown search mode: %q", opts.Mode)
 	}
@@ -679,6 +696,7 @@ func (e *Engine) Search(ctx context.Context, query string, opts Options) ([]Resu
 
 	if opts.Explain {
 		attachQueryShapeExplain(results, queryShape)
+		attachQueryStrategyExplain(results, strategy)
 	}
 
 	if !opts.DisableDedupe {
@@ -1286,6 +1304,33 @@ func attachQueryShapeExplain(results []Result, shape queryShapeDecision) {
 			results[i].Explain.Why = "query shaping applied before retrieval"
 		} else {
 			results[i].Explain.Why += "; query shaping applied before retrieval"
+		}
+	}
+}
+
+func attachQueryStrategyExplain(results []Result, strategy queryStrategyDecision) {
+	for i := range results {
+		ensureExplain(&results[i])
+		explain := &ExplainQueryStrategy{
+			Primary:        strategy.Primary,
+			Entities:       append([]string(nil), strategy.Entities...),
+			SceneExpand:    strategy.EnableSceneExpand,
+			BridgeDiscover: strategy.EnableBridgeDiscover,
+			Reason:         strategy.Reason,
+		}
+		if strategy.TemporalQuery != nil {
+			explain.TemporalIntent = strategy.TemporalQuery.TemporalIntent
+			explain.TemporalKind = strategy.TemporalQuery.Kind
+		}
+		results[i].Explain.QueryStrategy = explain
+		if strategy.Primary == StrategyDefault {
+			continue
+		}
+		msg := fmt.Sprintf("query strategy: %s", strategy.Primary)
+		if results[i].Explain.Why == "" {
+			results[i].Explain.Why = msg
+		} else {
+			results[i].Explain.Why += "; " + msg
 		}
 	}
 }
@@ -3016,8 +3061,8 @@ func (e *Engine) searchHybrid(ctx context.Context, query string, opts Options) (
 
 // searchRRF performs both BM25 and semantic search, merging results with
 // Reciprocal Rank Fusion (RRF).
-func (e *Engine) searchRRF(ctx context.Context, query string, opts Options) ([]Result, error) {
-	if e.embedder == nil && !opts.EntityGraph {
+func (e *Engine) searchRRF(ctx context.Context, query string, opts Options, strategy queryStrategyDecision) ([]Result, error) {
+	if e.embedder == nil && !opts.EntityGraph && (strategy.TemporalQuery == nil || !strategy.TemporalQuery.TemporalIntent) {
 		// Graceful degradation: preserve legacy BM25 fallback when the entity channel is off.
 		fmt.Fprintf(os.Stderr, "Note: RRF mode requires an embedder; falling back to BM25 keyword search.\n")
 		fmt.Fprintf(os.Stderr, "  Use --embed <provider/model> for RRF results.\n")
@@ -3038,6 +3083,7 @@ func (e *Engine) searchRRF(ctx context.Context, query string, opts Options) ([]R
 	bm25Chan := make(chan searchResult, 1)
 	semanticChan := make(chan searchResult, 1)
 	entityChan := make(chan searchResult, 1)
+	temporalChan := make(chan searchResult, 1)
 
 	go func() {
 		results, err := e.searchBM25(ctx, query, candidateOpts)
@@ -3064,23 +3110,37 @@ func (e *Engine) searchRRF(ctx context.Context, query string, opts Options) ([]R
 		entityChan <- searchResult{}
 	}
 
+	if strategy.TemporalQuery != nil && strategy.TemporalQuery.TemporalIntent {
+		go func() {
+			results, err := e.searchTemporalChannel(ctx, query, candidateOpts, strategy)
+			temporalChan <- searchResult{results, err}
+		}()
+	} else {
+		temporalChan <- searchResult{}
+	}
+
 	bm25Result := <-bm25Chan
 	semanticResult := <-semanticChan
 	entityResult := <-entityChan
+	temporalResult := <-temporalChan
 
-	if bm25Result.err != nil && semanticResult.err != nil && entityResult.err != nil {
-		return nil, fmt.Errorf("all RRF channels failed: BM25: %w, Semantic: %v, Entity: %v", bm25Result.err, semanticResult.err, entityResult.err)
+	if bm25Result.err != nil && semanticResult.err != nil && entityResult.err != nil && temporalResult.err != nil {
+		return nil, fmt.Errorf("all RRF channels failed: BM25: %w, Semantic: %v, Entity: %v, Temporal: %v", bm25Result.err, semanticResult.err, entityResult.err, temporalResult.err)
 	}
 
-	channels := make([]rrfChannel, 0, 3)
+	cfg := rrfConfigForStrategy(strategy)
+	channels := make([]rrfChannel, 0, 4)
 	if bm25Result.err == nil && len(bm25Result.results) > 0 {
-		channels = append(channels, rrfChannel{name: "bm25", results: bm25Result.results, weight: DefaultRRFConfig().BM25Weight})
+		channels = append(channels, rrfChannel{name: "bm25", results: bm25Result.results, weight: cfg.BM25Weight})
 	}
 	if semanticResult.err == nil && len(semanticResult.results) > 0 {
-		channels = append(channels, rrfChannel{name: "semantic", results: semanticResult.results, weight: DefaultRRFConfig().SemanticWeight})
+		channels = append(channels, rrfChannel{name: "semantic", results: semanticResult.results, weight: cfg.SemanticWeight})
 	}
 	if entityResult.err == nil && len(entityResult.results) > 0 {
-		channels = append(channels, rrfChannel{name: "entity", results: entityResult.results, weight: DefaultRRFConfig().EntityWeight})
+		channels = append(channels, rrfChannel{name: "entity", results: entityResult.results, weight: cfg.EntityWeight})
+	}
+	if temporalResult.err == nil && len(temporalResult.results) > 0 {
+		channels = append(channels, rrfChannel{name: "temporal", results: temporalResult.results, weight: cfg.TemporalWeight})
 	}
 	if len(channels) == 0 {
 		if bm25Result.err != nil {
@@ -3093,7 +3153,7 @@ func (e *Engine) searchRRF(ctx context.Context, query string, opts Options) ([]R
 		channels,
 		rerankFusionLimit(opts.Limit, e.shouldApplyRerank(opts.RerankMode)),
 		opts.Explain,
-		DefaultRRFConfig(),
+		cfg,
 	)
 	if opts.EntityGraph {
 		bridgeResults, err := e.discoverBridgeResults(ctx, query, fused, candidateOpts)

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -3155,6 +3155,15 @@ func (e *Engine) searchRRF(ctx context.Context, query string, opts Options, stra
 		opts.Explain,
 		cfg,
 	)
+	if strategy.EnableSceneExpand {
+		sceneResults, err := e.searchSceneExpansion(ctx, query, fused, candidateOpts, strategy)
+		if err == nil && len(sceneResults) > 0 {
+			fused = mergeInjectedResults(fused, sceneResults)
+			if limit := rerankFusionLimit(opts.Limit, e.shouldApplyRerank(opts.RerankMode)); limit > 0 && len(fused) > limit {
+				fused = fused[:limit]
+			}
+		}
+	}
 	if opts.EntityGraph {
 		bridgeResults, err := e.discoverBridgeResults(ctx, query, fused, candidateOpts)
 		if err == nil && len(bridgeResults) > 0 {

--- a/internal/search/strategy.go
+++ b/internal/search/strategy.go
@@ -1,0 +1,218 @@
+package search
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hurttlocker/cortex/internal/temporal"
+)
+
+// QueryStrategy classifies the primary retrieval shape for a query.
+type QueryStrategy string
+
+const (
+	StrategyDefault    QueryStrategy = "default"
+	StrategyTemporal   QueryStrategy = "temporal"
+	StrategyEntity     QueryStrategy = "entity"
+	StrategyComparison QueryStrategy = "comparison"
+	StrategyBridge     QueryStrategy = "bridge"
+)
+
+type queryStrategyDecision struct {
+	Raw                  string
+	Primary              QueryStrategy
+	Entities             []string
+	TemporalQuery        *temporal.Query
+	EnableSceneExpand    bool
+	EnableBridgeDiscover bool
+	Reason               string
+}
+
+var comparisonCueTokens = map[string]struct{}{
+	"both": {}, "common": {}, "same": {}, "different": {}, "compare": {}, "shared": {},
+}
+
+var entityCueTokens = map[string]struct{}{
+	"who": {}, "whose": {}, "where": {}, "about": {},
+}
+
+var bridgeCueTokens = map[string]struct{}{
+	"why": {}, "how": {}, "after": {}, "before": {}, "because": {}, "happen": {}, "happened": {},
+}
+
+func (e *Engine) classifyQueryStrategy(ctx context.Context, query string) queryStrategyDecision {
+	query = strings.TrimSpace(query)
+	decision := queryStrategyDecision{
+		Raw:     query,
+		Primary: StrategyDefault,
+	}
+	if query == "" {
+		return decision
+	}
+
+	decision.TemporalQuery = temporal.ParseQuery(query)
+
+	resolvedEntities, err := e.resolveQueryEntities(ctx, query)
+	if err == nil && len(resolvedEntities) > 0 {
+		decision.Entities = make([]string, 0, len(resolvedEntities))
+		for _, entity := range resolvedEntities {
+			if entity == nil {
+				continue
+			}
+			decision.Entities = append(decision.Entities, entity.CanonicalName)
+		}
+	}
+
+	if len(decision.Entities) == 0 {
+		decision.Entities = likelyQueryEntities(query)
+	}
+
+	decision = classifyQueryStrategyHeuristic(query, decision.Entities, decision.TemporalQuery)
+	return decision
+}
+
+func classifyQueryStrategyHeuristic(query string, entities []string, tq *temporal.Query) queryStrategyDecision {
+	decision := queryStrategyDecision{
+		Raw:           strings.TrimSpace(query),
+		Primary:       StrategyDefault,
+		Entities:      dedupeStrings(entities),
+		TemporalQuery: tq,
+	}
+	tokenSet := queryTokenSet(query)
+	entityCount := len(decision.Entities)
+	hasTemporal := tq != nil && tq.TemporalIntent
+	hasComparison := hasAnyToken(tokenSet, comparisonCueTokens)
+	hasBridge := hasAnyToken(tokenSet, bridgeCueTokens)
+	hasEntityCue := hasAnyToken(tokenSet, entityCueTokens) || strings.HasPrefix(strings.ToLower(strings.TrimSpace(query)), "what does ")
+
+	switch {
+	case hasComparison || (entityCount >= 2 && strings.Contains(strings.ToLower(query), " in common")):
+		decision.Primary = StrategyComparison
+		decision.EnableSceneExpand = true
+		decision.EnableBridgeDiscover = true
+		decision.Reason = "comparison/commonality cues"
+	case hasBridge || (entityCount >= 2 && !hasTemporal):
+		decision.Primary = StrategyBridge
+		decision.EnableSceneExpand = true
+		decision.EnableBridgeDiscover = true
+		decision.Reason = "bridge/composition cues"
+	case hasTemporal:
+		decision.Primary = StrategyTemporal
+		decision.EnableSceneExpand = true
+		decision.Reason = "temporal cues"
+	case entityCount > 0 && hasEntityCue:
+		decision.Primary = StrategyEntity
+		decision.Reason = "entity-directed question"
+	default:
+		decision.Primary = StrategyDefault
+		decision.Reason = "default lexical/semantic retrieval"
+	}
+
+	if hasTemporal && decision.Primary != StrategyTemporal {
+		decision.EnableSceneExpand = true
+		if decision.Reason == "" {
+			decision.Reason = "temporal cues"
+		} else {
+			decision.Reason += " + temporal cues"
+		}
+	}
+
+	return decision
+}
+
+func likelyQueryEntities(query string) []string {
+	raw := extractQueryEntityCandidates(query)
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, candidate := range raw {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if strings.Contains(candidate, " ") {
+			parts := strings.Fields(candidate)
+			if len(parts) > 2 {
+				continue
+			}
+		}
+		if !looksLikeEntity(candidate) {
+			continue
+		}
+		out = append(out, candidate)
+	}
+	return dedupeStrings(out)
+}
+
+func looksLikeEntity(candidate string) bool {
+	fields := strings.Fields(strings.TrimSpace(candidate))
+	if len(fields) == 0 {
+		return false
+	}
+	for _, field := range fields {
+		if field == "" {
+			return false
+		}
+		r := []rune(field)[0]
+		if r < 'A' || r > 'Z' {
+			return false
+		}
+	}
+	return true
+}
+
+func dedupeStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func rrfConfigForStrategy(decision queryStrategyDecision) RRFConfig {
+	cfg := DefaultRRFConfig()
+	cfg.EntityWeight = 0.6
+	cfg.TemporalWeight = 0.4
+
+	switch decision.Primary {
+	case StrategyTemporal:
+		cfg.BM25Weight = 0.7
+		cfg.SemanticWeight = 0.8
+		cfg.EntityWeight = 0.3
+		cfg.TemporalWeight = 1.4
+	case StrategyEntity:
+		cfg.BM25Weight = 0.7
+		cfg.SemanticWeight = 0.8
+		cfg.EntityWeight = 1.4
+		cfg.TemporalWeight = 0.3
+	case StrategyComparison:
+		cfg.BM25Weight = 0.8
+		cfg.SemanticWeight = 1.0
+		cfg.EntityWeight = 1.2
+		cfg.TemporalWeight = 0.4
+	case StrategyBridge:
+		cfg.BM25Weight = 0.9
+		cfg.SemanticWeight = 1.1
+		cfg.EntityWeight = 1.0
+		cfg.TemporalWeight = 0.7
+	}
+
+	if decision.TemporalQuery != nil && decision.TemporalQuery.TemporalIntent && cfg.TemporalWeight < 1.0 {
+		cfg.TemporalWeight = 1.0
+	}
+	return normalizeRRFConfig(cfg)
+}

--- a/internal/search/strategy_test.go
+++ b/internal/search/strategy_test.go
@@ -1,0 +1,163 @@
+package search
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hurttlocker/cortex/internal/store"
+	"github.com/hurttlocker/cortex/internal/temporal"
+)
+
+func TestClassifyQueryStrategyHeuristic(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		entities []string
+		want     QueryStrategy
+	}{
+		{
+			name:  "temporal",
+			query: "When did Jon go to the fair?",
+			want:  StrategyTemporal,
+		},
+		{
+			name:     "entity",
+			query:    "What does Alice do?",
+			entities: []string{"Alice"},
+			want:     StrategyEntity,
+		},
+		{
+			name:     "comparison",
+			query:    "What do Jon and Gina both have in common?",
+			entities: []string{"Jon", "Gina"},
+			want:     StrategyComparison,
+		},
+		{
+			name:     "bridge",
+			query:    "How did Jon and Gina meet after dance class?",
+			entities: []string{"Jon", "Gina"},
+			want:     StrategyBridge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyQueryStrategyHeuristic(tt.query, tt.entities, nil)
+			if tt.want == StrategyTemporal {
+				got = classifyQueryStrategyHeuristic(tt.query, tt.entities, temporalQuery(tt.query))
+			}
+			if got.Primary != tt.want {
+				t.Fatalf("primary = %s, want %s", got.Primary, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchExplain_AttachesQueryStrategy(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	memID, err := s.AddMemory(ctx, &store.Memory{
+		Content:       "General meeting notes without the entity name in the body.",
+		SourceFile:    "entity-profile.md",
+		SourceSection: "notes",
+	})
+	if err != nil {
+		t.Fatalf("add memory: %v", err)
+	}
+	if _, err := s.AddFact(ctx, &store.Fact{
+		MemoryID:    memID,
+		Subject:     "Alice",
+		Predicate:   "role",
+		Object:      "project manager",
+		FactType:    "relationship",
+		Confidence:  0.95,
+		SourceQuote: "Alice is the project manager.",
+	}); err != nil {
+		t.Fatalf("add fact: %v", err)
+	}
+
+	engine := NewEngine(s)
+	results, err := engine.Search(ctx, "What does Alice do?", Options{
+		Mode:    ModeRRF,
+		Limit:   5,
+		Explain: true,
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results")
+	}
+	if results[0].Explain == nil || results[0].Explain.QueryStrategy == nil {
+		t.Fatal("expected query strategy explain payload")
+	}
+	if results[0].Explain.QueryStrategy.Primary != StrategyEntity {
+		t.Fatalf("strategy = %s, want %s", results[0].Explain.QueryStrategy.Primary, StrategyEntity)
+	}
+}
+
+func TestSearchRRFTemporalChannelWithoutEmbedder(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	memID, err := s.AddMemory(ctx, &store.Memory{
+		Content:    "Jon went to the fair last week.",
+		SourceFile: "jon.md",
+		Metadata: &store.Metadata{
+			TimestampStart: "2023-03-09T00:00:00Z",
+		},
+	})
+	if err != nil {
+		t.Fatalf("add memory: %v", err)
+	}
+	if _, err := s.AddFact(ctx, &store.Fact{
+		MemoryID:    memID,
+		Subject:     "Jon",
+		Predicate:   "went_to",
+		Object:      "the fair last week",
+		FactType:    "temporal",
+		Confidence:  0.95,
+		SourceQuote: "Jon went to the fair last week.",
+		TemporalNorm: &temporal.Norm{
+			Kind:       "date_range",
+			Literal:    "last week",
+			Start:      "2023-03-02",
+			End:        "2023-03-08",
+			Anchor:     "2023-03-09",
+			Precision:  "day",
+			Resolution: "resolved_from_anchor",
+		},
+	}); err != nil {
+		t.Fatalf("add fact: %v", err)
+	}
+
+	engine := NewEngine(s)
+	results, err := engine.Search(ctx, "What happened the week before March 9, 2023?", Options{
+		Mode:  ModeRRF,
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected temporal channel results")
+	}
+	if results[0].MemoryID != memID {
+		t.Fatalf("top result memory_id = %d, want %d", results[0].MemoryID, memID)
+	}
+	if results[0].MatchType != "rrf" {
+		t.Fatalf("match_type = %q, want rrf", results[0].MatchType)
+	}
+}
+
+func TestRRFConfigForStrategyComparisonBoostsEntity(t *testing.T) {
+	cfg := rrfConfigForStrategy(queryStrategyDecision{Primary: StrategyComparison})
+	if cfg.EntityWeight <= cfg.BM25Weight {
+		t.Fatalf("entity weight %.2f should exceed bm25 %.2f for comparison", cfg.EntityWeight, cfg.BM25Weight)
+	}
+}
+
+func temporalQuery(query string) *temporal.Query {
+	return temporal.ParseQuery(query)
+}

--- a/internal/search/temporal_channel.go
+++ b/internal/search/temporal_channel.go
@@ -1,0 +1,172 @@
+package search
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/hurttlocker/cortex/internal/store"
+	"github.com/hurttlocker/cortex/internal/temporal"
+)
+
+const (
+	temporalChannelMinFactLimit = 60
+	temporalChannelMaxFactLimit = 400
+)
+
+func (e *Engine) searchTemporalChannel(ctx context.Context, query string, opts Options, strategy queryStrategyDecision) ([]Result, error) {
+	tq := strategy.TemporalQuery
+	if tq == nil {
+		tq = opts.TemporalQuery
+	}
+	if tq == nil || !tq.TemporalIntent {
+		return nil, nil
+	}
+
+	factLimit := opts.Limit * 20
+	if factLimit < temporalChannelMinFactLimit {
+		factLimit = temporalChannelMinFactLimit
+	}
+	if factLimit > temporalChannelMaxFactLimit {
+		factLimit = temporalChannelMaxFactLimit
+	}
+
+	facts, err := e.store.ListFacts(ctx, store.ListOpts{
+		Limit:             factLimit,
+		FactType:          "temporal",
+		IncludeSuperseded: opts.IncludeSuperseded,
+		Agent:             opts.Agent,
+	})
+	if err != nil || len(facts) == 0 {
+		return nil, err
+	}
+
+	memoryIDs := make([]int64, 0, len(facts))
+	seen := make(map[int64]struct{}, len(facts))
+	for _, fact := range facts {
+		if fact == nil || fact.MemoryID <= 0 {
+			continue
+		}
+		if _, ok := seen[fact.MemoryID]; ok {
+			continue
+		}
+		seen[fact.MemoryID] = struct{}{}
+		memoryIDs = append(memoryIDs, fact.MemoryID)
+	}
+	if len(memoryIDs) == 0 {
+		return nil, nil
+	}
+
+	memories, err := e.store.GetMemoriesByIDs(ctx, memoryIDs)
+	if err != nil {
+		return nil, err
+	}
+	memoryByID := make(map[int64]*store.Memory, len(memories))
+	for _, memory := range memories {
+		memoryByID[memory.ID] = memory
+	}
+
+	queryLower := strings.ToLower(strings.TrimSpace(query))
+	queryTokens := queryTokenSet(query)
+	grouped := make(map[int64]*Result, len(memoryIDs))
+
+	for _, fact := range facts {
+		if fact == nil {
+			continue
+		}
+		memory := memoryByID[fact.MemoryID]
+		if memory == nil {
+			continue
+		}
+
+		score := temporalFactScore(queryLower, queryTokens, tq, memory, fact)
+		if score <= 0 {
+			continue
+		}
+
+		entry, ok := grouped[fact.MemoryID]
+		if !ok {
+			entry = &Result{
+				Content:       memory.Content,
+				SourceFile:    memory.SourceFile,
+				SourceTier:    SourceTierForFile(memory.SourceFile),
+				SourceLine:    memory.SourceLine,
+				SourceSection: memory.SourceSection,
+				Project:       memory.Project,
+				MemoryClass:   memory.MemoryClass,
+				Metadata:      memory.Metadata,
+				ImportedAt:    memory.ImportedAt,
+				MemoryID:      memory.ID,
+				MatchType:     "temporal",
+			}
+			if memory.Metadata != nil && len(memory.Metadata.TimestampStart) >= 10 {
+				entry.TemporalAnchor = memory.Metadata.TimestampStart[:10]
+			}
+			grouped[fact.MemoryID] = entry
+		}
+		if score > entry.Score {
+			entry.Score = score
+			entry.Snippet = strings.TrimSpace(strings.Join([]string{fact.Subject, fact.Predicate, fact.Object}, " "))
+		}
+		if fact.TemporalNorm != nil {
+			entry.TemporalNorms = appendTemporalNorm(entry.TemporalNorms, *fact.TemporalNorm)
+		}
+		entry.FactIDs = appendUniqueInt64(entry.FactIDs, fact.ID)
+	}
+
+	results := make([]Result, 0, len(grouped))
+	for _, result := range grouped {
+		results = append(results, *result)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score == results[j].Score {
+			return results[i].MemoryID < results[j].MemoryID
+		}
+		return results[i].Score > results[j].Score
+	})
+	if opts.Limit > 0 && len(results) > opts.Limit*2 {
+		results = results[:opts.Limit*2]
+	}
+	return results, nil
+}
+
+func temporalFactScore(queryLower string, queryTokens map[string]struct{}, tq *temporal.Query, memory *store.Memory, fact *store.Fact) float64 {
+	score := 0.0
+	textScore := factTextScore(queryLower, queryTokens, fact)
+	score += 0.35 * textScore
+
+	if fact.TemporalNorm != nil {
+		score += 0.35
+		if tq != nil && tq.Resolved && temporal.MatchesQuery(tq, fact.TemporalNorm) {
+			score += 1.10
+		}
+	}
+
+	if memory != nil && memory.Metadata != nil && len(memory.Metadata.TimestampStart) >= 10 {
+		score += 0.10
+		if tq != nil && tq.Resolved {
+			if anchorNorm := temporal.NormalizeLiteral(memory.Metadata.TimestampStart[:10], ""); anchorNorm != nil && temporal.MatchesQuery(tq, anchorNorm) {
+				score += 0.75
+			}
+		}
+	}
+
+	score += 0.15 * clamp01(fact.Confidence)
+	if tq != nil && tq.Resolved && score < 0.55 {
+		return 0
+	}
+	return score
+}
+
+func appendTemporalNorm(existing []temporal.Norm, norm temporal.Norm) []temporal.Norm {
+	for _, current := range existing {
+		if current.Kind == norm.Kind &&
+			current.Value == norm.Value &&
+			current.Start == norm.Start &&
+			current.End == norm.End &&
+			current.Anchor == norm.Anchor {
+			return existing
+		}
+	}
+	return append(existing, norm)
+}


### PR DESCRIPTION
## Summary

Build the first retrieval-parity foundation layer for Cortex:

- add deterministic query strategy classification
- make RRF strategy-aware across BM25 / semantic / entity / temporal channels
- add a temporal retrieval channel in RRF
- add bounded scene expansion after fusion
- group evidence blocks in `ask` / `answer`
- default `ask` and `answer` to `rrf`
- add normalized benchmark scoring helpers for parity reporting

## What Shipped

### Retrieval routing

- `internal/search/strategy.go`
- strategy labels: `default`, `temporal`, `entity`, `comparison`, `bridge`
- strategy-specific RRF weights
- explain output now surfaces the strategy decision

### Retrieval channels

- `internal/search/rrf.go`
- `internal/search/temporal_channel.go`
- temporal channel added to RRF
- entity graph auto-enable is now query-shape aware instead of globally blunt

### Evidence expansion / packing

- `internal/search/scene.go`
- `internal/ask/engine.go`
- `internal/answer/engine.go`
- bounded same-scene neighbor expansion
- grouped evidence rendering for reader models

### Product defaults

- `cmd/cortex/main.go`
- `ask` and `answer` now default to `rrf`

### Benchmark helpers

- `internal/benchscore/score.go`
- normalized answer / normalized exact-match helpers for scorer parity work

## Benchmark

Benchmark note:

- `docs/research/retrieval-parity-foundation-benchmark-2026-03-23.md`

Same fresh LoCoMo-only DB and same public `conv-30` 81-question slice used in `v1.4.0`:

- `rrf_default` (`--mode rrf --rerank off`): `11.90%` F1, `6461.61 ms`, `0` degraded
- `rrf_rerank_daemon` (`--mode rrf --rerank on`): `15.03%` F1, `9706.82 ms`, `0` degraded

Comparison to prior notes:

- vs `v1.4.0` baseline `A`: `11.81%` -> `11.90%`
- vs `v1.4.0` reranker path `C`: `13.26%` -> `15.03%`
- vs prior best reference `15.77%`: now `-0.74`

Important diagnostic read:

- category `1` moved the most: `27.46%` F1 with daemon-backed rerank
- category `2` remains the main ceiling blocker
- category `4` is improved from the plain baseline but not a dramatic jump

## Validation

- `go test ./internal/search ./cmd/cortex`
- `go test ./internal/search ./internal/ask ./internal/answer ./cmd/cortex`
- `go test ./...`
- `go vet ./...`

## Notes

I left unrelated untracked local artifacts out of this branch:

- `docs/research/slm-v3-benchmark-2026-03-23.md`
- `scripts/bench/run_slm_locomo_benchmark_2026_03_23.py`
- `scripts/bench/__pycache__/`
