### PR TITLE
fix: add per-memory ollama embed timeout

### DIFF
--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -80,6 +80,13 @@ type Client struct {
 	mu     sync.Mutex
 }
 
+func ollamaRequestTimeout(textCount int) time.Duration {
+	if textCount <= 0 {
+		textCount = 1
+	}
+	return time.Duration(textCount) * 10 * time.Second
+}
+
 // HealthCheck pings the embedding provider to verify connectivity.
 // For Ollama, hits /api/tags (lightweight). For others, sends a minimal embed request.
 func (c *Client) HealthCheck(ctx context.Context) error {
@@ -441,8 +448,15 @@ func (c *Client) attemptEmbedBatch(ctx context.Context, texts []string) ([][]flo
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 
+	requestCtx := ctx
+	if c.config.Provider == "ollama" {
+		var cancel context.CancelFunc
+		requestCtx, cancel = context.WithTimeout(ctx, ollamaRequestTimeout(len(texts)))
+		defer cancel()
+	}
+
 	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.config.Endpoint, bytes.NewBuffer(requestBody))
+	httpReq, err := http.NewRequestWithContext(requestCtx, "POST", c.config.Endpoint, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -571,6 +571,61 @@ func TestEmbed_OllamaProvider(t *testing.T) {
 	}
 }
 
+func TestOllamaRequestTimeout(t *testing.T) {
+	if got := ollamaRequestTimeout(1); got != 10*time.Second {
+		t.Fatalf("timeout(1) = %s, want 10s", got)
+	}
+	if got := ollamaRequestTimeout(3); got != 30*time.Second {
+		t.Fatalf("timeout(3) = %s, want 30s", got)
+	}
+	if got := ollamaRequestTimeout(0); got != 10*time.Second {
+		t.Fatalf("timeout(0) = %s, want 10s", got)
+	}
+}
+
+func TestEmbed_OllamaBatchTimeoutContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(2 * time.Second):
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(EmbedResponse{
+				Data: []struct {
+					Embedding []float32 `json:"embedding"`
+					Index     int       `json:"index"`
+				}{
+					{Embedding: []float32{0.1, 0.2, 0.3}, Index: 0},
+				},
+			})
+		case <-r.Context().Done():
+			return
+		}
+	}))
+	defer server.Close()
+
+	config := &EmbedConfig{
+		Provider:    "ollama",
+		Model:       "all-minilm",
+		Endpoint:    server.URL,
+		MaxRetries:  0,
+		TimeoutSecs: 60,
+	}
+
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+	_, err = client.EmbedBatch(ctx, []string{"slow text"})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "context deadline exceeded") && !strings.Contains(err.Error(), "sending request") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestEmbed_OpenAIProvider(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check Authorization header


### PR DESCRIPTION
Closes #362.

What changed
- add a 10s-per-memory timeout policy for Ollama embedding requests
- scope the request context in the embed client for Ollama batches
- add focused timeout/unit tests for the new behavior

Why this change exists
- the current Ollama embed path can hang indefinitely on problematic memories
- this blocks background embedding, benchmark runs, and import-quality experiments
- a bounded timeout unblocks the whole local eval stack

Touched surfaces
- internal/embed/embed.go
- internal/embed/embed_test.go

Tests run
- go test ./internal/embed -run 'Ollama|Timeout|Embed_Ollama'

Risk
- changes Ollama timeout behavior only
- could surface more timeout errors on very slow local hosts, but that is preferable to indefinite hangs
