### PR TITLE
feat: add native ONNX all-MiniLM embedder

### DIFF
--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -236,11 +236,11 @@ func remediationHint(err error) string {
 	case strings.Contains(msg, "health check failed"):
 		return "Embedding provider is unreachable. Check that the service is running, or switch providers with `--embed <provider/model>`."
 	case strings.Contains(msg, "unknown provider") && strings.Contains(msg, "supported"):
-		return "Supported embed providers: ollama, openai, deepseek, openrouter, custom. Example: `--embed ollama/nomic-embed-text`"
+		return "Supported embed providers: ollama, onnx, openai, deepseek, openrouter, custom. Example: `--embed onnx/all-minilm-l6-v2`"
 	case strings.Contains(msg, "api key is required for provider"):
 		return "Set the API key for your embed provider via environment variable (e.g., OPENAI_API_KEY, OPENROUTER_API_KEY)."
 	case strings.Contains(msg, "invalid --embed format"):
-		return "Use format: `--embed provider/model` (e.g., `--embed ollama/nomic-embed-text`)."
+		return "Use format: `--embed provider/model` (e.g., `--embed onnx/all-minilm-l6-v2`)."
 
 	// LLM provider errors
 	case strings.Contains(msg, "unknown llm provider"):
@@ -1707,7 +1707,7 @@ func newSearchEngineForModeStrict(s store.Store, mode search.Mode, embedFlag str
 			return nil, fmt.Errorf("creating embedder: %w", clientErr)
 		}
 		engine := search.NewEngineWithEmbedder(s, embedder)
-		loadSearchHNSW(engine, "auto-resolved from config")
+		loadSearchHNSW(engine, "auto-resolved")
 		return engine, nil
 	}
 
@@ -2228,7 +2228,7 @@ func newSearchEngineForMode(s store.Store, mode search.Mode, embedFlag string) (
 			if autoConfig.Validate() == nil {
 				if embedder, clientErr := newEmbedClient(autoConfig); clientErr == nil {
 					engine := search.NewEngineWithEmbedder(s, embedder)
-					loadSearchHNSW(engine, "auto-resolved from config")
+					loadSearchHNSW(engine, "auto-resolved")
 					return engine, nil
 				}
 			}
@@ -3574,7 +3574,7 @@ func relativeTimeString(t time.Time) string {
 func buildHealthRecommendations(report healthReport) []string {
 	recs := make([]string, 0, 4)
 	if report.EmbeddingCoverage < 10 {
-		recs = append(recs, "⚠ Embedding coverage low — run: cortex embed ollama/nomic-embed-text")
+		recs = append(recs, "⚠ Embedding coverage low — run: cortex embed")
 	} else {
 		recs = append(recs, "✓ Embedding coverage healthy")
 	}
@@ -3721,7 +3721,7 @@ func runEvalSearch(args []string) error {
 	fixturePath := "tests/fixtures/retrieval/ci-gate.json"
 	corpusPath := "tests/fixtures/retrieval/ci-corpus"
 	mode := "keyword"
-	embedFlag := "ollama/nomic-embed-text"
+	embedFlag := "onnx/all-minilm-l6-v2"
 	jsonOutput := false
 	minPassRate := 0.95
 	minAvgPrecision := 0.60
@@ -8270,7 +8270,7 @@ func runIndex(args []string) error {
 	}
 
 	if count == 0 {
-		fmt.Println("No embeddings found. Run 'cortex embed <provider/model>' first.")
+		fmt.Println("No embeddings found. Run 'cortex embed' first.")
 		return nil
 	}
 
@@ -8410,7 +8410,7 @@ Flags:
 
 Examples:
   cortex embed-source /path/to/memory/2026-02-21.md
-  cortex embed-source /path/to/memory/2026-02-21.md ollama/nomic-embed-text
+  cortex embed-source /path/to/memory/2026-02-21.md onnx/all-minilm-l6-v2
   cortex embed-source /path/to/memory/2026-02-21.md --batch-size 4
 `)
 			return nil
@@ -8514,6 +8514,24 @@ func runEmbedStatus() error {
 			dims = got
 		}
 	}
+	resolvedCfg, err := embed.ResolveEmbedConfig("")
+	if err != nil {
+		return fmt.Errorf("resolving embedder: %w", err)
+	}
+	providerRef := resolvedEmbedRef(resolvedCfg)
+	providerDims := embed.ExpectedDimensions(resolvedCfg)
+	sourceRef := resolvedEmbedSource(resolvedCfg)
+	statusRef := resolvedEmbedStatus(resolvedCfg)
+	modelPath := ""
+	speedHint := ""
+	dimsMatch := true
+	if resolvedCfg != nil {
+		modelPath = resolvedCfg.ModelPath
+		speedHint = embed.SpeedHint(resolvedCfg)
+		if dims > 0 && providerDims > 0 {
+			dimsMatch = dims == providerDims
+		}
+	}
 
 	coverage := 0.0
 	if stats.MemoryCount > 0 {
@@ -8522,13 +8540,20 @@ func runEmbedStatus() error {
 
 	running := isEmbedWorkerRunning()
 	if !isTTY() {
-		fmt.Printf("embed_status memories=%d embeddings=%d remaining=%d coverage_pct=%.2f worker_running=%t dimensions=%d\n",
+		fmt.Printf("embed_status memories=%d embeddings=%d remaining=%d coverage_pct=%.2f worker_running=%t stored_dimensions=%d provider=%q provider_dimensions=%d source=%q status=%q model_path=%q speed=%q dimensions_match=%t\n",
 			stats.MemoryCount,
 			stats.EmbeddingCount,
 			remaining,
 			coverage,
 			running,
 			dims,
+			providerRef,
+			providerDims,
+			sourceRef,
+			statusRef,
+			modelPath,
+			speedHint,
+			dimsMatch,
 		)
 		return nil
 	}
@@ -8538,11 +8563,65 @@ func runEmbedStatus() error {
 	fmt.Printf("  Embedded:        %d\n", stats.EmbeddingCount)
 	fmt.Printf("  Remaining:       %d\n", remaining)
 	fmt.Printf("  Coverage:        %.1f%%\n", coverage)
+	if providerRef != "" {
+		fmt.Printf("  Resolved:        %s\n", providerRef)
+	}
+	if sourceRef != "" {
+		fmt.Printf("  Source:          %s\n", sourceRef)
+	}
+	if statusRef != "" {
+		fmt.Printf("  Status:          %s\n", statusRef)
+	}
+	if modelPath != "" {
+		fmt.Printf("  Model path:      %s\n", modelPath)
+	}
+	if providerDims > 0 {
+		fmt.Printf("  Provider dims:   %d\n", providerDims)
+	}
 	if dims > 0 {
-		fmt.Printf("  Dimensions:      %d\n", dims)
+		fmt.Printf("  Stored dims:     %d\n", dims)
+	}
+	if dims > 0 && providerDims > 0 {
+		fmt.Printf("  Compatible:      %t\n", dimsMatch)
+	}
+	if speedHint != "" {
+		fmt.Printf("  Speed:           %s\n", speedHint)
 	}
 	fmt.Printf("  Worker running:  %t\n", running)
 	return nil
+}
+
+func resolvedEmbedRef(cfg *embed.EmbedConfig) string {
+	if cfg == nil || strings.TrimSpace(cfg.Provider) == "" || strings.TrimSpace(cfg.Model) == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s", cfg.Provider, cfg.Model)
+}
+
+func resolvedEmbedSource(cfg *embed.EmbedConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	source := strings.TrimSpace(cfg.ResolvedFrom)
+	detail := strings.TrimSpace(cfg.ResolvedDetail)
+	switch {
+	case source != "" && detail != "":
+		return fmt.Sprintf("%s (%s)", source, detail)
+	case detail != "":
+		return detail
+	default:
+		return source
+	}
+}
+
+func resolvedEmbedStatus(cfg *embed.EmbedConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.Provider == "onnx" && cfg.WillDownload {
+		return "auto-download pending"
+	}
+	return "ready"
 }
 
 func parseEmbedArgs(args []string) (embedCmdOptions, error) {
@@ -8640,10 +8719,6 @@ func parseEmbedArgs(args []string) (embedCmdOptions, error) {
 	if opts.watch && opts.forceReembed {
 		return opts, fmt.Errorf("--watch cannot be used with --force")
 	}
-	if opts.embedFlag == "" && os.Getenv("CORTEX_EMBED") == "" {
-		return opts, fmt.Errorf("usage: cortex embed [provider/model] [--watch] [--interval 30m] [--batch N|--batch-size N] [--workers N] [--force]\n       cortex embed --status\n       (or set CORTEX_EMBED)")
-	}
-
 	return opts, nil
 }
 
@@ -8688,10 +8763,6 @@ func parseEmbedSourceArgs(args []string) (embedCmdOptions, error) {
 	if opts.batchSize <= 0 {
 		return opts, fmt.Errorf("--batch-size must be > 0")
 	}
-	if opts.embedFlag == "" && os.Getenv("CORTEX_EMBED") == "" {
-		return opts, fmt.Errorf("usage: cortex embed-source <path> [provider/model] [--batch-size N]\n       (or set CORTEX_EMBED)")
-	}
-
 	return opts, nil
 }
 
@@ -12002,11 +12073,9 @@ func runInit(args []string) error {
 			llmEnvKey = "OPENAI_API_KEY"
 		}
 
-		// Detect embed provider
-		embedProvider := ""
-		if isOllamaRunning() {
-			embedProvider = "ollama/nomic-embed-text"
-		}
+		embedCfg, _ := embed.ResolveEmbedConfig("")
+		embedProvider := resolvedEmbedRef(embedCfg)
+		embedSource := resolvedEmbedSource(embedCfg)
 
 		if llmProvider != "" {
 			fmt.Printf("  ✓ Detected LLM key: %s\n", llmEnvKey)
@@ -12019,10 +12088,13 @@ func runInit(args []string) error {
 		fmt.Println()
 
 		if embedProvider != "" {
-			fmt.Printf("  ✓ Detected Ollama running — will use %s for embeddings\n", embedProvider)
+			fmt.Printf("  ✓ Default embedder: %s\n", embedProvider)
+			if embedSource != "" {
+				fmt.Printf("    Source: %s\n", embedSource)
+			}
 		} else {
-			fmt.Println("  ⚠ Ollama not detected — semantic search will be unavailable")
-			fmt.Println("    Install: https://ollama.ai then run: ollama pull nomic-embed-text")
+			fmt.Println("  ⚠ No embedder detected")
+			fmt.Println("    Semantic search will require an explicit --embed provider.")
 		}
 		fmt.Println()
 
@@ -12042,13 +12114,13 @@ func runInit(args []string) error {
 			cfgLines = append(cfgLines, "#   api_key: your-key-here")
 			cfgLines = append(cfgLines, "")
 		}
-		if embedProvider != "" {
+		if strings.HasPrefix(embedProvider, "ollama/") {
 			cfgLines = append(cfgLines, "embed:")
 			cfgLines = append(cfgLines, fmt.Sprintf("  provider: %s", embedProvider))
 			cfgLines = append(cfgLines, "")
 		} else {
 			cfgLines = append(cfgLines, "# embed:")
-			cfgLines = append(cfgLines, "#   provider: ollama/nomic-embed-text")
+			cfgLines = append(cfgLines, "#   provider: onnx/all-minilm-l6-v2")
 			cfgLines = append(cfgLines, "")
 		}
 		cfgContent := strings.Join(cfgLines, "\n") + "\n"
@@ -12170,7 +12242,7 @@ func runDoctorChecks() doctorReport {
 	report := doctorReport{
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		DBPath:      dbPath,
-		Checks:      make([]doctorCheck, 0, 8),
+		Checks:      make([]doctorCheck, 0, 12),
 	}
 
 	ctx := context.Background()
@@ -12222,6 +12294,7 @@ func runDoctorChecks() doctorReport {
 	}
 
 	var stats *store.StoreStats
+	storedEmbeddingDims := 0
 	if canOpenDB {
 		st, err := store.NewStore(store.StoreConfig{DBPath: dbPath, ReadOnly: true})
 		if err != nil {
@@ -12262,19 +12335,20 @@ func runDoctorChecks() doctorReport {
 					Name:    "embeddings",
 					Status:  "warn",
 					Details: "no memories imported yet",
-					Hint:    "Run `cortex import <path>` first, then `cortex embed <provider/model>`.",
+					Hint:    "Run `cortex import <path>` first, then `cortex embed`.",
 				})
 			case stats.EmbeddingCount == 0:
 				addDoctorCheck(&report, doctorCheck{
 					Name:    "embeddings",
 					Status:  "warn",
 					Details: "no embeddings found",
-					Hint:    "Run `cortex embed ollama/nomic-embed-text` for semantic/hybrid search.",
+					Hint:    "Run `cortex embed` for semantic/hybrid search.",
 				})
 			default:
 				detail := fmt.Sprintf("%d embedding vectors available", stats.EmbeddingCount)
 				if sqlStore, ok := st.(*store.SQLiteStore); ok {
 					if dims, err := sqlStore.GetEmbeddingDimensions(ctx); err == nil && dims > 0 {
+						storedEmbeddingDims = dims
 						detail = fmt.Sprintf("%d embedding vectors (%d dimensions)", stats.EmbeddingCount, dims)
 					}
 				}
@@ -12392,12 +12466,77 @@ func runDoctorChecks() doctorReport {
 				Status:  "pass",
 				Details: fmt.Sprintf("embed_provider: %s (from: %s)", embedProvider, from),
 			})
-		} else if stats != nil && stats.EmbeddingCount > 0 {
+		} else if autoEmbedCfg, autoErr := embed.ResolveEmbedConfig(""); autoErr == nil && autoEmbedCfg != nil {
 			addDoctorCheck(&report, doctorCheck{
 				Name:    "embed_config",
+				Status:  "pass",
+				Details: fmt.Sprintf("auto: %s (%s)", resolvedEmbedRef(autoEmbedCfg), resolvedEmbedSource(autoEmbedCfg)),
+			})
+		}
+	}
+
+	autoEmbedCfg, autoEmbedErr := embed.ResolveEmbedConfig("")
+	if autoEmbedErr != nil {
+		addDoctorCheck(&report, doctorCheck{
+			Name:    "embedder",
+			Status:  "warn",
+			Details: fmt.Sprintf("embedder resolution failed: %v", autoEmbedErr),
+			Hint:    "Validate embed.provider in ~/.cortex/config.yaml or CORTEX_EMBED.",
+		})
+	} else if autoEmbedCfg != nil {
+		providerDims := embed.ExpectedDimensions(autoEmbedCfg)
+		locality := "remote"
+		if autoEmbedCfg.Local {
+			locality = "local"
+		}
+		detail := fmt.Sprintf("%s (%s", resolvedEmbedRef(autoEmbedCfg), locality)
+		if providerDims > 0 {
+			detail += fmt.Sprintf(", %dd", providerDims)
+		}
+		detail += ")"
+		addDoctorCheck(&report, doctorCheck{
+			Name:    "embedder",
+			Status:  "pass",
+			Details: detail,
+		})
+		addDoctorCheck(&report, doctorCheck{
+			Name:    "embedder_source",
+			Status:  "pass",
+			Details: resolvedEmbedSource(autoEmbedCfg),
+		})
+		if autoEmbedCfg.ModelPath != "" {
+			addDoctorCheck(&report, doctorCheck{
+				Name:    "embedder_model",
+				Status:  "pass",
+				Details: autoEmbedCfg.ModelPath,
+			})
+		}
+		status := resolvedEmbedStatus(autoEmbedCfg)
+		statusLevel := "pass"
+		statusHint := ""
+		if status != "ready" {
+			statusLevel = "warn"
+			statusHint = "The built-in ONNX model downloads automatically the first time you run `cortex embed`, `cortex search --mode semantic`, or `cortex answer --mode hybrid`."
+		}
+		addDoctorCheck(&report, doctorCheck{
+			Name:    "embedder_status",
+			Status:  statusLevel,
+			Details: status,
+			Hint:    statusHint,
+		})
+		if speed := embed.SpeedHint(autoEmbedCfg); speed != "" {
+			addDoctorCheck(&report, doctorCheck{
+				Name:    "embedder_speed",
+				Status:  "pass",
+				Details: speed,
+			})
+		}
+		if storedEmbeddingDims > 0 && providerDims > 0 && storedEmbeddingDims != providerDims {
+			addDoctorCheck(&report, doctorCheck{
+				Name:    "embedder_compat",
 				Status:  "warn",
-				Details: "embeddings exist, but no embed provider is configured for new query embeddings",
-				Hint:    "Set embed.provider in ~/.cortex/config.yaml or CORTEX_EMBED (for example ollama/nomic-embed-text) so hybrid/semantic search can use the stored vectors.",
+				Details: fmt.Sprintf("resolved embedder uses %d dimensions but stored embeddings use %d", providerDims, storedEmbeddingDims),
+				Hint:    "Run `cortex embed` to regenerate embeddings with the resolved provider.",
 			})
 		}
 	}
@@ -12952,7 +13091,7 @@ Maintenance:
   cleanup               Remove garbage memories, headless facts, and prune noise
   backfill-scope        Infer missing fact scope from linked memory metadata
   optimize              DB maintenance (integrity check, VACUUM, ANALYZE)
-  embed <provider/model> Generate embeddings, run/watch the worker, or show status
+  embed [provider/model] Generate embeddings, run/watch the worker, or show status
   embed-source <path>   Finish embeddings for one source file
   suppress              Manage extract suppression patterns in config
   source-weight         Manage search source weights in config

--- a/cmd/cortex/main_test.go
+++ b/cmd/cortex/main_test.go
@@ -1171,6 +1171,8 @@ func TestRunEmbed_StatusReportsCoverage(t *testing.T) {
 		globalDBPath = oldDBPath
 		globalReadOnly = oldReadOnly
 	})
+	t.Setenv("HOME", filepath.Join(tmpDir, "home"))
+	t.Setenv("CORTEX_DISABLE_OLLAMA_AUTODETECT", "1")
 
 	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
 	if err != nil {
@@ -1209,6 +1211,9 @@ func TestRunEmbed_StatusReportsCoverage(t *testing.T) {
 	}
 	if !strings.Contains(out, "remaining=1") {
 		t.Fatalf("expected remaining count in status output, got %q", out)
+	}
+	if !strings.Contains(out, `provider="onnx/all-minilm-l6-v2"`) {
+		t.Fatalf("expected resolved provider in status output, got %q", out)
 	}
 }
 
@@ -1829,9 +1834,34 @@ func TestMain_CorruptDBIncludesRecoveryHint(t *testing.T) {
 
 func TestMain_OpenRouterMissingKeyIncludesHint(t *testing.T) {
 	homeDir := t.TempDir()
+	dbPath := filepath.Join(homeDir, "cortex.db")
+	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	ctx := context.Background()
+	memID, err := s.AddMemory(ctx, &store.Memory{Content: "classify seed", SourceFile: "seed.md"})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if _, err := s.AddFact(ctx, &store.Fact{
+		MemoryID:   memID,
+		Subject:    "cortex",
+		Predicate:  "setting",
+		Object:     "enabled",
+		Confidence: 0.9,
+		FactType:   "kv",
+	}); err != nil {
+		t.Fatalf("AddFact: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close store: %v", err)
+	}
+
 	exitCode, out := runMainSubprocessWithEnv(t, map[string]string{
 		"OPENROUTER_API_KEY": "",
 		"HOME":               homeDir,
+		"CORTEX_DB":          dbPath,
 	}, "classify", "--llm", "openrouter/deepseek/deepseek-v3.2", "--limit", "1")
 	if exitCode != 1 {
 		t.Fatalf("exit code = %d, want 1; output=%q", exitCode, out)
@@ -2066,6 +2096,8 @@ func TestRunDoctor_JSONHealthyDB(t *testing.T) {
 	oldDBPath := globalDBPath
 	globalDBPath = dbPath
 	t.Cleanup(func() { globalDBPath = oldDBPath })
+	t.Setenv("HOME", filepath.Join(tmpDir, "home"))
+	t.Setenv("CORTEX_DISABLE_OLLAMA_AUTODETECT", "1")
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
 
 	s, err := store.NewStore(store.StoreConfig{DBPath: dbPath})
@@ -2138,6 +2170,10 @@ func TestRunDoctor_JSONHealthyDB(t *testing.T) {
 	if !ok || llm.Status != "pass" {
 		t.Fatalf("expected llm_keys check to pass, got %+v", llm)
 	}
+	embedder, ok := findDoctorCheck(report, "embedder")
+	if !ok || embedder.Status != "pass" {
+		t.Fatalf("expected embedder check to pass, got %+v", embedder)
+	}
 }
 
 func TestRunDoctor_ResolvedConfigProviderOnlyPasses(t *testing.T) {
@@ -2169,6 +2205,7 @@ func TestRunDoctor_ResolvedConfigProviderOnlyPasses(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
 	t.Setenv("CORTEX_LLM", "")
+	t.Setenv("CORTEX_DISABLE_OLLAMA_AUTODETECT", "1")
 
 	var (
 		runErr error

--- a/docs/research/onnx-embedder-benchmark-2026-03-24.md
+++ b/docs/research/onnx-embedder-benchmark-2026-03-24.md
@@ -1,0 +1,150 @@
+# ONNX Embedder Benchmark — 2026-03-24
+
+## Scope
+
+This note records the first local-embedder benchmark for issue `#360` / `#361`.
+
+The target was the real live Cortex DB:
+
+- DB: `~/.cortex/cortex.db`
+- memories: `5694`
+- facts: `5822`
+- stored embeddings: `5694`
+- stored dimensions: `384`
+
+Important live-state note:
+
+- `cortex embed --status` showed a pre-existing config mismatch before the benchmark:
+  - configured provider: `ollama/nomic-embed-text`
+  - stored corpus dimensions: `384`
+- because `nomic-embed-text` is `768d`, the live DB was clearly not aligned with the current configured provider
+- for that reason I benchmarked with explicit provider flags on copied DBs instead of mutating the live DB in place
+
+## Setup
+
+- binary under test: `/tmp/cortex-onnx-embed`
+- source DB: `~/.cortex/cortex.db`
+- ONNX benchmark DB copy: `/tmp/cortex-onnx-solo-2026-03-24.db`
+- bounded Ollama-rate DB copy: `/tmp/cortex-ollama-rate-2026-03-24.db`
+- ONNX model warmed once before timing so the measured run excludes the first-use download
+
+Commands used:
+
+```bash
+/tmp/cortex-onnx-embed --db /tmp/cortex-onnx-solo-2026-03-24.db \
+  embed onnx/all-minilm-l6-v2 --force
+```
+
+```bash
+/tmp/cortex-onnx-embed --db /tmp/cortex-ollama-rate-2026-03-24.db \
+  embed ollama/all-minilm --force
+```
+
+## Throughput
+
+### ONNX full live-DB pass
+
+Measured command result:
+
+```text
+embed memories_processed=5694 embeddings_added=5694 embeddings_skipped=0 errors=0 elapsed_ms=69199
+```
+
+Derived throughput:
+
+- `5694 / 69.199s = 82.3 emb/s`
+
+### Ollama live-DB bounded sample
+
+I did not wait for a full `--force` pass to finish because the live-DB run was projecting to hours, not minutes.
+
+Observed progress on the copied live DB:
+
+- after `120s`: `12` embeddings persisted
+- after `180s`: `18` embeddings persisted
+
+Derived bounded-sample throughput:
+
+- `18 / 180s = 0.10 emb/s`
+
+Extrapolated full-pass duration at that observed rate:
+
+- `5694 / 0.10 emb/s = 56,940s`
+- about `15.8h`
+
+## Result
+
+| Provider | Corpus | Measurement type | Elapsed | Throughput |
+| --- | ---: | --- | ---: | ---: |
+| `onnx/all-minilm-l6-v2` | `5694` memories | full run | `69.2s` | `82.3 emb/s` |
+| `ollama/all-minilm` | `5694` memories | bounded live sample, extrapolated | `180s` sample | `0.10 emb/s` observed |
+
+Read plainly:
+
+- ONNX was dramatically faster than the live Ollama path on this machine
+- this does **not** match the earlier small-corpus manual reference (`~6.9 emb/s`) mentioned in issue `#361`
+- the honest interpretation is that the current live Ollama setup here is underperforming badly relative to prior reference numbers
+
+## Search Quality
+
+I checked quality in two ways.
+
+### 1. Existing live `384d` corpus vs fresh ONNX re-embed
+
+I compared semantic top-5 results for five representative live-memory queries using the same ONNX query embedder against:
+
+- the fully ONNX-reembedded DB copy
+- the existing live `384d` DB
+
+Those rankings were **not identical**.
+
+That is consistent with the earlier config mismatch:
+
+- the existing live corpus is `384d`
+- but the configured provider is `nomic-embed-text`
+- so the current live store cannot be treated as a clean runtime-to-runtime all-MiniLM baseline
+
+### 2. Direct ONNX vs Ollama all-MiniLM runtime parity
+
+To isolate the runtime difference from the stale live corpus, I embedded:
+
+- `8` representative recent live-memory excerpts
+- `5` representative search queries
+
+with both providers directly:
+
+- `onnx/all-minilm-l6-v2`
+- `ollama/all-minilm`
+
+Results:
+
+- average candidate-vector cosine between runtimes: `0.986`
+- average query-vector cosine between runtimes: `0.991`
+- identical top-1 retrieval on the sampled set: `5 / 5`
+- identical top-3 retrieval on the sampled set: `4 / 5`
+
+Interpretation:
+
+- the two runtimes are very close on the same model family
+- they are not bit-identical in this environment
+- for sampled retrieval they were effectively top-1 equivalent
+
+## Bottom Line
+
+The ONNX embedder is viable and fast on the real live corpus:
+
+- full `5694`-memory re-embed completed in `69.2s`
+- no external service dependency
+- `384d` output matches the preferred all-MiniLM footprint
+
+The live Ollama path here was too slow to finish a full fair pass during the benchmark window:
+
+- bounded sample observed `0.10 emb/s`
+- projected full pass was `~15.8h`
+
+So the honest conclusion from this environment is:
+
+1. local ONNX embedding is ready for zero-setup use
+2. ONNX speed is more than acceptable here
+3. the current live Ollama setup is the outlier, not ONNX
+4. the direct provider-to-provider sample shows near-parity quality at top-1, even though the stale live corpus does not rank identically

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -1,13 +1,12 @@
-// Package embed provides text-to-vector embedding via OpenAI-compatible APIs.
+// Package embed provides text-to-vector embedding via HTTP APIs and local ONNX.
 //
 // Supports multiple providers:
 // - ollama: http://localhost:11434/v1/embeddings
 // - openai: https://api.openai.com/v1/embeddings
 // - openrouter: https://openrouter.ai/api/v1/embeddings
 // - deepseek: https://api.deepseek.com/v1/embeddings
+// - onnx: local ONNX Runtime inference
 // - custom: user-specified endpoint
-//
-// All providers use the OpenAI-compatible /v1/embeddings format for consistency.
 package embed
 
 import (
@@ -35,13 +34,18 @@ type Embedder interface {
 
 // EmbedConfig holds embedding provider configuration.
 type EmbedConfig struct {
-	Provider    string // "ollama", "openai", "deepseek", "openrouter", "custom"
-	Model       string // model name
-	Endpoint    string // full API URL
-	APIKey      string
-	MaxRetries  int // default: 3
-	TimeoutSecs int // per-request timeout (default: 60)
-	dimensions  int // auto-detected on first call
+	Provider       string // "ollama", "openai", "deepseek", "openrouter", "onnx", "custom"
+	Model          string // model name
+	Endpoint       string // full API URL
+	APIKey         string
+	MaxRetries     int // default: 3
+	TimeoutSecs    int // per-request timeout (default: 60)
+	ResolvedFrom   string
+	ResolvedDetail string
+	ModelPath      string
+	Local          bool
+	WillDownload   bool
+	dimensions     int // auto-detected on first call
 }
 
 // EmbedRequest represents an OpenAI-compatible embeddings request.
@@ -167,7 +171,7 @@ func ParseEmbedFlag(flag string) (*EmbedConfig, error) {
 		return nil, fmt.Errorf("invalid --embed format: expected 'provider/model', got %q", flag)
 	}
 
-	provider := flag[:slashIdx]
+	provider := strings.ToLower(flag[:slashIdx])
 	model := flag[slashIdx+1:]
 
 	if provider == "" {
@@ -198,12 +202,26 @@ func ParseEmbedFlag(flag string) (*EmbedConfig, error) {
 	case "openrouter":
 		config.Endpoint = "https://openrouter.ai/api/v1/embeddings"
 		config.APIKey = os.Getenv("OPENROUTER_API_KEY")
+	case "onnx":
+		spec, err := ResolveONNXModelSpec(model)
+		if err != nil {
+			return nil, err
+		}
+		files, err := ResolveONNXModelFiles(spec)
+		if err != nil {
+			return nil, err
+		}
+		config.Model = spec.Key
+		config.ModelPath = files.ModelPath
+		config.Local = true
+		config.WillDownload = !ONNXModelReady(files)
+		config.dimensions = spec.Dimensions
 	case "custom":
 		// Custom provider - user must set endpoint and key via env vars
 		config.Endpoint = os.Getenv("CORTEX_EMBED_ENDPOINT")
 		config.APIKey = os.Getenv("CORTEX_EMBED_API_KEY")
 	default:
-		return nil, fmt.Errorf("unknown provider %q. Supported: ollama, openai, deepseek, openrouter, custom", provider)
+		return nil, fmt.Errorf("unknown provider %q. Supported: ollama, onnx, openai, deepseek, openrouter, custom", provider)
 	}
 
 	// Only apply generic overrides for custom provider (other providers have their own env vars)
@@ -233,53 +251,6 @@ func NewEmbedConfig(providerModel string) (*EmbedConfig, error) {
 	return ParseEmbedFlag(providerModel)
 }
 
-// ResolveEmbedConfig resolves configuration from all sources.
-// Priority: config file < env vars < CLI flag
-func ResolveEmbedConfig(cliFlag string) (*EmbedConfig, error) {
-	resolved, err := cfgresolver.ResolveConfig(cfgresolver.ResolveOptions{CLIEmbed: cliFlag})
-	if err != nil {
-		return nil, err
-	}
-
-	flag := strings.TrimSpace(cliFlag)
-	if flag == "" {
-		flag = strings.TrimSpace(resolved.EmbedProvider.Value)
-	}
-	if flag == "" {
-		return nil, nil // No embedding configuration found
-	}
-
-	if !strings.Contains(flag, "/") {
-		// Provider-only entry in config/env; use sensible defaults.
-		switch strings.ToLower(flag) {
-		case "ollama":
-			flag = "ollama/nomic-embed-text"
-		case "openrouter":
-			flag = "openrouter/text-embedding-3-small"
-		case "openai":
-			flag = "openai/text-embedding-3-small"
-		case "deepseek":
-			flag = "deepseek/deepseek-embedding"
-		}
-	}
-
-	config, err := ParseEmbedFlag(flag)
-	if err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(config.APIKey) == "" {
-		if strings.TrimSpace(resolved.EmbedAPIKey.Value) != "" {
-			config.APIKey = resolved.EmbedAPIKey.Value
-		} else if rv := resolved.APIKeyForProvider(config.Provider); strings.TrimSpace(rv.Value) != "" {
-			config.APIKey = rv.Value
-		}
-	}
-	if strings.TrimSpace(resolved.EmbedEndpoint.Value) != "" {
-		config.Endpoint = resolved.EmbedEndpoint.Value
-	}
-	return config, nil
-}
-
 // Validate checks if the embedding configuration is valid and complete.
 func (c *EmbedConfig) Validate() error {
 	if c.Provider == "" {
@@ -288,12 +259,12 @@ func (c *EmbedConfig) Validate() error {
 	if c.Model == "" {
 		return fmt.Errorf("model is required")
 	}
-	if c.Endpoint == "" {
+	if c.Provider != "onnx" && c.Provider != "test" && c.Endpoint == "" {
 		return fmt.Errorf("endpoint is required")
 	}
 
 	// API key validation (except for Ollama and test providers which don't need one)
-	if c.Provider != "ollama" && c.Provider != "test" && c.APIKey == "" {
+	if c.Provider != "ollama" && c.Provider != "onnx" && c.Provider != "test" && c.APIKey == "" {
 		return fmt.Errorf("API key is required for provider %q (set via environment variable)", c.Provider)
 	}
 
@@ -308,13 +279,16 @@ func (c *EmbedConfig) Validate() error {
 }
 
 // NewClient creates a new embedding client with the given configuration.
-func NewClient(config *EmbedConfig) (*Client, error) {
+func NewClient(config *EmbedConfig) (Embedder, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config is required")
 	}
 
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+	if config.Provider == "onnx" {
+		return NewONNXEmbedder(config)
 	}
 
 	transport := &http.Transport{

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -52,6 +52,16 @@ func TestParseEmbedFlag(t *testing.T) {
 			},
 		},
 		{
+			name: "onnx all-minilm",
+			flag: "onnx/all-minilm-l6-v2",
+			want: &EmbedConfig{
+				Provider:    "onnx",
+				Model:       "all-minilm-l6-v2",
+				MaxRetries:  3,
+				TimeoutSecs: 60,
+			},
+		},
+		{
 			name:    "empty flag",
 			flag:    "",
 			wantErr: true,
@@ -132,6 +142,16 @@ func TestEmbedConfig_Validate(t *testing.T) {
 				Model:       "text-embedding-3-small",
 				Endpoint:    "https://api.openai.com/v1/embeddings",
 				APIKey:      "sk-test",
+				MaxRetries:  3,
+				TimeoutSecs: 60,
+			},
+			want: true,
+		},
+		{
+			name: "valid onnx",
+			config: EmbedConfig{
+				Provider:    "onnx",
+				Model:       "all-minilm-l6-v2",
 				MaxRetries:  3,
 				TimeoutSecs: 60,
 			},
@@ -672,30 +692,38 @@ func TestEmbed_OpenAIProvider(t *testing.T) {
 	}
 }
 
-// TestResolveEmbedConfig_NoConfigReturnsNil verifies that when no config file or
-// env var provides an embed provider, ResolveEmbedConfig("") returns nil without error.
-// This is the base case for hybrid auto-resolve: if nil, fall back gracefully.
-func TestResolveEmbedConfig_NoConfigReturnsNil(t *testing.T) {
-	// Isolate from the caller's real ~/.cortex/config.yaml and env.
+func TestResolveEmbedConfig_AutoDetectsONNXFallback(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CORTEX_EMBED", "")
 	t.Setenv("CORTEX_EMBED_ENDPOINT", "")
 	t.Setenv("CORTEX_EMBED_API_KEY", "")
+	t.Setenv("CORTEX_DISABLE_OLLAMA_AUTODETECT", "1")
 
 	cfg, err := ResolveEmbedConfig("")
 	if err != nil {
-		t.Fatalf("ResolveEmbedConfig with no config should not error, got: %v", err)
+		t.Fatalf("ResolveEmbedConfig should not error, got: %v", err)
 	}
-	if cfg != nil {
-		t.Errorf("ResolveEmbedConfig with no config should return nil, got: %+v", cfg)
+	if cfg == nil {
+		t.Fatal("ResolveEmbedConfig should auto-detect ONNX, got nil")
+	}
+	if cfg.Provider != "onnx" {
+		t.Fatalf("expected provider onnx, got %q", cfg.Provider)
+	}
+	if cfg.Model != "all-minilm-l6-v2" {
+		t.Fatalf("expected model all-minilm-l6-v2, got %q", cfg.Model)
+	}
+	if cfg.ResolvedFrom != "auto-detected" {
+		t.Fatalf("expected auto-detected source, got %q", cfg.ResolvedFrom)
+	}
+	if cfg.ModelPath == "" {
+		t.Fatal("expected ONNX model path to be populated")
 	}
 }
 
-// TestResolveEmbedConfig_EnvVarResolution verifies that CORTEX_EMBED env var is
-// picked up when no CLI flag is passed — the mechanism hybrid auto-resolve relies on.
 func TestResolveEmbedConfig_EnvVarResolution(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CORTEX_EMBED", "ollama/nomic-embed-text")
+	t.Setenv("CORTEX_DISABLE_OLLAMA_AUTODETECT", "1")
 
 	cfg, err := ResolveEmbedConfig("")
 	if err != nil {

--- a/internal/embed/onnx_disabled.go
+++ b/internal/embed/onnx_disabled.go
@@ -1,0 +1,9 @@
+//go:build !cgo
+
+package embed
+
+import "fmt"
+
+func NewONNXEmbedder(cfg *EmbedConfig) (Embedder, error) {
+	return nil, fmt.Errorf("%w: cortex was built without cgo support", ErrORTUnavailable)
+}

--- a/internal/embed/onnx_enabled.go
+++ b/internal/embed/onnx_enabled.go
@@ -1,0 +1,392 @@
+//go:build cgo
+
+package embed
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/sugarme/tokenizer"
+	"github.com/sugarme/tokenizer/pretrained"
+	ort "github.com/yalue/onnxruntime_go"
+)
+
+var (
+	embedORTInitOnce sync.Once
+	embedORTInitErr  error
+)
+
+type onnxEmbedder struct {
+	name         string
+	spec         ONNXModelSpec
+	files        ONNXModelFiles
+	tokenizer    *tokenizer.Tokenizer
+	session      *ort.DynamicAdvancedSession
+	batchSize    int
+	maxSeqLen    int
+	padTokenID   int64
+	sessionMutex sync.Mutex
+}
+
+func NewONNXEmbedder(cfg *EmbedConfig) (Embedder, error) {
+	spec, err := ResolveONNXModelSpec(cfg.Model)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := EnsureONNXModel(context.Background(), spec)
+	if err != nil {
+		return nil, err
+	}
+
+	libPath := strings.TrimSpace(DetectORTLibraryPath())
+	if libPath == "" {
+		return nil, fmt.Errorf("%w: set ONNXRUNTIME_SHARED_LIBRARY_PATH or install the shared library", ErrORTUnavailable)
+	}
+	if err := ensureORTEnvironment(libPath); err != nil {
+		return nil, err
+	}
+
+	tok, err := pretrained.FromFile(files.TokenizerPath)
+	if err != nil {
+		return nil, fmt.Errorf("load embed tokenizer: %w", err)
+	}
+	tok.WithPadding(nil)
+	tok.WithTruncation(&tokenizer.TruncationParams{
+		MaxLength: spec.MaxSequenceLen,
+		Strategy:  tokenizer.LongestFirst,
+		Stride:    0,
+	})
+
+	sessionOptions, err := ort.NewSessionOptions()
+	if err != nil {
+		return nil, fmt.Errorf("create onnx session options: %w", err)
+	}
+	defer sessionOptions.Destroy()
+
+	_ = sessionOptions.SetGraphOptimizationLevel(ort.GraphOptimizationLevelEnableAll)
+	_ = sessionOptions.SetExecutionMode(ort.ExecutionModeSequential)
+	threads := minInt(runtime.NumCPU(), 4)
+	if threads < 1 {
+		threads = 1
+	}
+	_ = sessionOptions.SetIntraOpNumThreads(threads)
+	_ = sessionOptions.SetInterOpNumThreads(1)
+
+	session, err := ort.NewDynamicAdvancedSession(
+		files.ModelPath,
+		[]string{"input_ids", "attention_mask", "token_type_ids"},
+		[]string{"last_hidden_state"},
+		sessionOptions,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load embed model: %w", err)
+	}
+
+	padTokenID := int64(0)
+	if id, ok := tok.TokenToId("[PAD]"); ok {
+		padTokenID = int64(id)
+	} else if id, ok := tok.TokenToId("<pad>"); ok {
+		padTokenID = int64(id)
+	}
+
+	cfg.Model = spec.Key
+	cfg.ModelPath = files.ModelPath
+	cfg.Local = true
+	cfg.WillDownload = false
+	cfg.dimensions = spec.Dimensions
+
+	return &onnxEmbedder{
+		name:       spec.DisplayName,
+		spec:       spec,
+		files:      files,
+		tokenizer:  tok,
+		session:    session,
+		batchSize:  32,
+		maxSeqLen:  spec.MaxSequenceLen,
+		padTokenID: padTokenID,
+	}, nil
+}
+
+func (o *onnxEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	if strings.TrimSpace(text) == "" {
+		return nil, fmt.Errorf("empty text")
+	}
+	embeddings, err := o.EmbedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) != 1 {
+		return nil, fmt.Errorf("expected 1 embedding, got %d", len(embeddings))
+	}
+	return embeddings[0], nil
+}
+
+func (o *onnxEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	nonEmptyTexts := make([]string, 0, len(texts))
+	indexMap := make([]int, 0, len(texts))
+	for i, text := range texts {
+		if strings.TrimSpace(text) != "" {
+			nonEmptyTexts = append(nonEmptyTexts, text)
+			indexMap = append(indexMap, i)
+		}
+	}
+	if len(nonEmptyTexts) == 0 {
+		return make([][]float32, len(texts)), nil
+	}
+
+	nonEmptyEmbeddings := make([][]float32, 0, len(nonEmptyTexts))
+	for start := 0; start < len(nonEmptyTexts); start += o.batchSize {
+		end := start + o.batchSize
+		if end > len(nonEmptyTexts) {
+			end = len(nonEmptyTexts)
+		}
+		batchEmbeddings, err := o.embedBatch(ctx, nonEmptyTexts[start:end])
+		if err != nil {
+			return nil, err
+		}
+		nonEmptyEmbeddings = append(nonEmptyEmbeddings, batchEmbeddings...)
+	}
+
+	result := make([][]float32, len(texts))
+	for i, embedding := range nonEmptyEmbeddings {
+		if i < len(indexMap) {
+			result[indexMap[i]] = embedding
+		}
+	}
+	return result, nil
+}
+
+func (o *onnxEmbedder) Dimensions() int {
+	return o.spec.Dimensions
+}
+
+func (o *onnxEmbedder) HealthCheck(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if o == nil || o.session == nil || o.tokenizer == nil {
+		return fmt.Errorf("onnx embedder not initialized")
+	}
+	return nil
+}
+
+func (o *onnxEmbedder) Close() error {
+	if o == nil || o.session == nil {
+		return nil
+	}
+	return o.session.Destroy()
+}
+
+func (o *onnxEmbedder) embedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	encodings := make([]*tokenizer.Encoding, 0, len(texts))
+	maxLen := 1
+	for _, text := range texts {
+		encoding, err := o.tokenizer.EncodeSingle(strings.TrimSpace(text), true)
+		if err != nil {
+			return nil, fmt.Errorf("encode text: %w", err)
+		}
+		if encoding.Len() > o.maxSeqLen {
+			if _, err := encoding.Truncate(o.maxSeqLen, 0); err != nil {
+				return nil, fmt.Errorf("truncate embed tokens: %w", err)
+			}
+		}
+		if encoding.Len() > maxLen {
+			maxLen = encoding.Len()
+		}
+		encodings = append(encodings, encoding)
+	}
+
+	idsData := make([]int64, len(texts)*maxLen)
+	maskData := make([]int64, len(texts)*maxLen)
+	typeData := make([]int64, len(texts)*maxLen)
+	for i := range idsData {
+		idsData[i] = o.padTokenID
+	}
+
+	for row, encoding := range encodings {
+		ids := encoding.GetIds()
+		mask := encoding.GetAttentionMask()
+		typeIDs := encoding.GetTypeIds()
+		for col, id := range ids {
+			offset := row*maxLen + col
+			idsData[offset] = int64(id)
+		}
+		for col, value := range mask {
+			offset := row*maxLen + col
+			maskData[offset] = int64(value)
+		}
+		for col, value := range typeIDs {
+			offset := row*maxLen + col
+			typeData[offset] = int64(value)
+		}
+	}
+
+	inputShape := ort.NewShape(int64(len(texts)), int64(maxLen))
+	inputIDs, err := ort.NewTensor(inputShape, idsData)
+	if err != nil {
+		return nil, fmt.Errorf("create input_ids tensor: %w", err)
+	}
+	defer inputIDs.Destroy()
+
+	attentionMask, err := ort.NewTensor(inputShape, maskData)
+	if err != nil {
+		return nil, fmt.Errorf("create attention_mask tensor: %w", err)
+	}
+	defer attentionMask.Destroy()
+
+	tokenTypeIDs, err := ort.NewTensor(inputShape, typeData)
+	if err != nil {
+		return nil, fmt.Errorf("create token_type_ids tensor: %w", err)
+	}
+	defer tokenTypeIDs.Destroy()
+
+	outputs := []ort.Value{nil}
+	o.sessionMutex.Lock()
+	err = o.session.Run([]ort.Value{inputIDs, attentionMask, tokenTypeIDs}, outputs)
+	o.sessionMutex.Unlock()
+	if err != nil {
+		return nil, fmt.Errorf("run embed session: %w", err)
+	}
+	defer func() {
+		for _, output := range outputs {
+			if output != nil {
+				_ = output.Destroy()
+			}
+		}
+	}()
+
+	hiddenState, ok := outputs[0].(*ort.Tensor[float32])
+	if !ok {
+		return nil, fmt.Errorf("unexpected embed output type %T", outputs[0])
+	}
+
+	shape := hiddenState.GetShape()
+	if len(shape) != 3 {
+		return nil, fmt.Errorf("unexpected embed output shape %v", shape)
+	}
+	if int(shape[0]) != len(texts) {
+		return nil, fmt.Errorf("unexpected embed batch size %d", shape[0])
+	}
+
+	hiddenSize := int(shape[2])
+	if hiddenSize != o.spec.Dimensions {
+		return nil, fmt.Errorf("unexpected embed hidden size %d", hiddenSize)
+	}
+
+	return meanPoolAndNormalize(hiddenState.GetData(), maskData, len(texts), maxLen, hiddenSize), nil
+}
+
+func meanPoolAndNormalize(hiddenState []float32, attentionMask []int64, batchSize, seqLen, dims int) [][]float32 {
+	embeddings := make([][]float32, 0, batchSize)
+	for row := 0; row < batchSize; row++ {
+		embedding := make([]float32, dims)
+		tokenCount := float64(0)
+		for col := 0; col < seqLen; col++ {
+			if attentionMask[row*seqLen+col] == 0 {
+				continue
+			}
+			base := (row*seqLen + col) * dims
+			for i := 0; i < dims; i++ {
+				embedding[i] += hiddenState[base+i]
+			}
+			tokenCount++
+		}
+		if tokenCount > 0 {
+			inv := float32(1.0 / tokenCount)
+			for i := range embedding {
+				embedding[i] *= inv
+			}
+		}
+		normalizeVector(embedding)
+		embeddings = append(embeddings, embedding)
+	}
+	return embeddings
+}
+
+func normalizeVector(v []float32) {
+	var sum float64
+	for _, value := range v {
+		sum += float64(value * value)
+	}
+	if sum == 0 {
+		return
+	}
+	scale := float32(1.0 / math.Sqrt(sum))
+	for i := range v {
+		v[i] *= scale
+	}
+}
+
+func ensureORTEnvironment(libPath string) error {
+	embedORTInitOnce.Do(func() {
+		ort.SetSharedLibraryPath(libPath)
+		embedORTInitErr = ort.InitializeEnvironment(ort.WithLogLevelWarning())
+	})
+	if embedORTInitErr != nil {
+		return fmt.Errorf("%w: %v", ErrORTUnavailable, embedORTInitErr)
+	}
+	return nil
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func DetectORTLibraryPath() string {
+	candidates := make([]string, 0, 8)
+	for _, envKey := range []string{"CORTEX_ONNXRUNTIME_PATH", "ONNXRUNTIME_SHARED_LIBRARY_PATH"} {
+		if value := strings.TrimSpace(os.Getenv(envKey)); value != "" {
+			candidates = append(candidates, value)
+		}
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = append(candidates,
+			"/usr/local/lib/libonnxruntime.dylib",
+			"/usr/local/opt/onnxruntime/lib/libonnxruntime.dylib",
+			"/opt/homebrew/lib/libonnxruntime.dylib",
+			"/opt/homebrew/opt/onnxruntime/lib/libonnxruntime.dylib",
+		)
+	case "linux":
+		candidates = append(candidates,
+			"/usr/lib/libonnxruntime.so",
+			"/usr/lib/libonnxruntime.so.1.24.1",
+			"/usr/local/lib/libonnxruntime.so",
+			"/usr/local/lib/libonnxruntime.so.1.24.1",
+		)
+	case "windows":
+		candidates = append(candidates, `C:\onnxruntime\onnxruntime.dll`)
+	}
+
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}

--- a/internal/embed/onnx_model.go
+++ b/internal/embed/onnx_model.go
@@ -1,0 +1,190 @@
+package embed
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const defaultModelHTTPTimeout = 10 * time.Minute
+
+var ErrORTUnavailable = fmt.Errorf("onnx runtime unavailable")
+
+type ONNXModelSpec struct {
+	Key            string
+	DisplayName    string
+	Repo           string
+	RemoteModel    string
+	RemoteFiles    map[string]string
+	Dimensions     int
+	MaxSequenceLen int
+	SpeedHint      string
+}
+
+type ONNXModelFiles struct {
+	Dir                 string
+	ModelPath           string
+	TokenizerPath       string
+	ConfigPath          string
+	TokenizerConfigPath string
+	SpecialTokensPath   string
+}
+
+func DefaultONNXModelSpec() ONNXModelSpec {
+	return ONNXModelSpec{
+		Key:         "all-minilm-l6-v2",
+		DisplayName: "onnx/all-minilm-l6-v2",
+		Repo:        "Xenova/all-MiniLM-L6-v2",
+		RemoteModel: "onnx/model_int8.onnx",
+		RemoteFiles: map[string]string{
+			"tokenizer.json":          "tokenizer.json",
+			"config.json":             "config.json",
+			"tokenizer_config.json":   "tokenizer_config.json",
+			"special_tokens_map.json": "special_tokens_map.json",
+		},
+		Dimensions:     384,
+		MaxSequenceLen: 128,
+		SpeedHint:      "~7 emb/s",
+	}
+}
+
+func ResolveONNXModelSpec(raw string) (ONNXModelSpec, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "all-minilm", "all-minilm-l6-v2", "sentence-transformers/all-minilm-l6-v2":
+		return DefaultONNXModelSpec(), nil
+	default:
+		return ONNXModelSpec{}, fmt.Errorf("unknown onnx embedding model %q (valid: all-minilm-l6-v2)", raw)
+	}
+}
+
+func defaultEmbedModelsRoot() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cortex", "models", "embed"), nil
+}
+
+func ResolveONNXModelFiles(spec ONNXModelSpec) (ONNXModelFiles, error) {
+	root, err := defaultEmbedModelsRoot()
+	if err != nil {
+		return ONNXModelFiles{}, err
+	}
+	dir := filepath.Join(root, spec.Key)
+	return ONNXModelFiles{
+		Dir:                 dir,
+		ModelPath:           filepath.Join(dir, "model.onnx"),
+		TokenizerPath:       filepath.Join(dir, "tokenizer.json"),
+		ConfigPath:          filepath.Join(dir, "config.json"),
+		TokenizerConfigPath: filepath.Join(dir, "tokenizer_config.json"),
+		SpecialTokensPath:   filepath.Join(dir, "special_tokens_map.json"),
+	}, nil
+}
+
+func ONNXModelReady(files ONNXModelFiles) bool {
+	required := []string{
+		files.ModelPath,
+		files.TokenizerPath,
+	}
+	for _, path := range required {
+		info, err := os.Stat(path)
+		if err != nil || info.Size() == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func EnsureONNXModel(ctx context.Context, spec ONNXModelSpec) (ONNXModelFiles, error) {
+	files, err := ResolveONNXModelFiles(spec)
+	if err != nil {
+		return ONNXModelFiles{}, err
+	}
+	if ONNXModelReady(files) {
+		return files, nil
+	}
+	if err := os.MkdirAll(files.Dir, 0o755); err != nil {
+		return ONNXModelFiles{}, fmt.Errorf("creating embed model dir: %w", err)
+	}
+
+	client := &http.Client{Timeout: defaultModelHTTPTimeout}
+	targets := map[string]string{
+		spec.RemoteModel: files.ModelPath,
+	}
+	for remote, localName := range spec.RemoteFiles {
+		targets[remote] = resolveONNXRemotePath(files, localName)
+	}
+
+	for remote, local := range targets {
+		if err := downloadModelFile(ctx, client, hfResolveURL(spec.Repo, remote), local); err != nil {
+			return ONNXModelFiles{}, err
+		}
+	}
+
+	return files, nil
+}
+
+func resolveONNXRemotePath(files ONNXModelFiles, localName string) string {
+	switch filepath.Base(localName) {
+	case "tokenizer.json":
+		return files.TokenizerPath
+	case "config.json":
+		return files.ConfigPath
+	case "tokenizer_config.json":
+		return files.TokenizerConfigPath
+	case "special_tokens_map.json":
+		return files.SpecialTokensPath
+	default:
+		return filepath.Join(files.Dir, filepath.Base(localName))
+	}
+}
+
+func hfResolveURL(repo, path string) string {
+	return fmt.Sprintf("https://huggingface.co/%s/resolve/main/%s", repo, path)
+}
+
+func downloadModelFile(ctx context.Context, client *http.Client, url, dest string) error {
+	if info, err := os.Stat(dest); err == nil && info.Size() > 0 {
+		return nil
+	}
+
+	tmp := dest + ".tmp"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build download request for %s: %w", url, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: unexpected HTTP %d", url, resp.StatusCode)
+	}
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create temp file for %s: %w", dest, err)
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write %s: %w", dest, err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close %s: %w", dest, err)
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename %s: %w", dest, err)
+	}
+	return nil
+}

--- a/internal/embed/resolve.go
+++ b/internal/embed/resolve.go
@@ -1,0 +1,242 @@
+package embed
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	cfgresolver "github.com/hurttlocker/cortex/internal/config"
+)
+
+const ollamaDetectTimeout = 750 * time.Millisecond
+
+type ollamaTagsResponse struct {
+	Models []struct {
+		Name  string `json:"name"`
+		Model string `json:"model"`
+	} `json:"models"`
+}
+
+// ResolveEmbedConfig resolves configuration from all sources.
+//
+// Resolution order:
+// 1. Explicit CLI/config/env provider
+// 2. Ollama running with an embedding model available
+// 3. Local ONNX model already downloaded
+// 4. Built-in ONNX fallback (auto-downloads on first use)
+func ResolveEmbedConfig(cliFlag string) (*EmbedConfig, error) {
+	resolved, err := cfgresolver.ResolveConfig(cfgresolver.ResolveOptions{CLIEmbed: cliFlag})
+	if err != nil {
+		return nil, err
+	}
+
+	flag := strings.TrimSpace(cliFlag)
+	if flag != "" {
+		return parseResolvedEmbedFlag(flag, &resolved, "explicit", "CLI flag")
+	}
+
+	if explicit := strings.TrimSpace(resolved.EmbedProvider.Value); explicit != "" {
+		from := strings.TrimSpace(resolved.EmbedProvider.From)
+		if from == "" {
+			from = string(resolved.EmbedProvider.Source)
+		}
+		return parseResolvedEmbedFlag(explicit, &resolved, "explicit", fmt.Sprintf("from %s", from))
+	}
+
+	if model, detail, ok := detectOllamaEmbedModel(); ok {
+		cfg, err := ParseEmbedFlag("ollama/" + model)
+		if err != nil {
+			return nil, err
+		}
+		cfg.ResolvedFrom = "auto-detected"
+		cfg.ResolvedDetail = detail
+		return cfg, nil
+	}
+
+	spec := DefaultONNXModelSpec()
+	cfg, err := ParseEmbedFlag("onnx/" + spec.Key)
+	if err != nil {
+		return nil, err
+	}
+	cfg.ResolvedFrom = "auto-detected"
+	if cfg.WillDownload {
+		cfg.ResolvedDetail = "no Ollama embed model found, downloading built-in ONNX on first use"
+	} else {
+		cfg.ResolvedDetail = "no Ollama embed model found, using built-in ONNX"
+	}
+	return cfg, nil
+}
+
+func parseResolvedEmbedFlag(flag string, resolved *cfgresolver.ResolvedConfig, source, detail string) (*EmbedConfig, error) {
+	flag = normalizeEmbedFlag(flag)
+	config, err := ParseEmbedFlag(flag)
+	if err != nil {
+		return nil, err
+	}
+	config.ResolvedFrom = source
+	config.ResolvedDetail = detail
+
+	if resolved == nil {
+		return config, nil
+	}
+	if strings.TrimSpace(config.APIKey) == "" {
+		if strings.TrimSpace(resolved.EmbedAPIKey.Value) != "" {
+			config.APIKey = resolved.EmbedAPIKey.Value
+		} else if rv := resolved.APIKeyForProvider(config.Provider); strings.TrimSpace(rv.Value) != "" {
+			config.APIKey = rv.Value
+		}
+	}
+	if config.Provider != "onnx" && strings.TrimSpace(resolved.EmbedEndpoint.Value) != "" {
+		config.Endpoint = resolved.EmbedEndpoint.Value
+	}
+	return config, nil
+}
+
+func normalizeEmbedFlag(flag string) string {
+	flag = strings.TrimSpace(flag)
+	if strings.Contains(flag, "/") {
+		return flag
+	}
+	switch strings.ToLower(flag) {
+	case "ollama":
+		return "ollama/all-minilm"
+	case "onnx":
+		return "onnx/all-minilm-l6-v2"
+	case "openrouter":
+		return "openrouter/text-embedding-3-small"
+	case "openai":
+		return "openai/text-embedding-3-small"
+	case "deepseek":
+		return "deepseek/deepseek-embedding"
+	default:
+		return flag
+	}
+}
+
+func detectOllamaEmbedModel() (string, string, bool) {
+	models, err := listOllamaModels()
+	if err != nil || len(models) == 0 {
+		return "", "", false
+	}
+
+	preferred := []string{"all-minilm", "nomic-embed-text", "mxbai-embed-large"}
+	for _, want := range preferred {
+		for _, model := range models {
+			if canonicalOllamaModelName(model) == want {
+				return model, fmt.Sprintf("Ollama detected with %s", model), true
+			}
+		}
+	}
+
+	sort.Strings(models)
+	for _, model := range models {
+		if looksLikeOllamaEmbedModel(model) {
+			return model, fmt.Sprintf("Ollama detected with %s", model), true
+		}
+	}
+
+	return "", "", false
+}
+
+func listOllamaModels() ([]string, error) {
+	if strings.TrimSpace(os.Getenv("CORTEX_DISABLE_OLLAMA_AUTODETECT")) == "1" {
+		return nil, fmt.Errorf("ollama autodetect disabled")
+	}
+
+	client := &http.Client{Timeout: ollamaDetectTimeout}
+	resp, err := client.Get("http://localhost:11434/api/tags")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ollama tags returned HTTP %d", resp.StatusCode)
+	}
+
+	var payload ollamaTagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	unique := make(map[string]struct{}, len(payload.Models))
+	for _, model := range payload.Models {
+		name := strings.TrimSpace(model.Name)
+		if name == "" {
+			name = strings.TrimSpace(model.Model)
+		}
+		if name == "" {
+			continue
+		}
+		unique[name] = struct{}{}
+	}
+
+	models := make([]string, 0, len(unique))
+	for model := range unique {
+		models = append(models, model)
+	}
+	return models, nil
+}
+
+func canonicalOllamaModelName(model string) string {
+	model = strings.TrimSpace(strings.ToLower(model))
+	tagIdx := strings.LastIndex(model, ":")
+	if tagIdx > strings.LastIndex(model, "/") {
+		model = model[:tagIdx]
+	}
+	return model
+}
+
+func looksLikeOllamaEmbedModel(model string) bool {
+	base := canonicalOllamaModelName(model)
+	for _, token := range []string{"embed", "minilm", "bge", "e5", "gte", "jina"} {
+		if strings.Contains(base, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func ExpectedDimensions(cfg *EmbedConfig) int {
+	if cfg == nil {
+		return 0
+	}
+	if cfg.dimensions > 0 {
+		return cfg.dimensions
+	}
+	switch cfg.Provider {
+	case "onnx":
+		spec, err := ResolveONNXModelSpec(cfg.Model)
+		if err == nil {
+			return spec.Dimensions
+		}
+	case "ollama":
+		switch canonicalOllamaModelName(cfg.Model) {
+		case "all-minilm":
+			return 384
+		case "nomic-embed-text":
+			return 768
+		case "mxbai-embed-large":
+			return 1024
+		}
+	}
+	return 0
+}
+
+func SpeedHint(cfg *EmbedConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.Provider != "onnx" {
+		return ""
+	}
+	spec, err := ResolveONNXModelSpec(cfg.Model)
+	if err != nil {
+		return ""
+	}
+	return spec.SpeedHint
+}

--- a/internal/ingest/import_keepdrop_gate.go
+++ b/internal/ingest/import_keepdrop_gate.go
@@ -184,13 +184,13 @@ func augmentImportQualityText(raw RawMemory, memoryClass string) string {
 }
 
 var (
-	importPositivePathRE = regexp.MustCompile(`(?i)(readme|memory|decision|rule|prd|docs/|design|spec|architecture|roadmap)`)
-	importNegativePathRE = regexp.MustCompile(`(?i)(/logs?/|/tmp/|/cache/|/node_modules/|/target/|\.log$|\.tmp$|\.out$)`)
-	importLowSignalAckRE = regexp.MustCompile(`(?i)\b(?:got it|sounds good|thank you|thanks!|okay|ok|cool|awesome|roger|copy that|noted)\b`)
-	importCLICommandRE  = regexp.MustCompile(`(?i)\b(?:git|go|cortex|openclaw|npm|python3|pip|ollama|gh)\b`)
-	importOpsKeywordRE  = regexp.MustCompile(`(?i)\b(?:gateway|restart|status|import|search|test|build|push|pull|deploy|alert|maintenance|db_size_high)\b`)
+	importPositivePathRE     = regexp.MustCompile(`(?i)(readme|memory|decision|rule|prd|docs/|design|spec|architecture|roadmap)`)
+	importNegativePathRE     = regexp.MustCompile(`(?i)(/logs?/|/tmp/|/cache/|/node_modules/|/target/|\.log$|\.tmp$|\.out$)`)
+	importLowSignalAckRE     = regexp.MustCompile(`(?i)\b(?:got it|sounds good|thank you|thanks!|okay|ok|cool|awesome|roger|copy that|noted)\b`)
+	importCLICommandRE       = regexp.MustCompile(`(?i)\b(?:git|go|cortex|openclaw|npm|python3|pip|ollama|gh)\b`)
+	importOpsKeywordRE       = regexp.MustCompile(`(?i)\b(?:gateway|restart|status|import|search|test|build|push|pull|deploy|alert|maintenance|db_size_high)\b`)
 	importEndpointOrConfigRE = regexp.MustCompile(`(?i)(?:/[a-z0-9._~!$&'()*+,;=:@%/-]+|[A-Z_]{3,}=)`)
-	importProtocolNoiseRE = regexp.MustCompile(
+	importProtocolNoiseRE    = regexp.MustCompile(
 		`(?i)\b(?:heartbeat|status: ok|health check|ping|pong|keepalive|session started|session ended|connected|disconnected|retrying|ws_token|bearer token|http 200|http 201|trace_id|request_id)\b`,
 	)
 )


### PR DESCRIPTION
Closes #360
Closes #361

## What changed

- adds `onnx/all-minilm-l6-v2` as a native embed provider in the Cortex embed pipeline
- auto-downloads the local ONNX model and tokenizer into `~/.cortex/models/embed/all-minilm-l6-v2/`
- adds embedder auto-resolution in this order: explicit config, Ollama with an embed model, local ONNX, ONNX auto-download fallback
- wires the resolved embedder into `cortex embed`, `search`, `ask`, `answer`, the background embed worker, `cortex embed --status`, and `cortex doctor`
- adds local embedder status reporting, source reporting, model-path reporting, and stored-vs-resolved dimension mismatch reporting
- adds the benchmark note at `docs/research/onnx-embedder-benchmark-2026-03-24.md`

## Why this change exists

Cortex already had native ONNX runtime support for reranking, but embeddings were still the last external dependency. This change makes semantic memory work with zero Ollama process and zero API keys on a fresh machine while still respecting an explicit configured provider when one exists.

## Touched surfaces

- `internal/embed`
- `cmd/cortex`
- `docs/research/onnx-embedder-benchmark-2026-03-24.md`

## Tests run

- `go test ./...`

## Verification and benchmark notes

- `cortex embed --status` now reports the resolved provider, source, model path, status, and dimension compatibility
- `cortex doctor --json` now reports the resolved embedder and surfaces config/store dimension mismatches
- full ONNX live-DB re-embed result from the benchmark note:
  - `5694` memories in `69199 ms`
  - about `82.3 emb/s`
- the bounded live-DB Ollama sample observed `18` embeddings in `180s`, which projects to about `15.8h`; that is documented explicitly as an extrapolation, not a completed full pass
- direct ONNX vs Ollama all-MiniLM parity on representative live-memory excerpts showed average query-vector cosine `0.991`, average candidate-vector cosine `0.986`, and identical top-1 retrieval on `5/5` sampled queries

## Risk

- the live benchmark also surfaced a pre-existing config mismatch: the current config pointed at `ollama/nomic-embed-text` while the stored live corpus is `384d`; the new doctor/status reporting makes that visible, but users with stale explicit configs may need to re-embed
- the ONNX benchmark is a completed full pass; the Ollama benchmark is an honest bounded-sample extrapolation because the full live-DB pass was too slow to finish in the benchmark window

## Docs / release-note impact

- docs updated in the same PR with the benchmark note
- product behavior changed: yes
- benchmark / eval interpretation changed: yes
