### PR TITLE
fix: include source titles in graph exports

### DIFF
--- a/cmd/cortex/graph_subject_test.go
+++ b/cmd/cortex/graph_subject_test.go
@@ -63,7 +63,11 @@ func TestRunGraph_SubjectJSONIncludesSeedFactIDs(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	memoryID, err := s.AddMemory(ctx, &store.Memory{Content: "graph run memory", ImportedAt: time.Now().UTC()})
+	memoryID, err := s.AddMemory(ctx, &store.Memory{
+		Content:    "graph run memory",
+		SourceFile: "/vault/projects/cortex-plan.md",
+		ImportedAt: time.Now().UTC(),
+	})
 	if err != nil {
 		t.Fatalf("AddMemory: %v", err)
 	}
@@ -100,7 +104,8 @@ func TestRunGraph_SubjectJSONIncludesSeedFactIDs(t *testing.T) {
 
 	var payload struct {
 		Nodes []struct {
-			ID int64 `json:"id"`
+			ID          int64  `json:"id"`
+			SourceTitle string `json:"source_title"`
 		} `json:"nodes"`
 		Meta map[string]interface{} `json:"meta"`
 	}
@@ -120,6 +125,11 @@ func TestRunGraph_SubjectJSONIncludesSeedFactIDs(t *testing.T) {
 	}
 	if len(payload.Nodes) < 2 {
 		t.Fatalf("expected at least 2 nodes for subject graph, got %d", len(payload.Nodes))
+	}
+	for _, node := range payload.Nodes {
+		if node.SourceTitle != "cortex-plan.md" {
+			t.Fatalf("expected graph node source_title to fall back to base filename, got node %#v", node)
+		}
 	}
 }
 

--- a/cmd/cortex/main.go
+++ b/cmd/cortex/main.go
@@ -6778,13 +6778,14 @@ func runCluster(args []string) error {
 
 // graphExportNode mirrors the MCP export format for CLI output.
 type graphExportNode struct {
-	ID         int64   `json:"id"`
-	Subject    string  `json:"subject"`
-	Predicate  string  `json:"predicate"`
-	Object     string  `json:"object"`
-	Confidence float64 `json:"confidence"`
-	AgentID    string  `json:"agent_id,omitempty"`
-	FactType   string  `json:"type"`
+	ID          int64   `json:"id"`
+	Subject     string  `json:"subject"`
+	Predicate   string  `json:"predicate"`
+	Object      string  `json:"object"`
+	Confidence  float64 `json:"confidence"`
+	AgentID     string  `json:"agent_id,omitempty"`
+	FactType    string  `json:"type"`
+	SourceTitle string  `json:"source_title,omitempty"`
 }
 
 type graphExportEdge struct {
@@ -6815,6 +6816,22 @@ func runGraphExportJSON(ctx context.Context, sqlStore *store.SQLiteStore, nodes 
 	}, agentFilter)
 }
 
+func graphSourceTitle(ctx context.Context, sqlStore *store.SQLiteStore, fact *store.Fact) string {
+	if fact == nil || fact.MemoryID == 0 {
+		return ""
+	}
+	memory, err := sqlStore.GetMemory(ctx, fact.MemoryID)
+	if err != nil || memory == nil {
+		return ""
+	}
+	return search.CitationTitleForResult(search.Result{
+		Kind:          fact.FactType,
+		Content:       fact.Object,
+		SourceFile:    memory.SourceFile,
+		SourceSection: memory.SourceSection,
+	})
+}
+
 func runGraphExportJSONWithMeta(ctx context.Context, sqlStore *store.SQLiteStore, nodes []store.GraphNode, meta map[string]interface{}, agentFilter string) error {
 	if meta == nil {
 		meta = map[string]interface{}{}
@@ -6838,13 +6855,14 @@ func runGraphExportJSONWithMeta(ctx context.Context, sqlStore *store.SQLiteStore
 			seenNodes[gn.Fact.ID] = true
 			allFactIDs = append(allFactIDs, gn.Fact.ID)
 			result.Nodes = append(result.Nodes, graphExportNode{
-				ID:         gn.Fact.ID,
-				Subject:    gn.Fact.Subject,
-				Predicate:  gn.Fact.Predicate,
-				Object:     gn.Fact.Object,
-				Confidence: gn.Fact.Confidence,
-				AgentID:    gn.Fact.AgentID,
-				FactType:   gn.Fact.FactType,
+				ID:          gn.Fact.ID,
+				Subject:     gn.Fact.Subject,
+				Predicate:   gn.Fact.Predicate,
+				Object:      gn.Fact.Object,
+				Confidence:  gn.Fact.Confidence,
+				AgentID:     gn.Fact.AgentID,
+				FactType:    gn.Fact.FactType,
+				SourceTitle: graphSourceTitle(ctx, sqlStore, gn.Fact),
 			})
 		}
 		for _, e := range gn.Edges {


### PR DESCRIPTION
## What changed
- Adds `source_title` to graph JSON export nodes so graph consumers receive the same non-empty citation title fallback used by answer citations.
- Derives the title from the backing memory's section/header first, then the base source filename when `source_section` is empty.
- Adds regression coverage for subject graph JSON exports with an empty `source_section`.

## Why this change exists
Graph export consumers could not rely on a human-readable source title when a memory had no `source_section`, even though citation titles already had a shared fallback path.

## Touched surfaces
- `cmd/cortex/main.go` graph JSON export
- `cmd/cortex/graph_subject_test.go`

## Tests
- `go test ./cmd/cortex -run 'TestRunGraph_SubjectJSONIncludesSeedFactIDs|TestResolveGraphSeedFactIDsBySubject|TestRunGraph_SubjectAndFactIDMutuallyExclusive'`
- `go test ./...`
- `go vet ./...`

## Risk
Low. This adds an optional JSON field and leaves existing graph node fields unchanged.

AI-assisted implementation, reviewed locally with the test suite above.

Fixes #374
