### PR TITLE
fix: add source titles to MCP graph facts

### DIFF
--- a/internal/mcp/graph_tools.go
+++ b/internal/mcp/graph_tools.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hurttlocker/cortex/internal/search"
 	"github.com/hurttlocker/cortex/internal/store"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -24,13 +25,19 @@ const (
 )
 
 type graphExploreFact struct {
-	ID         int64   `json:"id"`
-	Subject    string  `json:"subject"`
-	Predicate  string  `json:"predicate"`
-	Object     string  `json:"object"`
-	Confidence float64 `json:"confidence"`
-	Hop        int     `json:"hop"`
-	Source     string  `json:"source"`
+	ID          int64   `json:"id"`
+	Subject     string  `json:"subject"`
+	Predicate   string  `json:"predicate"`
+	Object      string  `json:"object"`
+	Confidence  float64 `json:"confidence"`
+	Hop         int     `json:"hop"`
+	Source      string  `json:"source"`
+	SourceTitle string  `json:"source_title,omitempty"`
+}
+
+type graphMemorySource struct {
+	file    string
+	section string
 }
 
 type graphExploreEdge struct {
@@ -362,8 +369,8 @@ func buildGraphExploreResult(
 
 	facts := make([]graphExploreFact, 0, len(nodeByID))
 	for id, nv := range nodeByID {
-		source := memorySources[nv.fact.MemoryID]
-		if !matchesSourcePrefix(source, sourcePrefix) {
+		memorySource := memorySources[nv.fact.MemoryID]
+		if !matchesSourcePrefix(memorySource.file, sourcePrefix) {
 			continue
 		}
 		facts = append(facts, graphExploreFact{
@@ -373,7 +380,14 @@ func buildGraphExploreResult(
 			Object:     nv.fact.Object,
 			Confidence: nv.fact.Confidence,
 			Hop:        nv.hop,
-			Source:     source,
+			Source:     memorySource.file,
+			SourceTitle: search.CitationTitleForResult(search.Result{
+				Kind:          nv.fact.FactType,
+				Content:       nv.fact.Object,
+				SourceFile:    memorySource.file,
+				SourceSection: memorySource.section,
+				MemoryID:      nv.fact.MemoryID,
+			}),
 		})
 	}
 	sort.Slice(facts, func(i, j int) bool {
@@ -552,7 +566,7 @@ func resolveSeedFactsBySubject(ctx context.Context, db *sql.DB, subject string, 
 	return ids, rows.Err()
 }
 
-func loadMemorySourcesForNodeViews(ctx context.Context, db *sql.DB, nodes map[int64]graphNodeView) (map[int64]string, error) {
+func loadMemorySourcesForNodeViews(ctx context.Context, db *sql.DB, nodes map[int64]graphNodeView) (map[int64]graphMemorySource, error) {
 	memoryIDs := make([]int64, 0)
 	seen := make(map[int64]struct{})
 	for _, nv := range nodes {
@@ -566,7 +580,7 @@ func loadMemorySourcesForNodeViews(ctx context.Context, db *sql.DB, nodes map[in
 		memoryIDs = append(memoryIDs, nv.fact.MemoryID)
 	}
 	if len(memoryIDs) == 0 {
-		return map[int64]string{}, nil
+		return map[int64]graphMemorySource{}, nil
 	}
 
 	placeholders := make([]string, len(memoryIDs))
@@ -576,7 +590,7 @@ func loadMemorySourcesForNodeViews(ctx context.Context, db *sql.DB, nodes map[in
 		args[i] = id
 	}
 	query := fmt.Sprintf(
-		`SELECT id, COALESCE(source_file, '')
+		`SELECT id, COALESCE(source_file, ''), COALESCE(source_section, '')
 		 FROM memories
 		 WHERE id IN (%s)`,
 		strings.Join(placeholders, ","),
@@ -588,11 +602,11 @@ func loadMemorySourcesForNodeViews(ctx context.Context, db *sql.DB, nodes map[in
 	}
 	defer rows.Close()
 
-	result := make(map[int64]string, len(memoryIDs))
+	result := make(map[int64]graphMemorySource, len(memoryIDs))
 	for rows.Next() {
 		var id int64
-		var source string
-		if err := rows.Scan(&id, &source); err != nil {
+		var source graphMemorySource
+		if err := rows.Scan(&id, &source.file, &source.section); err != nil {
 			return nil, fmt.Errorf("scanning memory source: %w", err)
 		}
 		result[id] = source

--- a/internal/mcp/graph_tools_test.go
+++ b/internal/mcp/graph_tools_test.go
@@ -34,6 +34,37 @@ func TestMCPGraphExploreBySubject(t *testing.T) {
 	}
 }
 
+func TestMCPGraphExploreSourceTitleFallsBackToBaseFilename(t *testing.T) {
+	s, srv, _ := setupGraphToolServer(t)
+	defer s.Close()
+
+	result := callTool(t, srv, "graph_explore", map[string]interface{}{
+		"subject": "cortex",
+		"depth":   float64(1),
+	})
+
+	var payload graphExploreResult
+	if err := json.Unmarshal([]byte(getTextContent(t, result)), &payload); err != nil {
+		t.Fatalf("parse graph_explore result: %v", err)
+	}
+	if len(payload.Facts) == 0 {
+		t.Fatal("expected graph_explore to return facts")
+	}
+	foundReadme := false
+	for _, fact := range payload.Facts {
+		if fact.Source != "readme.md" {
+			continue
+		}
+		foundReadme = true
+		if fact.SourceTitle != "readme.md" {
+			t.Fatalf("expected source_title to fall back to base filename, got %#v", fact)
+		}
+	}
+	if !foundReadme {
+		t.Fatal("expected a fact backed by readme.md")
+	}
+}
+
 func TestMCPGraphExploreByFactID(t *testing.T) {
 	s, srv, _ := setupGraphToolServer(t)
 	defer s.Close()


### PR DESCRIPTION
## What

- add `source_title` to MCP `graph_explore` and `graph_impact` fact payloads
- derive titles through the shared `search.CitationTitleForResult` helper
- batch-load each memory's source file and section once for the export
- add MCP regression coverage for the empty-section filename fallback

## Why

MCP graph consumers currently receive only the raw `source` path, while CLI graph JSON exports also expose a human-readable source title. This brings the two graph surfaces into parity without duplicating citation-title logic.

Fixes #381

## How

The existing per-export memory lookup now selects both `source_file` and `source_section` into a map keyed by memory ID. Each graph fact uses those cached fields with `CitationTitleForResult`, preserving the existing source filter and avoiding per-fact database queries.

Touched surfaces:
- `internal/mcp/graph_tools.go`
- `internal/mcp/graph_tools_test.go`

Product behavior changed: yes, additively; MCP graph fact JSON may now include `source_title`.
Benchmark/eval interpretation changed: no.

## Testing

- [x] `go test ./internal/mcp -run 'TestMCPGraphExplore(SourceTitleFallsBackToBaseFilename|BySubject|SourceFilter)' -count=1 -v`
- [x] `go test ./internal/mcp -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `go build ./cmd/cortex/`
- [x] `python3 scripts/validate_visualizer_contract.py`
- [x] `scripts/connectivity_smoke.sh`
- [x] `git diff --check`

## Risk

Low. The field is additive and omitted when no title can be derived. Existing source filtering and result ordering are unchanged.

## AI-assisted contribution note

The implementation and test were AI-assisted. I reviewed the issue requirements, repository contribution rules, source-title helper reuse, query batching, generated diff, commit identity, and all test output listed above.

## Checklist

- [x] Unit tests added/updated
- [x] Code follows Go conventions (`gofmt`, `go vet`)
- [x] No unrelated changes included
- [x] Documentation update is not required for this additive payload parity fix
