### PR TITLE
Codex CLI integration: config.toml setup, example, docs parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cortex import ~/notes/ --recursive --extract
 # 3. Search your knowledge
 cortex search "what did I decide about the API design"
 
-# 4. Connect to your agent (Claude Code, Cursor, Windsurf, etc.)
+# 4. Connect to your agent (Claude Code, Codex CLI, Cursor, Windsurf, etc.)
 claude mcp add cortex -- cortex mcp
 ```
 
@@ -191,7 +191,7 @@ Session ledger (agents') ─→ propose scan ──→ YOU accept/dismiss ──
 | **Connectors** | GitHub, Gmail, Calendar, Drive, Slack, Discord, Telegram, Notion. Import + extract facts in one step. |
 | **Provenance** | Every fact tracks source file, line, section, timestamp. Full audit trail. |
 | **Export** | JSON, Markdown, CSV. Your memory is yours. No lock-in. |
-| **MCP server** | `cortex mcp` — stdio or HTTP. Works with Claude Code, Cursor, any MCP client. |
+| **MCP server** | `cortex mcp` — stdio or HTTP. Works with Claude Code, Codex CLI, Cursor, any MCP client. |
 
 ## vs. alternatives
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,10 +153,10 @@ Imports data from external services into the standard pipeline.
 Model Context Protocol server for agent integration.
 
 - **Transport**: stdio (default) or HTTP+SSE (`--port`)
-- **17 tools**: Search, import, facts, stats, stale, reinforce, reason, edge-add, graph (4 tools), clusters, connect (4 tools)
+- **21 tools**: Search, import, facts, stats, stale, reinforce, reason, edge-add, graph (4 tools), clusters, connect (4 tools), directives (2 tools), ledger, proposals
 - **4 resources**: stats, recent memories, graph subjects, graph clusters
 - **Agent scoping**: `--agent` sets default agent for all tool invocations; per-request `agent_id` overrides
-- **Tested with**: Claude Code, Cursor, Windsurf
+- **Tested with**: Claude Code, Codex CLI, Cursor, Windsurf
 
 ### `observe/` — Observability (823 lines)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,7 +153,7 @@ Imports data from external services into the standard pipeline.
 Model Context Protocol server for agent integration.
 
 - **Transport**: stdio (default) or HTTP+SSE (`--port`)
-- **21 tools**: Search, import, facts, stats, stale, reinforce, reason, edge-add, graph (4 tools), clusters, connect (4 tools), directives (2 tools), ledger, proposals
+- **22 tools**: Answer, search, import, facts, stats, stale, reinforce, reason, edge-add, graph (2 tools), explore/impact/clusters (3 tools), connect (4 tools), directives (2 tools), ledger, proposals
 - **4 resources**: stats, recent memories, graph subjects, graph clusters
 - **Agent scoping**: `--agent` sets default agent for all tool invocations; per-request `agent_id` overrides
 - **Tested with**: Claude Code, Codex CLI, Cursor, Windsurf

--- a/docs/CORTEX_DEEP_DIVE.md
+++ b/docs/CORTEX_DEEP_DIVE.md
@@ -53,7 +53,7 @@ Files/Sources → Import → Chunk → Extract (rules) → Enrich (LLM) → Clas
 | **Confidence Decay** | Ebbinghaus forgetting curves per fact type. Identity decays slowly (years). Temporal decays fast (days). `cortex reinforce <id>` resets the decay timer. |
 | **Knowledge Graph** | Subject→predicate→object triples with cluster detection. Interactive 2D explorer at `localhost:8090`. 5 view modes: graph, table, subjects, clusters, search. |
 | **Connectors** | 8 providers: GitHub, Gmail, Calendar, Drive, Slack, Discord, Telegram, Notion. Incremental sync with cursor tracking. OS-native scheduling (launchd/systemd). |
-| **MCP Server** | 21 tools + 4 resources. stdio or HTTP+SSE transport. Works with Claude Code, Codex CLI, Cursor, Windsurf, any MCP client. |
+| **MCP Server** | 22 tools + 4 resources. stdio or HTTP+SSE transport. Works with Claude Code, Codex CLI, Cursor, Windsurf, any MCP client. |
 | **Multi-Agent** | `--agent` flag scopes all operations. `cortex agents` lists known agents. Memories tagged with agent ID. No cross-agent leakage. |
 | **Observability** | `stats`, `stale`, `conflicts`, `alerts`, `doctor`. Proactive health monitoring. |
 | **Reasoning** | One-shot and recursive chain-of-thought over your memory corpus. Search → synthesize → answer. |
@@ -197,7 +197,7 @@ cortex mcp --agent mister
 claude mcp add cortex -- cortex mcp
 ```
 
-That's it. Claude Code now has persistent memory with 21 tools.
+That's it. Claude Code now has persistent memory with 22 tools.
 
 ---
 

--- a/docs/CORTEX_DEEP_DIVE.md
+++ b/docs/CORTEX_DEEP_DIVE.md
@@ -53,7 +53,7 @@ Files/Sources → Import → Chunk → Extract (rules) → Enrich (LLM) → Clas
 | **Confidence Decay** | Ebbinghaus forgetting curves per fact type. Identity decays slowly (years). Temporal decays fast (days). `cortex reinforce <id>` resets the decay timer. |
 | **Knowledge Graph** | Subject→predicate→object triples with cluster detection. Interactive 2D explorer at `localhost:8090`. 5 view modes: graph, table, subjects, clusters, search. |
 | **Connectors** | 8 providers: GitHub, Gmail, Calendar, Drive, Slack, Discord, Telegram, Notion. Incremental sync with cursor tracking. OS-native scheduling (launchd/systemd). |
-| **MCP Server** | 17 tools + 4 resources. stdio or HTTP+SSE transport. Works with Claude Code, Cursor, Windsurf, any MCP client. |
+| **MCP Server** | 21 tools + 4 resources. stdio or HTTP+SSE transport. Works with Claude Code, Codex CLI, Cursor, Windsurf, any MCP client. |
 | **Multi-Agent** | `--agent` flag scopes all operations. `cortex agents` lists known agents. Memories tagged with agent ID. No cross-agent leakage. |
 | **Observability** | `stats`, `stale`, `conflicts`, `alerts`, `doctor`. Proactive health monitoring. |
 | **Reasoning** | One-shot and recursive chain-of-thought over your memory corpus. Search → synthesize → answer. |
@@ -181,7 +181,7 @@ The MCP server is how agents interact with Cortex. It exposes the full feature s
 ### Starting the MCP Server
 
 ```bash
-# stdio (for Claude Code, Cursor, etc.)
+# stdio (for Claude Code, Codex CLI, Cursor, etc.)
 cortex mcp
 
 # HTTP+SSE (for web clients)
@@ -197,7 +197,7 @@ cortex mcp --agent mister
 claude mcp add cortex -- cortex mcp
 ```
 
-That's it. Claude Code now has persistent memory with 17 tools.
+That's it. Claude Code now has persistent memory with 21 tools.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,6 +61,11 @@ cortex search "PostgreSQL migration" --mode bm25
 # Claude Code
 claude mcp add cortex -- cortex mcp
 
+# Codex CLI (add to ~/.codex/config.toml)
+[mcp_servers.cortex]
+command = "cortex"
+args = ["mcp"]
+
 # Cursor (add to .cursor/mcp.json)
 {
   "mcpServers": {
@@ -78,7 +83,7 @@ cortex mcp
 cortex mcp --port 8080
 ```
 
-Your agent now has persistent memory with 17 tools.
+Your agent now has persistent memory with 21 tools.
 
 ## 5. Check What You Know
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,7 @@ cortex mcp
 cortex mcp --port 8080
 ```
 
-Your agent now has persistent memory with 21 tools.
+Your agent now has persistent memory with 22 tools.
 
 ## 5. Check What You Know
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 Practical setups you can copy and run.
 
 - `local-first/` — fully local workflow (Ollama + SQLite, no API keys)
+- `codex/` — Codex CLI MCP setup and ledger workflow
 - `openclaw-agent/` — MCP integration pattern for OpenClaw/Claude Code style agents
 - `openclaw-plugin/` — OpenClaw plugin reference adapter (not actively maintained)
 - `obsidian-sync/` — export + validate + periodic sync workflow

--- a/examples/codex/AGENTS.md
+++ b/examples/codex/AGENTS.md
@@ -1,0 +1,6 @@
+# Cortex memory
+
+- Cortex is available through MCP. At the start of a task, call `cortex_directive_list` and follow active directives.
+- At the end of a task, call `cortex_ledger_record` with a short `task_summary`, an `outcome` of `success`, `partial`, or `failure`, the `files_touched`, and a stable `fix_pattern` when the task contains a reusable fix.
+- Leave `fix_pattern` empty when no recurring pattern applies. Do not invent one to fill the field.
+- Never accept or dismiss a proposal. Those actions are human-only through `cortex propose accept` or `cortex propose dismiss` in the terminal.

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -1,0 +1,84 @@
+# Codex CLI integration
+
+Connect Codex CLI to Cortex over stdio MCP.
+
+## 1. Install Cortex
+
+```bash
+brew install hurttlocker/cortex/cortex-memory
+cortex version
+```
+
+Other install options are in [Getting Started](../../docs/getting-started.md).
+
+## 2. Register the MCP server
+
+Add the contents of [`config.toml`](config.toml) to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.cortex]
+command = "cortex"
+args = ["mcp"]
+```
+
+Verify the registration, then start Codex:
+
+```bash
+codex mcp list
+codex
+```
+
+Run `/mcp` in the Codex TUI to confirm `cortex` is connected.
+
+## 3. Add the first directive
+
+Directives are human-authored rules. Add one from the terminal:
+
+```bash
+cortex directive add "Always run the project tests before committing"
+```
+
+In Codex, ask:
+
+```text
+List the active Cortex directives, then make the requested change and follow them.
+```
+
+Codex can read the directive with `cortex_directive_list`.
+
+## 4. Record the session outcome
+
+Copy [`AGENTS.md`](AGENTS.md) into the project, or merge its Cortex section into an existing `AGENTS.md`. It tells Codex to call `cortex_ledger_record` at the end of each task with:
+
+- `task_summary`
+- `outcome` (`success`, `partial`, or `failure`)
+- `files_touched`
+- `fix_pattern` when a reusable fix occurred
+- `agent_id` and `project` when known
+
+Run a Codex task normally:
+
+```text
+Fix the authentication gate regression. Run the tests and record the outcome in Cortex when the task is complete.
+```
+
+The ledger is append-only. Codex records outcomes; it does not create directives from them.
+
+## 5. Review proposals
+
+After the same `fix_pattern` appears at least three times in the ledger, scan from the terminal:
+
+```bash
+cortex propose scan
+cortex propose list
+```
+
+Review the evidence, then accept or dismiss the proposal yourself:
+
+```bash
+cortex propose accept <id>
+# or
+cortex propose dismiss <id>
+```
+
+Accept and dismiss are CLI-only. Codex can list pending proposals with `cortex_propose_list`, but cannot approve them.

--- a/examples/codex/config.toml
+++ b/examples/codex/config.toml
@@ -1,0 +1,3 @@
+[mcp_servers.cortex]
+command = "cortex"
+args = ["mcp"]


### PR DESCRIPTION
## What changed

- Added the verified Codex CLI stdio MCP block for `~/.codex/config.toml` to Getting Started.
- Added `examples/codex/` with a copy-paste config, end-to-end setup and governance workflow, and a drop-in `AGENTS.md` snippet.
- Added Codex CLI wherever current docs enumerate Claude Code and Cursor as supported MCP clients.
- Updated adjacent touched MCP tool counts from 17 to the registry-confirmed count of 22.

Touched surfaces: `README.md`, `docs/getting-started.md`, `docs/ARCHITECTURE.md`, `docs/CORTEX_DEEP_DIVE.md`, and `examples/`. No Go or runtime files changed.

## Why

Codex CLI was the only major MCP-capable agent harness in the existing docs with no setup path. Cortex already supports the required stdio transport, so this adds the missing integration surface without changing the server.

**Issue:** N/A (direct documentation task; no issue supplied)

## Verification

Verified the schema against the current official Codex MCP documentation: `[mcp_servers.<name>]`, required `command`, and optional `args` in `~/.codex/config.toml`.

```text
$ go build ./cmd/cortex/
go build ./cmd/cortex/: PASS

$ go test ./...
ok   github.com/hurttlocker/cortex/internal/mcp      (cached)
ok   github.com/hurttlocker/cortex/internal/store    (cached)
ok   github.com/hurttlocker/cortex/scripts/bench     (cached)

$ go vet ./...
go vet ./...: PASS

$ git ls-files -z '*.go' | xargs -0 gofmt -l
(no output; clean)

$ CODEX_HOME=<temp> PATH="$PWD:$PATH" codex mcp list
Name    Command  Args  Env  Cwd  Status   Auth
cortex  cortex   mcp   -    -    enabled  Unsupported
```

Direct MCP initialization against the built binary returned Cortex `2.0.0`; `tools/list` included `cortex_directive_list`, `cortex_ledger_record`, and `cortex_propose_list`.

End-to-end Codex CLI `0.144.1` handshake with the documented `command = "cortex"` / `args = ["mcp"]` configuration:

```text
mcp: cortex/cortex_directive_list started
mcp: cortex/cortex_directive_list (completed)
Succeeded. Active directives returned: 0.
```

Added relative link targets: PASS. `git diff --check`: PASS.

## Risk

Docs and examples only. No runtime, MCP protocol, dependency, database, or Go code changes.

## AI-assisted contribution

Codex drafted the documentation changes. The final diff was reviewed against the official Codex MCP schema, Cortex v2 tool definitions, the repository operating contract, and the command outputs above.
